### PR TITLE
Start recording from cursor

### DIFF
--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -52,11 +52,12 @@ export default class {
     this.mediaRecorder = new MediaRecorder(stream);
 
     this.mediaRecorder.onstart = () => {
+      const start = this.cursor;
       const track = new Track();
       track.setName("Recording");
       track.setEnabledStates();
       track.setEventEmitter(this.ee);
-      track.setStartTime(this.cursor);
+      track.setStartTime(start);
 
       this.recordingTrack = track;
       this.tracks.push(track);
@@ -852,12 +853,13 @@ export default class {
 
   record() {
     const playoutPromises = [];
+    const start = this.cursor;
     this.mediaRecorder.start(300);
 
     this.tracks.forEach((track) => {
       track.setState("none");
       playoutPromises.push(
-        track.schedulePlay(this.ac.currentTime, 0, undefined, {
+        track.schedulePlay(this.ac.currentTime, start, undefined, {
           shouldPlay: this.shouldTrackPlay(track),
         })
       );

--- a/src/Playlist.js
+++ b/src/Playlist.js
@@ -56,6 +56,7 @@ export default class {
       track.setName("Recording");
       track.setEnabledStates();
       track.setEventEmitter(this.ee);
+      track.setStartTime(this.cursor);
 
       this.recordingTrack = track;
       this.tracks.push(track);


### PR DESCRIPTION
At this moment the recording always creates a new track, which is then recorded from the beginning. It feels more intuitive that the recording actually starts where the cursor is located.

I noticed that in some parts of the code const start exists, including this.pauseAt. I was unable to get this to work, but wonder if this would be the intented behavior. If the cursor should move, it should move as playhead.

![image](https://user-images.githubusercontent.com/502394/224398405-4effdc78-86e3-4938-88f6-9345f516b821.png)
