### PR TITLE
 Added stereoPan option and fixed build issue on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash.assign": "^4.0.0",
     "lodash.defaults": "^4.0.0",
     "lodash.forown": "^4.0.0",
+    "mkdirp": "^0.5.1",
     "mucss": "^1.1.5",
     "uuid": "^2.0.1",
     "virtual-dom": "^2.1.1",
@@ -63,7 +64,7 @@
   },
   "scripts": {
     "clean": "rm -Rf dist && rm -Rf lib && rm -Rf styles",
-    "styles": "mkdir -p styles && cp ghpages/_sass/_playlist.scss styles/playlist.scss",
+    "styles": "mkdirp styles && cp ghpages/_sass/_playlist.scss styles/playlist.scss",
     "compile": "babel src --out-dir lib",
     "jekyll": "jekyll build -s ghpages -d dist/waveform-playlist",
     "jekyll:dev": "jekyll build -s ghpages -d dist/waveform-playlist --watch &",

--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -264,6 +264,10 @@ export default class {
       this.drawRequest();
     });
 
+    ee.on('stereopan', (panvalue, track) => {
+      track.setStereoPanValue(panvalue);
+    });
+
     ee.on('fadetype', (type) => {
       this.fadeType = type;
     });
@@ -341,6 +345,7 @@ export default class {
         const peaks = info.peaks || { type: 'WebAudio', mono: this.mono };
         const customClass = info.customClass || undefined;
         const waveOutlineColor = info.waveOutlineColor || undefined;
+        const stereoPan = info.stereoPan || 0;
 
         // webaudio specific playout for now.
         const playout = new Playout(this.ac, audioBuffer);
@@ -377,6 +382,7 @@ export default class {
         track.setPlayout(playout);
 
         track.setGainLevel(gain);
+        track.setStereoPanValue(stereoPan);
 
         if (muted) {
           this.muteTrack(track);
@@ -849,7 +855,7 @@ export default class {
   renderTimeScale() {
     const controlWidth = this.controls.show ? this.controls.width : 0;
     const timeScale = new TimeScale(this.duration, this.scrollLeft,
-      this.samplesPerPixel, this.sampleRate, controlWidth);
+      this.samplesPerPixel, this.sampleRate, controlWidth, this.colors);
 
     return timeScale.render();
   }

--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -855,7 +855,7 @@ export default class {
   renderTimeScale() {
     const controlWidth = this.controls.show ? this.controls.width : 0;
     const timeScale = new TimeScale(this.duration, this.scrollLeft,
-      this.samplesPerPixel, this.sampleRate, controlWidth, this.colors);
+      this.samplesPerPixel, this.sampleRate, controlWidth);
 
     return timeScale.render();
   }

--- a/src/Playout.js
+++ b/src/Playout.js
@@ -51,6 +51,7 @@ export default class {
         this.fadeGain.disconnect();
         this.volumeGain.disconnect();
         this.shouldPlayGain.disconnect();
+        this.panner.disconnect();
         this.masterGain.disconnect();
 
 
@@ -58,6 +59,7 @@ export default class {
         this.fadeGain = undefined;
         this.volumeGain = undefined;
         this.shouldPlayGain = undefined;
+        this.panner = undefined;
         this.masterGain = undefined;
 
         resolve();
@@ -70,12 +72,14 @@ export default class {
     // used for solo/mute
     this.shouldPlayGain = this.ac.createGain();
     this.masterGain = this.ac.createGain();
+    this.panner = this.ac.createStereoPanner();
 
     this.source.connect(this.fadeGain);
     this.fadeGain.connect(this.volumeGain);
     this.volumeGain.connect(this.shouldPlayGain);
     this.shouldPlayGain.connect(this.masterGain);
-    this.masterGain.connect(this.destination);
+    this.masterGain.connect(this.panner);
+    this.panner.connect(this.destination);
 
     return sourcePromise;
   }
@@ -95,6 +99,12 @@ export default class {
   setMasterGainLevel(level) {
     if (this.masterGain) {
       this.masterGain.gain.value = level;
+    }
+  }
+
+  setStereoPanValue(value) {
+    if (this.panner) {
+      this.panner.pan.value = value === undefined ? 0 : value;
     }
   }
 

--- a/src/Track.js
+++ b/src/Track.js
@@ -34,6 +34,7 @@ export default class {
     this.duration = 0;
     this.startTime = 0;
     this.endTime = 0;
+    this.stereoPan = 0;
   }
 
   setEventEmitter(ee) {
@@ -222,6 +223,11 @@ export default class {
     this.playout.setMasterGainLevel(level);
   }
 
+  setStereoPanValue(value) {
+    this.stereoPan = value;
+    this.playout.setStereoPanValue(value);
+  }
+
   /*
     startTime, endTime in seconds (float).
     segment is for a highlighted section in the UI.
@@ -314,6 +320,7 @@ export default class {
     playoutSystem.setVolumeGainLevel(this.gain);
     playoutSystem.setShouldPlay(options.shouldPlay);
     playoutSystem.setMasterGainLevel(options.masterGain);
+    playoutSystem.setStereoPanValue(this.stereoPan);
     playoutSystem.play(when, start, duration);
 
     return sourcePromise;


### PR DESCRIPTION
The stereoPan option on each track expects a value from -1 (full left pan) to 1 (full right pan).
This allows us to have left-right stereo mix in the playout.

This PR also changes from "mkdir" to "mkdirp" in package.json "styles" script, in order to make it work on Windows as well.