### PR TITLE
Fetch API

### DIFF
--- a/src/track/loader/FetchLoader.js
+++ b/src/track/loader/FetchLoader.js
@@ -8,7 +8,7 @@ export default class extends Loader {
     return new Promise((resolve, reject) => {
       fetch(this.src)
         .then((data) => data.arrayBuffer())
-        .then((arrayBuffer) => super.ac.decodeAudioData(arrayBuffer))
+        .then((arrayBuffer) => super.fetchLoad(arrayBuffer))
         .then((decodedAudio) => resolve(decodedAudio))
         .catch((err) => {
           reject(Error(`Track ${this.src} failed to load with error: ${err}`));

--- a/src/track/loader/FetchLoader.js
+++ b/src/track/loader/FetchLoader.js
@@ -1,0 +1,18 @@
+import Loader from "./Loader";
+
+export default class extends Loader {
+  /**
+   * Loads an audio file via fetch API.
+   */
+  load() {
+    return new Promise((resolve, reject) => {
+      fetch(this.src)
+        .then((data) => data.arrayBuffer())
+        .then((arrayBuffer) => super.ac.decodeAudioData(arrayBuffer))
+        .then((decodedAudio) => resolve(decodedAudio))
+        .catch((err) => {
+          reject(Error(`Track ${this.src} failed to load with error: ${err}`));
+        });
+    });
+  }
+}

--- a/src/track/loader/Loader.js
+++ b/src/track/loader/Loader.js
@@ -59,4 +59,28 @@ export default class {
       );
     });
   }
+
+  fetchLoad(arrayBuffer) {
+    this.setStateChange(STATE_DECODING);
+
+    return new Promise((resolve, reject) => {
+      this.ac.decodeAudioData(
+        arrayBuffer,
+        (audioBuffer) => {
+          this.audioBuffer = audioBuffer;
+          this.setStateChange(STATE_FINISHED);
+
+          resolve(audioBuffer);
+        },
+        (err) => {
+          if (err === null) {
+            // Safari issues with null error
+            reject(Error("MediaDecodeAudioDataUnknownContentType"));
+          } else {
+            reject(err);
+          }
+        }
+      );
+    });
+  }
 }

--- a/src/track/loader/Loader.js
+++ b/src/track/loader/Loader.js
@@ -35,6 +35,8 @@ export default class {
   fileLoad(e) {
     const audioData = e.target.response || e.target.result;
 
+    // TODO: Here, detect if the `audioData` is of type MIDI.
+
     this.setStateChange(STATE_DECODING);
 
     return new Promise((resolve, reject) => {

--- a/src/track/loader/Loader.js
+++ b/src/track/loader/Loader.js
@@ -35,8 +35,6 @@ export default class {
   fileLoad(e) {
     const audioData = e.target.response || e.target.result;
 
-    // TODO: Here, detect if the `audioData` is of type MIDI.
-
     this.setStateChange(STATE_DECODING);
 
     return new Promise((resolve, reject) => {

--- a/src/track/loader/LoaderFactory.js
+++ b/src/track/loader/LoaderFactory.js
@@ -1,6 +1,7 @@
 import BlobLoader from "./BlobLoader";
 import IdentityLoader from "./IdentityLoader";
 import XHRLoader from "./XHRLoader";
+import FetchLoader from "./FetchLoader";
 
 export default class {
   static createLoader(src, audioContext, ee) {
@@ -9,7 +10,8 @@ export default class {
     } else if (src instanceof AudioBuffer) {
       return new IdentityLoader(src, audioContext, ee);
     } else if (typeof src === "string") {
-      return new XHRLoader(src, audioContext, ee);
+      //return new XHRLoader(src, audioContext, ee);
+      return new FetchLoader(src, audioContext, ee);
     }
 
     throw new Error("Unsupported src type");


### PR DESCRIPTION
Replace XMLHttpRequest with Fetch API. According to [this](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API):

> The Fetch API ... will seem familiar to anyone who has used XMLHttpRequest, but the new API provides a more **powerful** and **flexible** feature set.

# Why?

Fetch API might be helpful when implementing the *audio streaming* in the future. According to [that](https://github.com/Rich-Harris/phonograph#the-solution):

> By using the `fetch()` API, we can stream the data rather than waiting for the whole file to load.