### PR TITLE
Fixed Firefox by allowing recovery after ondataavailable processing f…

### DIFF
--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -79,6 +79,8 @@ export default class {
           this.recordingTrack.setBuffer(audioBuffer);
           this.recordingTrack.setPlayout(new Playout(this.ac, audioBuffer));
           this.adjustDuration();
+        }).catch((err) => {
+          this.working = false;
         });
         this.working = true;
       }

--- a/src/track/loader/BlobLoader.js
+++ b/src/track/loader/BlobLoader.js
@@ -23,7 +23,7 @@ export default class extends Loader {
 
           decoderPromise.then((audioBuffer) => {
             resolve(audioBuffer);
-          });
+          }).catch(reject);
         });
 
         fr.addEventListener('error', (err) => {


### PR DESCRIPTION
…ails.

It appears that Firefox's ogg decoder was failing if too short a buffer
was passed to it. Because the error handling was broken that led to a
permanent failure. Now the error is caught, and the next ondataavailable
callback will be able to retry the processing, which will succeed once
enough data has been recorded.