### PR TITLE
add a loader for AudioBuffer sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ var options = {
 
 ```javascript
 {
-  // a media path for XHR or a File object.
+  // a media path for XHR, a Blob, a File, or an AudioBuffer object.
   src: 'media/audio/BassDrums30.mp3',
 
   // name that will display in the playlist control panel.

--- a/src/track/loader/IdentityLoader.js
+++ b/src/track/loader/IdentityLoader.js
@@ -1,0 +1,7 @@
+import Loader from './Loader';
+
+export default class IdentityLoader extends Loader {
+  load() {
+    return Promise.resolve(this.src);
+  }
+}

--- a/src/track/loader/LoaderFactory.js
+++ b/src/track/loader/LoaderFactory.js
@@ -1,10 +1,13 @@
 import BlobLoader from './BlobLoader';
+import IdentityLoader from './IdentityLoader';
 import XHRLoader from './XHRLoader';
 
 export default class {
   static createLoader(src, audioContext, ee) {
     if (src instanceof Blob) {
       return new BlobLoader(src, audioContext, ee);
+    } else if (src instanceof AudioBuffer) {
+      return new IdentityLoader(src, audioContext, ee);
     } else if (typeof (src) === 'string') {
       return new XHRLoader(src, audioContext, ee);
     }


### PR DESCRIPTION
Loading an audio buffer directly allows for generating tracks programmatically, or preprocessing existing audio before adding it as a track.