### PR TITLE
Now possible to control the master volume

### DIFF
--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -190,6 +190,13 @@ export default class {
             track.setGainLevel(volume/100);
         });
 
+        ee.on('supermastervolumechange', (volume) => {
+            //track.setGainLevel(volume/100);
+            this.tracks.forEach((track) => {
+                track.setSuperMasterGainLevel(volume/100);
+            });
+        });
+
         ee.on('fadein', (duration, track) => {
             track.setFadeIn(duration, this.fadeType);
             this.draw(this.render());
@@ -446,6 +453,10 @@ export default class {
         return this.ac.currentTime - this.lastPlay;
     }
 
+    setSuperMasterVolume(volume){
+        this.ee.emit('supermastervolumechange', volume);
+    }
+
     restartPlayFrom(start, end) {
         this.stopAnimation();
 
@@ -475,7 +486,8 @@ export default class {
         this.tracks.forEach((track) => {
             track.setState('cursor');
             playoutPromises.push(track.schedulePlay(currentTime, startTime, endTime, {
-                masterGain: this.shouldTrackPlay(track) ? 1 : 0
+                masterGain: this.shouldTrackPlay(track) ? 1 : 0,
+                superMasterGain : track.superMasterGain
             }));
         });
 

--- a/src/Playout.js
+++ b/src/Playout.js
@@ -55,11 +55,14 @@ export default class {
                 this.fadeGain.disconnect();
                 this.outputGain.disconnect();
                 this.masterGain.disconnect();
+                this.superMasterGain.disconnect();
+
 
                 this.source = undefined;
                 this.fadeGain = undefined;
                 this.outputGain = undefined;
                 this.masterGain = undefined;
+                this.superMasterGain = undefined;
 
                 resolve();
             }
@@ -70,11 +73,13 @@ export default class {
         this.outputGain = this.ac.createGain();
         //used for solo/mute
         this.masterGain = this.ac.createGain();
+        this.superMasterGain = this.ac.createGain();
 
         this.source.connect(this.fadeGain);
         this.fadeGain.connect(this.outputGain);
         this.outputGain.connect(this.masterGain);
-        this.masterGain.connect(this.destination);
+        this.masterGain.connect(this.superMasterGain);
+        this.superMasterGain.connect(this.destination);
 
         return sourcePromise;
     }
@@ -83,8 +88,14 @@ export default class {
         this.outputGain && (this.outputGain.gain.value = level);
     }
 
+
+
     setMasterGainLevel(level) {
         this.masterGain && (this.masterGain.gain.value = level);
+    }
+
+    setSuperMasterGainLevel(level){
+        this.superMasterGain && (this.superMasterGain.gain.value = level);
     }
 
     /*

--- a/src/Track.js
+++ b/src/Track.js
@@ -24,6 +24,7 @@ export default class {
 
         this.name = "Untitled";
         this.gain = 1;
+        this.superMasterGain = 1;
         this.fades = {};
         this.peakData = {
             type: "WebAudio",
@@ -197,6 +198,11 @@ export default class {
         this.playout.setGainLevel(level);
     }
 
+    setSuperMasterGainLevel(level) {
+        this.superMasterGain = level;
+        this.playout.setSuperMasterGainLevel(level);
+    }
+
     setMasterGainLevel(level) {
         this.playout.setMasterGainLevel(level);
     }
@@ -286,6 +292,7 @@ export default class {
 
         this.playout.setGainLevel(this.gain);
         this.playout.setMasterGainLevel(options.masterGain);
+        this.playout.setSuperMasterGainLevel(options.superMasterGain);
         this.playout.play(when, start, duration);
 
         return sourcePromise;


### PR DESCRIPTION
Hi !
For a project, I had to setup a master volume, so I have decided to edit your project. I  also saw that this feature is asked by some people ( issue #14 ).

To make this thing possible I have used another gainNode, just before going to speakers, it is just like the gain for one specific track, but this time every tracks have the same gain level.

In the code I called the node "superMasterGain" because there was already a "masterGain" node.

To set the master volume there are 2 different way to do that : 
 - via event emitter : 
```
playlist.getEventEmitter().emit("supermastervolumechange", level)
```
 - via  a function call : 
``` 
var playlist = WaveformPlaylist.init(this.opt.multiTracks.option);
playlist.setSuperMasterVolume(level);
```
if you want to bind it to a slider : 
```
$("#master-volume-slider").on("input change", function(node){
       ee.emit("supermastervolumechange", node.target.value);
    });
``` 


