### PR TITLE
Fix incorrect handling of startTime === 0;

### DIFF
--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -747,7 +747,7 @@ export default class {
     const selected = this.getTimeSelection();
     const playoutPromises = [];
 
-    const start = startTime || this.pausedAt || this.cursor;
+    const start = (startTime === 0) ? 0 : (startTime || this.pausedAt || this.cursor);
     let end = endTime;
 
     if (!end && selected.end !== selected.start && selected.end > start) {


### PR DESCRIPTION
When `startTime === 0`, play from 0, rather than from `this.pausedAt` or `this.cursor`.

Fixes https://github.com/naomiaro/waveform-playlist/issues/239