### PR TITLE
Custom track waveform background

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ var options = {
   "customClass" : 'vocals',
 
   //custom background-color for the canvas-drawn waveform
-  "waveBackgroundColor": "#f3f3f3",
+  "waveOutlineColor": "#f3f3f3",
 
   //interaction states allowed on this track.
   //DEFAULT - all true

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ var options = {
   //custom class for unique track styling
   "customClass" : 'vocals',
 
+  //custom background-color for the canvas-drawn waveform
+  "waveBackgroundColor": "#f3f3f3",
+
   //interaction states allowed on this track.
   //DEFAULT - all true
   "states": {

--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -309,7 +309,7 @@ export default class {
                 let selection = info.selected;
                 let peaks = info.peaks || {type: "WebAudio", mono: this.mono};
                 let customClass = info.customClass || undefined;
-                let waveBackgroundColor = info.waveBackgroundColor || undefined;
+                let waveOutlineColor = info.waveOutlineColor || undefined;
 
                 //webaudio specific playout for now.
                 let playout = new Playout(this.ac, audioBuffer);
@@ -322,7 +322,7 @@ export default class {
                 track.setEnabledStates(states);
                 track.setCues(cueIn, cueOut);
                 track.setCustomClass(customClass);
-                track.setWaveBackgroundColor(waveBackgroundColor);
+                track.setWaveOutlineColor(waveOutlineColor);
 
                 if (fadeIn !== undefined) {
                     track.setFadeIn(fadeIn.duration, fadeIn.shape);
@@ -815,8 +815,7 @@ export default class {
                 "isActive": this.isActiveTrack(track),
                 "shouldPlay": this.shouldTrackPlay(track),
                 "soloed": this.soloedTracks.indexOf(track) > -1,
-                "muted": this.mutedTracks.indexOf(track) > -1,
-                "waveBackgroundColor": track.waveBackgroundColor
+                "muted": this.mutedTracks.indexOf(track) > -1
             }));
         });
 

--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -309,6 +309,7 @@ export default class {
                 let selection = info.selected;
                 let peaks = info.peaks || {type: "WebAudio", mono: this.mono};
                 let customClass = info.customClass || undefined;
+                let waveBackgroundColor = info.waveBackgroundColor || undefined;
 
                 //webaudio specific playout for now.
                 let playout = new Playout(this.ac, audioBuffer);
@@ -321,6 +322,7 @@ export default class {
                 track.setEnabledStates(states);
                 track.setCues(cueIn, cueOut);
                 track.setCustomClass(customClass);
+                track.setWaveBackgroundColor(waveBackgroundColor);
 
                 if (fadeIn !== undefined) {
                     track.setFadeIn(fadeIn.duration, fadeIn.shape);
@@ -685,7 +687,7 @@ export default class {
             this.scrollLeft = 0;
 
             this.seek(0, 0, undefined);
-        }); 
+        });
     }
 
     record() {
@@ -813,7 +815,8 @@ export default class {
                 "isActive": this.isActiveTrack(track),
                 "shouldPlay": this.shouldTrackPlay(track),
                 "soloed": this.soloedTracks.indexOf(track) > -1,
-                "muted": this.mutedTracks.indexOf(track) > -1
+                "muted": this.mutedTracks.indexOf(track) > -1,
+                "waveBackgroundColor": track.waveBackgroundColor
             }));
         });
 

--- a/src/Track.js
+++ b/src/Track.js
@@ -24,6 +24,7 @@ export default class {
 
         this.name = "Untitled";
         this.customClass = undefined;
+        this.waveBackgroundColor = undefined;
         this.gain = 1;
         this.fades = {};
         this.peakData = {
@@ -48,6 +49,10 @@ export default class {
 
     setCustomClass(className) {
         this.customClass = className;
+    }
+
+    setWaveBackgroundColor(color) {
+        this.waveBackgroundColor = color;
     }
 
     setCues(cueIn, cueOut) {
@@ -439,7 +444,7 @@ export default class {
                         "height": data.height,
                         "style": "float: left; position: relative; margin: 0; padding: 0; z-index: 3;"
                     },
-                    "hook": new CanvasHook(peaks, offset, this.peaks.bits, data.colors.waveOutlineColor)
+                    "hook": new CanvasHook(peaks, offset, this.peaks.bits, data.waveBackgroundColor ? data.waveBackgroundColor : data.colors.waveOutlineColor)
                 }));
 
                 totalWidth -= currentWidth;

--- a/src/Track.js
+++ b/src/Track.js
@@ -24,7 +24,7 @@ export default class {
 
         this.name = "Untitled";
         this.customClass = undefined;
-        this.waveBackgroundColor = undefined;
+        this.waveOutlineColor = undefined;
         this.gain = 1;
         this.fades = {};
         this.peakData = {
@@ -51,8 +51,8 @@ export default class {
         this.customClass = className;
     }
 
-    setWaveBackgroundColor(color) {
-        this.waveBackgroundColor = color;
+    setWaveOutlineColor(color) {
+        this.waveOutlineColor = color;
     }
 
     setCues(cueIn, cueOut) {
@@ -444,7 +444,7 @@ export default class {
                         "height": data.height,
                         "style": "float: left; position: relative; margin: 0; padding: 0; z-index: 3;"
                     },
-                    "hook": new CanvasHook(peaks, offset, this.peaks.bits, data.waveBackgroundColor ? data.waveBackgroundColor : data.colors.waveOutlineColor)
+                    "hook": new CanvasHook(peaks, offset, this.peaks.bits, this.waveOutlineColor ? this.waveOutlineColor : data.colors.waveOutlineColor)
                 }));
 
                 totalWidth -= currentWidth;


### PR DESCRIPTION
Added some simple support for custom waveform background colors for individual tracks.

The `customClass` property is great for styling the channel and some aspects of the waveform, but the waveform itself is drawn with a `canvas` so using a class you aren't able to customize the color of the track waveform.

I'm open to any suggestions, I tried to keep this as simple as possible!