### PR TITLE
Decouple spectrogram from browser package

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,13 @@ Multi-track audio editor roadmap for waveform-playlist.
 - Audacity-style loop playback (separate loop region from selection, timescale-only UI)
 - Sample-based peaks generation (no floating-point precision errors)
 
+### Bundle Optimization ✅
+
+- Spectrogram decoupled from browser package (2025-01-31)
+  - `@waveform-playlist/spectrogram` is now optional via `SpectrogramIntegrationContext`
+  - Browser dist: 269KB/67KB gzipped, zero spectrogram runtime code
+  - New `SpectrogramProvider` wrapper in spectrogram package
+
 ---
 
 ## 🔮 Future Phases

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -58,7 +58,6 @@
     "@waveform-playlist/media-element-playout": "workspace:*",
     "@waveform-playlist/playout": "workspace:*",
     "@waveform-playlist/recording": "workspace:*",
-    "@waveform-playlist/spectrogram": "workspace:*",
     "@waveform-playlist/ui-components": "workspace:*",
     "@waveform-playlist/webaudio-peaks": "workspace:*",
     "uuid": "^13.0.0",

--- a/packages/browser/src/SpectrogramIntegrationContext.tsx
+++ b/packages/browser/src/SpectrogramIntegrationContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import type { SpectrogramData, SpectrogramConfig, ColorMapValue, RenderMode, TrackSpectrogramOverrides } from '@waveform-playlist/core';
 
 export interface SpectrogramIntegration {
@@ -12,7 +12,7 @@ export interface SpectrogramIntegration {
   registerSpectrogramCanvases: (clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => void;
   unregisterSpectrogramCanvases: (clipId: string, channelIndex: number) => void;
   /** Render spectrogram menu items for a track's context menu */
-  renderMenuItems?: (props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => any[];
+  renderMenuItems?: (props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => Array<{ id: string; label?: string; content: React.ReactNode }>;
   /** Settings modal component provided by the spectrogram package */
   SettingsModal?: React.ComponentType<{
     open: boolean;

--- a/packages/browser/src/SpectrogramIntegrationContext.tsx
+++ b/packages/browser/src/SpectrogramIntegrationContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react';
+import type { SpectrogramData, SpectrogramConfig, ColorMapValue, RenderMode, TrackSpectrogramOverrides } from '@waveform-playlist/core';
+
+export interface SpectrogramIntegration {
+  spectrogramDataMap: Map<string, SpectrogramData[]>;
+  trackSpectrogramOverrides: Map<string, TrackSpectrogramOverrides>;
+  spectrogramWorkerApi: SpectrogramWorkerApi | null;
+  spectrogramConfig?: SpectrogramConfig;
+  spectrogramColorMap?: ColorMapValue;
+  setTrackRenderMode: (trackId: string, mode: RenderMode) => void;
+  setTrackSpectrogramConfig: (trackId: string, config: SpectrogramConfig, colorMap?: ColorMapValue) => void;
+  registerSpectrogramCanvases: (clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => void;
+  unregisterSpectrogramCanvases: (clipId: string, channelIndex: number) => void;
+  /** Render spectrogram menu items for a track's context menu */
+  renderMenuItems?: (props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => any[];
+  /** Settings modal component provided by the spectrogram package */
+  SettingsModal?: React.ComponentType<{
+    open: boolean;
+    onClose: () => void;
+    config: SpectrogramConfig;
+    colorMap: ColorMapValue;
+    onApply: (config: SpectrogramConfig, colorMap: ColorMapValue) => void;
+  }>;
+  /** Get color lookup table for a color map name */
+  getColorMap: (name: ColorMapValue) => Uint8Array;
+  /** Get frequency scale function for a scale name */
+  getFrequencyScale: (name: string) => (f: number, minF: number, maxF: number) => number;
+}
+
+/** Minimal type for the worker API surface used by browser components */
+export interface SpectrogramWorkerApi {
+  registerCanvas: (canvasId: string, canvas: OffscreenCanvas) => void;
+  unregisterCanvas: (canvasId: string) => void;
+}
+
+const SpectrogramIntegrationContext = createContext<SpectrogramIntegration | null>(null);
+
+export const SpectrogramIntegrationProvider = SpectrogramIntegrationContext.Provider;
+
+export function useSpectrogramIntegration(): SpectrogramIntegration | null {
+  return useContext(SpectrogramIntegrationContext);
+}

--- a/packages/browser/src/SpectrogramIntegrationContext.tsx
+++ b/packages/browser/src/SpectrogramIntegrationContext.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import type { SpectrogramData, SpectrogramConfig, ColorMapValue, RenderMode, TrackSpectrogramOverrides } from '@waveform-playlist/core';
+import type { TrackMenuItem } from '@waveform-playlist/ui-components';
 
 export interface SpectrogramIntegration {
   spectrogramDataMap: Map<string, SpectrogramData[]>;
@@ -12,7 +13,7 @@ export interface SpectrogramIntegration {
   registerSpectrogramCanvases: (clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => void;
   unregisterSpectrogramCanvases: (clipId: string, channelIndex: number) => void;
   /** Render spectrogram menu items for a track's context menu */
-  renderMenuItems?: (props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => Array<{ id: string; label?: string; content: React.ReactNode }>;
+  renderMenuItems?: (props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => TrackMenuItem[];
   /** Settings modal component provided by the spectrogram package */
   SettingsModal?: React.ComponentType<{
     open: boolean;

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { TonePlayout, type EffectsFunction, type TrackEffectsFunction } from '@waveform-playlist/playout';
-import { type Track, type ClipTrack, type Fade, type SpectrogramData, type SpectrogramConfig, type SpectrogramComputeConfig, type ColorMapValue, type RenderMode, type TrackSpectrogramOverrides } from '@waveform-playlist/core';
+import { type Track, type ClipTrack, type Fade } from '@waveform-playlist/core';
 import { type TimeFormat, type WaveformPlaylistTheme, defaultTheme } from '@waveform-playlist/ui-components';
 import { start as toneStart, getContext } from 'tone';
 import { generatePeaks } from './peaksUtil';
-import { computeSpectrogram, computeSpectrogramMono, createSpectrogramWorker, getColorMap, type SpectrogramWorkerApi } from '@waveform-playlist/spectrogram';
+
 import { extractPeaksFromWaveformData } from './waveformDataLoader';
 import type { PeakData } from '@waveform-playlist/webaudio-peaks';
 import { parseAeneas, type AnnotationData } from '@waveform-playlist/annotations';
@@ -186,13 +186,6 @@ export interface PlaylistControlsContextValue {
   setLoopRegionFromSelection: () => void;
   clearLoopRegion: () => void;
 
-  // Per-track render mode and spectrogram config
-  setTrackRenderMode: (trackId: string, mode: RenderMode) => void;
-  setTrackSpectrogramConfig: (trackId: string, config: SpectrogramConfig, colorMap?: ColorMapValue) => void;
-
-  // Spectrogram OffscreenCanvas registration
-  registerSpectrogramCanvases: (clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => void;
-  unregisterSpectrogramCanvases: (clipId: string, channelIndex: number) => void;
 }
 
 export interface PlaylistDataContextValue {
@@ -218,16 +211,8 @@ export interface PlaylistDataContextValue {
   progressBarWidth: number;
   /** Whether the playlist has finished loading all tracks */
   isReady: boolean;
-  /** Spectrogram data keyed by clipId, value is array of per-channel spectrograms */
-  spectrogramDataMap: Map<string, SpectrogramData[]>;
-  /** Global spectrogram configuration (fallback) */
-  spectrogramConfig?: SpectrogramConfig;
-  /** Global spectrogram color map (fallback) */
-  spectrogramColorMap?: ColorMapValue;
-  /** Per-track spectrogram overrides (render mode, config, color map) */
-  trackSpectrogramOverrides: Map<string, TrackSpectrogramOverrides>;
-  /** Spectrogram worker API (for OffscreenCanvas rendering) */
-  spectrogramWorkerApi: SpectrogramWorkerApi | null;
+  /** Whether tracks are rendered in mono mode */
+  mono: boolean;
 }
 
 // Create the 4 separate contexts
@@ -271,10 +256,6 @@ export interface WaveformPlaylistProviderProps {
   barGap?: number;
   /** Width in pixels of progress bars. Default: barWidth + barGap (fills gaps). */
   progressBarWidth?: number;
-  /** Global spectrogram configuration for tracks with renderMode 'spectrogram' or 'both' */
-  spectrogramConfig?: SpectrogramConfig;
-  /** Global color map for spectrogram rendering */
-  spectrogramColorMap?: ColorMapValue;
   children: ReactNode;
 }
 
@@ -296,8 +277,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
   barWidth = 1,
   barGap = 0,
   progressBarWidth: progressBarWidthProp,
-  spectrogramConfig,
-  spectrogramColorMap,
   children,
 }) => {
   // Default progressBarWidth to barWidth + barGap (fills gaps)
@@ -322,7 +301,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
   const [duration, setDuration] = useState(0);
   const [audioBuffers, setAudioBuffers] = useState<AudioBuffer[]>([]);
   const [peaksDataArray, setPeaksDataArray] = useState<TrackClipPeaks[]>([]); // Updated for clip-based peaks
-  const [spectrogramDataMap, setSpectrogramDataMap] = useState<Map<string, SpectrogramData[]>>(new Map());
   const [trackStates, setTrackStates] = useState<TrackState[]>([]);
   const [selectionStart, setSelectionStart] = useState(0);
   const [selectionEnd, setSelectionEnd] = useState(0);
@@ -335,14 +313,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
   const [loopStart, setLoopStartState] = useState(0);
   const [loopEnd, setLoopEndState] = useState(0);
   const [isReady, setIsReady] = useState(false);
-
-  // Per-track spectrogram overrides (render mode, config, color map) — single Map
-  const [trackSpectrogramOverrides, setTrackSpectrogramOverrides] = useState<Map<string, TrackSpectrogramOverrides>>(new Map());
-
-  // OffscreenCanvas registry for worker-rendered spectrograms
-  // Map: clipId → Map<channelIndex, { canvasIds: string[], canvasWidths: number[] }>
-  const spectrogramCanvasRegistryRef = useRef<Map<string, Map<number, { canvasIds: string[]; canvasWidths: number[] }>>>(new Map());
-  const [spectrogramCanvasVersion, setSpectrogramCanvasVersion] = useState(0);
 
   // Refs
   const playoutRef = useRef<TonePlayout | null>(null);
@@ -464,7 +434,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       setDuration(0);
       setTrackStates([]);
       setPeaksDataArray([]);
-      setSpectrogramDataMap(new Map());
       if (playoutRef.current) {
         playoutRef.current.dispose();
         playoutRef.current = null;
@@ -709,571 +678,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     setPeaksDataArray(allTrackPeaks);
   }, [tracks, samplesPerPixel, mono]);
 
-  // Compute spectrograms for tracks with renderMode 'spectrogram' or 'both'
-  // Uses per-track config; only recomputes tracks whose config changed.
-  // Computation runs in a Web Worker to avoid blocking the main thread.
-  const prevSpectrogramConfigRef = useRef<Map<string, string>>(new Map());
-  const prevSpectrogramFFTKeyRef = useRef<Map<string, string>>(new Map());
-  const spectrogramWorkerRef = useRef<ReturnType<typeof createSpectrogramWorker> | null>(null);
-  const spectrogramGenerationRef = useRef(0);
-  const prevCanvasVersionRef = useRef(0);
-  const [spectrogramWorkerReady, setSpectrogramWorkerReady] = useState(false);
-  // Per-clip cache keys from compute-fft, used to re-render from cache on display-only changes
-  const clipCacheKeysRef = useRef<Map<string, string>>(new Map());
-  // Abort controller for background chunk rendering
-  const backgroundRenderAbortRef = useRef<{ aborted: boolean } | null>(null);
-  // Track which clipIds have been pre-registered with the worker
-  const registeredAudioClipIdsRef = useRef<Set<string>>(new Set());
-
-  // Terminate worker on unmount
-  useEffect(() => {
-    return () => {
-      spectrogramWorkerRef.current?.terminate();
-      spectrogramWorkerRef.current = null;
-    };
-  }, []);
-
-  // Eagerly transfer audio data to worker when tracks load (pre-transfer optimization)
-  useEffect(() => {
-    if (!isReady || tracks.length === 0) return;
-
-    // Lazily create worker if not yet created
-    let workerApi = spectrogramWorkerRef.current;
-    if (!workerApi) {
-      try {
-        const rawWorker = new Worker(
-          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
-          { type: 'module' }
-        );
-        workerApi = createSpectrogramWorker(rawWorker);
-        spectrogramWorkerRef.current = workerApi;
-        setSpectrogramWorkerReady(true);
-      } catch {
-        console.warn('Spectrogram Web Worker unavailable for pre-transfer');
-        return;
-      }
-    }
-
-    const currentClipIds = new Set<string>();
-
-    for (const track of tracks) {
-      for (const clip of track.clips) {
-        if (!clip.audioBuffer) continue;
-        currentClipIds.add(clip.id);
-
-        if (!registeredAudioClipIdsRef.current.has(clip.id)) {
-          const channelDataArrays: Float32Array[] = [];
-          for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
-            channelDataArrays.push(clip.audioBuffer.getChannelData(ch));
-          }
-          workerApi.registerAudioData(clip.id, channelDataArrays, clip.audioBuffer.sampleRate);
-          registeredAudioClipIdsRef.current.add(clip.id);
-        }
-      }
-    }
-
-    // Unregister clips that were removed
-    for (const clipId of registeredAudioClipIdsRef.current) {
-      if (!currentClipIds.has(clipId)) {
-        workerApi.unregisterAudioData(clipId);
-        registeredAudioClipIdsRef.current.delete(clipId);
-      }
-    }
-  }, [isReady, tracks]);
-
-  useEffect(() => {
-    if (tracks.length === 0) return;
-
-    // Build full config key and FFT-only key per track to detect what changed
-    const currentKeys = new Map<string, string>();
-    const currentFFTKeys = new Map<string, string>();
-    tracks.forEach((track, i) => {
-      const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
-      if (mode === 'waveform') return;
-      const cfg = trackSpectrogramOverrides.get(track.id)?.config ?? track.spectrogramConfig ?? spectrogramConfig;
-      const cm = trackSpectrogramOverrides.get(track.id)?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap;
-      currentKeys.set(track.id, JSON.stringify({ mode, cfg, cm, mono }));
-      // FFT key: only SpectrogramComputeConfig fields (not gain, range, colormap, freq scale, etc.)
-      const computeConfig: SpectrogramComputeConfig = {
-        fftSize: cfg?.fftSize, hopSize: cfg?.hopSize,
-        windowFunction: cfg?.windowFunction, alpha: cfg?.alpha,
-        zeroPaddingFactor: cfg?.zeroPaddingFactor,
-      };
-      currentFFTKeys.set(track.id, JSON.stringify({ mode, mono, ...computeConfig }));
-    });
-
-    const prevKeys = prevSpectrogramConfigRef.current;
-    const prevFFTKeys = prevSpectrogramFFTKeyRef.current;
-
-    // Check if any track config changed (full key)
-    let configChanged = currentKeys.size !== prevKeys.size;
-    if (!configChanged) {
-      for (const [idx, key] of currentKeys) {
-        if (prevKeys.get(idx) !== key) { configChanged = true; break; }
-      }
-    }
-
-    // Check if FFT key changed (requires recomputation)
-    let fftKeyChanged = currentFFTKeys.size !== prevFFTKeys.size;
-    if (!fftKeyChanged) {
-      for (const [idx, key] of currentFFTKeys) {
-        if (prevFFTKeys.get(idx) !== key) { fftKeyChanged = true; break; }
-      }
-    }
-
-    // Check if canvas registrations changed (new canvases available for worker rendering)
-    const canvasVersionChanged = spectrogramCanvasVersion !== prevCanvasVersionRef.current;
-    prevCanvasVersionRef.current = spectrogramCanvasVersion;
-
-    if (!configChanged && !canvasVersionChanged) return;
-
-    // Only update prevKeys when config actually changed (not just canvas version)
-    if (configChanged) {
-      prevSpectrogramConfigRef.current = currentKeys;
-      prevSpectrogramFFTKeyRef.current = currentFFTKeys;
-    }
-
-    // Remove entries for clips that no longer need spectrograms (synchronous)
-    if (configChanged) {
-      setSpectrogramDataMap(prevMap => {
-        // Build set of clip IDs that still need spectrograms
-        const activeClipIds = new Set<string>();
-        for (const track of tracks) {
-          const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
-          if (mode === 'spectrogram' || mode === 'both') {
-            for (const clip of track.clips) {
-              activeClipIds.add(clip.id);
-            }
-          }
-        }
-        // Delete any map entries not in the active set (handles removed tracks + mode changes)
-        const newMap = new Map(prevMap);
-        for (const clipId of newMap.keys()) {
-          if (!activeClipIds.has(clipId)) {
-            newMap.delete(clipId);
-          }
-        }
-        return newMap;
-      });
-    }
-
-    // Abort any ongoing background rendering
-    if (backgroundRenderAbortRef.current) {
-      backgroundRenderAbortRef.current.aborted = true;
-    }
-
-    // Generation counter to discard stale results
-    const generation = ++spectrogramGenerationRef.current;
-
-    // Lazily create worker, fall back to synchronous if it fails
-    let workerApi = spectrogramWorkerRef.current;
-    if (!workerApi) {
-      try {
-        const rawWorker = new Worker(
-          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
-          { type: 'module' }
-        );
-        workerApi = createSpectrogramWorker(rawWorker);
-        spectrogramWorkerRef.current = workerApi;
-        setSpectrogramWorkerReady(true);
-      } catch {
-        console.warn('Spectrogram Web Worker unavailable, falling back to synchronous computation');
-      }
-    }
-
-    // Determine which tracks need FFT recomputation vs display-only re-render
-    const clipsNeedingFFT: Array<{
-      clipId: string;
-      trackIndex: number;
-      channelDataArrays: Float32Array[];
-      config: SpectrogramConfig;
-      sampleRate: number;
-      offsetSamples: number;
-      durationSamples: number;
-      clipStartSample: number;
-      monoFlag: boolean;
-      colorMap: ColorMapValue;
-    }> = [];
-    const clipsNeedingDisplayOnly: Array<{
-      clipId: string;
-      trackIndex: number;
-      config: SpectrogramConfig;
-      clipStartSample: number;
-      monoFlag: boolean;
-      colorMap: ColorMapValue;
-      numChannels: number;
-    }> = [];
-
-    tracks.forEach((track, i) => {
-      const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
-      if (mode === 'waveform') return;
-
-      const trackConfigChanged = configChanged && (currentKeys.get(track.id) !== prevKeys.get(track.id));
-      const trackFFTChanged = fftKeyChanged && (currentFFTKeys.get(track.id) !== prevFFTKeys.get(track.id));
-      const hasRegisteredCanvases = canvasVersionChanged && track.clips.some(
-        clip => spectrogramCanvasRegistryRef.current.has(clip.id)
-      );
-      if (!trackConfigChanged && !hasRegisteredCanvases) return;
-
-      const cfg = trackSpectrogramOverrides.get(track.id)?.config ?? track.spectrogramConfig ?? spectrogramConfig ?? {};
-      const cm = trackSpectrogramOverrides.get(track.id)?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap ?? 'viridis';
-
-      for (const clip of track.clips) {
-        if (!clip.audioBuffer) continue;
-
-        const monoFlag = mono || clip.audioBuffer.numberOfChannels === 1;
-
-        // If FFT key didn't change AND we have a cached key for this clip, display-only re-render
-        if (!trackFFTChanged && !hasRegisteredCanvases && clipCacheKeysRef.current.has(clip.id)) {
-          clipsNeedingDisplayOnly.push({
-            clipId: clip.id,
-            trackIndex: i,
-            config: cfg,
-            clipStartSample: clip.startSample,
-            monoFlag,
-            colorMap: cm,
-            numChannels: monoFlag ? 1 : clip.audioBuffer.numberOfChannels,
-          });
-          continue;
-        }
-
-        const channelDataArrays: Float32Array[] = [];
-        for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
-          channelDataArrays.push(clip.audioBuffer.getChannelData(ch));
-        }
-
-        clipsNeedingFFT.push({
-          clipId: clip.id,
-          trackIndex: i,
-          channelDataArrays,
-          config: cfg,
-          sampleRate: clip.audioBuffer.sampleRate,
-          offsetSamples: clip.offsetSamples,
-          durationSamples: clip.durationSamples,
-          clipStartSample: clip.startSample,
-          monoFlag,
-          colorMap: cm,
-        });
-      }
-    });
-
-    if (clipsNeedingFFT.length === 0 && clipsNeedingDisplayOnly.length === 0) return;
-
-    if (!workerApi) {
-      // Synchronous fallback (no caching optimization)
-      setSpectrogramDataMap(prevMap => {
-        const newMap = new Map(prevMap);
-        for (const item of clipsNeedingFFT) {
-          const channelSpectrograms: SpectrogramData[] = [];
-          if (item.monoFlag) {
-            channelSpectrograms.push(
-              computeSpectrogramMono(
-                tracks.flatMap(t => t.clips).find(c => c.id === item.clipId)!.audioBuffer!,
-                item.config, item.offsetSamples, item.durationSamples
-              )
-            );
-          } else {
-            const clip = tracks.flatMap(t => t.clips).find(c => c.id === item.clipId)!;
-            for (let ch = 0; ch < clip.audioBuffer!.numberOfChannels; ch++) {
-              channelSpectrograms.push(
-                computeSpectrogram(clip.audioBuffer!, item.config, item.offsetSamples, item.durationSamples, ch)
-              );
-            }
-          }
-          newMap.set(item.clipId, channelSpectrograms);
-        }
-        return newMap;
-      });
-      return;
-    }
-
-    // Helper: determine visible chunk indices from scroll position
-    // clipPixelOffset is the clip's pixel position on the timeline (from clip.startSample / samplesPerPixel)
-    const getVisibleChunkRange = (canvasWidths: number[], clipPixelOffset = 0): { visibleIndices: number[]; remainingIndices: number[] } => {
-      const container = scrollContainerRef.current;
-      if (!container) {
-        // No scroll info available — all chunks are "visible"
-        return { visibleIndices: canvasWidths.map((_, i) => i), remainingIndices: [] };
-      }
-
-      const scrollLeft = container.scrollLeft;
-      const viewportWidth = container.clientWidth;
-      const controlWidth = controls.show ? controls.width : 0;
-
-      const visibleIndices: number[] = [];
-      const remainingIndices: number[] = [];
-      let offset = 0;
-
-      for (let i = 0; i < canvasWidths.length; i++) {
-        const chunkLeft = offset + controlWidth + clipPixelOffset;
-        const chunkRight = chunkLeft + canvasWidths[i];
-        // Chunk is visible if it overlaps the viewport
-        if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
-          visibleIndices.push(i);
-        } else {
-          remainingIndices.push(i);
-        }
-        offset += canvasWidths[i];
-      }
-
-      return { visibleIndices, remainingIndices };
-    };
-
-    // Helper: render a set of chunks for a clip/channel via worker
-    const renderChunkSubset = async (
-      api: NonNullable<typeof workerApi>,
-      cacheKey: string,
-      channelInfo: { canvasIds: string[]; canvasWidths: number[] },
-      indices: number[],
-      item: { config: SpectrogramConfig; colorMap: ColorMapValue },
-      channelIndex: number,
-    ) => {
-      if (indices.length === 0) return;
-
-      const canvasIds = indices.map(i => channelInfo.canvasIds[i]);
-      const canvasWidths = indices.map(i => channelInfo.canvasWidths[i]);
-
-      // Compute globalPixelOffsets for each selected chunk
-      const globalPixelOffsets: number[] = [];
-      for (const idx of indices) {
-        let offset = 0;
-        for (let j = 0; j < idx; j++) {
-          offset += channelInfo.canvasWidths[j];
-        }
-        globalPixelOffsets.push(offset);
-      }
-
-      const colorLUT = getColorMap(item.colorMap);
-
-      await api.renderChunks({
-        cacheKey,
-        canvasIds,
-        canvasWidths,
-        globalPixelOffsets,
-        canvasHeight: waveHeight,
-        devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
-        samplesPerPixel,
-        colorLUT,
-        frequencyScale: item.config.frequencyScale ?? 'mel',
-        minFrequency: item.config.minFrequency ?? 0,
-        maxFrequency: item.config.maxFrequency ?? 0,
-        gainDb: item.config.gainDb ?? 20,
-        rangeDb: item.config.rangeDb ?? 80,
-        channelIndex,
-      });
-    };
-
-    // 3-phase async rendering pipeline
-    const computeAsync = async () => {
-      const abortToken = { aborted: false };
-      backgroundRenderAbortRef.current = abortToken;
-
-      // --- Process clips needing full FFT ---
-      for (const item of clipsNeedingFFT) {
-        if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-        try {
-          const clipCanvasInfo = spectrogramCanvasRegistryRef.current.get(item.clipId);
-          if (clipCanvasInfo && clipCanvasInfo.size > 0) {
-            const numChannels = item.monoFlag ? 1 : item.channelDataArrays.length;
-            const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
-
-            // Calculate visible sample range for range-limited FFT
-            const container = scrollContainerRef.current;
-            const windowSize = item.config.fftSize ?? 2048;
-            let visibleRange: { start: number; end: number } | undefined;
-
-            if (container) {
-              const scrollLeft = container.scrollLeft;
-              const viewportWidth = container.clientWidth;
-              const controlWidth = controls.show ? controls.width : 0;
-
-              // Viewport pixel range on the timeline
-              const vpStartPx = Math.max(0, scrollLeft - controlWidth);
-              const vpEndPx = vpStartPx + viewportWidth;
-
-              // Clip pixel range on the timeline
-              const clipStartPx = clipPixelOffset;
-              const clipEndPx = clipStartPx + Math.ceil(item.durationSamples / samplesPerPixel);
-
-              // Intersection of viewport with clip (in timeline pixels)
-              const overlapStartPx = Math.max(vpStartPx, clipStartPx);
-              const overlapEndPx = Math.min(vpEndPx, clipEndPx);
-
-              if (overlapEndPx > overlapStartPx) {
-                // Convert to clip-local pixels, then to buffer samples
-                const localStartPx = overlapStartPx - clipStartPx;
-                const localEndPx = overlapEndPx - clipStartPx;
-                const visStartSample = item.offsetSamples + Math.floor(localStartPx * samplesPerPixel);
-                const visEndSample = Math.min(
-                  item.offsetSamples + item.durationSamples,
-                  item.offsetSamples + Math.ceil(localEndPx * samplesPerPixel)
-                );
-                // Add padding for FFT windowing
-                const paddedStart = Math.max(item.offsetSamples, visStartSample - windowSize);
-                const paddedEnd = Math.min(item.offsetSamples + item.durationSamples, visEndSample + windowSize);
-
-                // Only use range-limited FFT if it's substantially smaller than the full clip
-                if ((paddedEnd - paddedStart) < item.durationSamples * 0.8) {
-                  visibleRange = { start: paddedStart, end: paddedEnd };
-                }
-              }
-            }
-
-            // Phase 1a: Compute visible-range FFT first (if range is smaller than full clip)
-            // Skip if the full-clip FFT is already cached (e.g., from a previous zoom level)
-            const fullClipAlreadyCached = clipCacheKeysRef.current.has(item.clipId);
-            if (visibleRange && !fullClipAlreadyCached) {
-              const { cacheKey: visibleCacheKey } = await workerApi!.computeFFT({
-                clipId: item.clipId,
-                channelDataArrays: item.channelDataArrays,
-                config: item.config,
-                sampleRate: item.sampleRate,
-                offsetSamples: item.offsetSamples,
-                durationSamples: item.durationSamples,
-                mono: item.monoFlag,
-                sampleRange: visibleRange,
-              });
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-              // Render visible chunks immediately from partial FFT
-              for (let ch = 0; ch < numChannels; ch++) {
-                const channelInfo = clipCanvasInfo.get(ch);
-                if (!channelInfo) continue;
-
-                const { visibleIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
-                await renderChunkSubset(workerApi!, visibleCacheKey, channelInfo, visibleIndices, item, ch);
-              }
-
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-            }
-
-            // Phase 1b: Compute full-clip FFT (cached in worker)
-            const { cacheKey } = await workerApi!.computeFFT({
-              clipId: item.clipId,
-              channelDataArrays: item.channelDataArrays,
-              config: item.config,
-              sampleRate: item.sampleRate,
-              offsetSamples: item.offsetSamples,
-              durationSamples: item.durationSamples,
-              mono: item.monoFlag,
-            });
-
-            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-            clipCacheKeysRef.current.set(item.clipId, cacheKey);
-
-            for (let ch = 0; ch < numChannels; ch++) {
-              const channelInfo = clipCanvasInfo.get(ch);
-              if (!channelInfo) continue;
-
-              const { visibleIndices, remainingIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
-
-              // Phase 2: Re-render visible chunks with full FFT data
-              // Always re-render: partial FFT may leave gaps at chunk edges outside the visible range
-              await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
-
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-              // Phase 3: Background render remaining chunks in batches
-              const BATCH_SIZE = 4;
-              for (let batchStart = 0; batchStart < remainingIndices.length; batchStart += BATCH_SIZE) {
-                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-                const batch = remainingIndices.slice(batchStart, batchStart + BATCH_SIZE);
-
-                // Yield to browser between batches
-                await new Promise<void>(resolve => {
-                  if (typeof requestIdleCallback === 'function') {
-                    requestIdleCallback(() => resolve());
-                  } else {
-                    setTimeout(resolve, 0);
-                  }
-                });
-
-                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-                await renderChunkSubset(workerApi!, cacheKey, channelInfo, batch, item, ch);
-              }
-            }
-          } else {
-            // Fallback: compute only, render on main thread
-            const spectrograms = await workerApi!.compute({
-              channelDataArrays: item.channelDataArrays,
-              config: item.config,
-              sampleRate: item.sampleRate,
-              offsetSamples: item.offsetSamples,
-              durationSamples: item.durationSamples,
-              mono: item.monoFlag,
-            });
-
-            if (spectrogramGenerationRef.current !== generation) return;
-
-            setSpectrogramDataMap(prevMap => {
-              const newMap = new Map(prevMap);
-              newMap.set(item.clipId, spectrograms);
-              return newMap;
-            });
-          }
-        } catch (err) {
-          console.warn('Spectrogram worker error for clip', item.clipId, err);
-        }
-      }
-
-      // --- Process clips needing display-only re-render (skip FFT) ---
-      for (const item of clipsNeedingDisplayOnly) {
-        if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-        const cacheKey = clipCacheKeysRef.current.get(item.clipId);
-        if (!cacheKey) continue;
-
-        const clipCanvasInfo = spectrogramCanvasRegistryRef.current.get(item.clipId);
-        if (!clipCanvasInfo || clipCanvasInfo.size === 0) continue;
-
-        try {
-          const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
-          for (let ch = 0; ch < item.numChannels; ch++) {
-            const channelInfo = clipCanvasInfo.get(ch);
-            if (!channelInfo) continue;
-
-            const { visibleIndices, remainingIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
-
-            // Phase 2: Visible chunks first
-            await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
-
-            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-            // Phase 3: Background render remaining
-            const BATCH_SIZE = 4;
-            for (let batchStart = 0; batchStart < remainingIndices.length; batchStart += BATCH_SIZE) {
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-              const batch = remainingIndices.slice(batchStart, batchStart + BATCH_SIZE);
-
-              await new Promise<void>(resolve => {
-                if (typeof requestIdleCallback === 'function') {
-                  requestIdleCallback(() => resolve());
-                } else {
-                  setTimeout(resolve, 0);
-                }
-              });
-
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-              await renderChunkSubset(workerApi!, cacheKey, channelInfo, batch, item, ch);
-            }
-          }
-        } catch (err) {
-          console.warn('Spectrogram display re-render error for clip', item.clipId, err);
-        }
-      }
-
-    };
-
-    computeAsync().catch(err => {
-      console.error('[waveform-playlist] Spectrogram computation failed:', err);
-    });
-  }, [tracks, mono, spectrogramConfig, spectrogramColorMap, trackSpectrogramOverrides, waveHeight, samplesPerPixel, spectrogramCanvasVersion]);
 
   // Animation loop
   const startAnimationLoop = useCallback(() => {
@@ -1612,51 +1016,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     }
   }, [trackStates]);
 
-  // Per-track render mode and spectrogram config setters (convenience wrappers over single Map)
-  const setTrackRenderMode = useCallback((trackId: string, mode: RenderMode) => {
-    setTrackSpectrogramOverrides(prev => {
-      const next = new Map(prev);
-      const existing = next.get(trackId);
-      next.set(trackId, { ...existing, renderMode: mode });
-      return next;
-    });
-  }, []);
-
-  const setTrackSpectrogramConfig = useCallback((trackId: string, config: SpectrogramConfig, colorMap?: ColorMapValue) => {
-    setTrackSpectrogramOverrides(prev => {
-      const next = new Map(prev);
-      const existing = next.get(trackId);
-      next.set(trackId, {
-        renderMode: existing?.renderMode ?? 'waveform',
-        config,
-        ...(colorMap !== undefined ? { colorMap } : { colorMap: existing?.colorMap }),
-      });
-      return next;
-    });
-  }, []);
-
-  // Spectrogram OffscreenCanvas registration
-  const registerSpectrogramCanvases = useCallback((clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => {
-    const registry = spectrogramCanvasRegistryRef.current;
-    if (!registry.has(clipId)) {
-      registry.set(clipId, new Map());
-    }
-    registry.get(clipId)!.set(channelIndex, { canvasIds, canvasWidths });
-    // Bump version to trigger re-computation with canvas rendering
-    setSpectrogramCanvasVersion(v => v + 1);
-  }, []);
-
-  const unregisterSpectrogramCanvases = useCallback((clipId: string, channelIndex: number) => {
-    const registry = spectrogramCanvasRegistryRef.current;
-    const clipChannels = registry.get(clipId);
-    if (clipChannels) {
-      clipChannels.delete(channelIndex);
-      if (clipChannels.size === 0) {
-        registry.delete(clipId);
-      }
-    }
-  }, []);
-
   // Selection
   const setSelection = useCallback((start: number, end: number) => {
     setSelectionStart(start);
@@ -1780,13 +1139,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     setLoopRegionFromSelection,
     clearLoopRegion,
 
-    // Per-track render mode and spectrogram config
-    setTrackRenderMode,
-    setTrackSpectrogramConfig,
-
-    // Spectrogram OffscreenCanvas registration
-    registerSpectrogramCanvases,
-    unregisterSpectrogramCanvases,
   };
 
   const dataValue: PlaylistDataContextValue = {
@@ -1810,11 +1162,7 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     barGap,
     progressBarWidth,
     isReady,
-    spectrogramDataMap,
-    spectrogramConfig,
-    spectrogramColorMap,
-    trackSpectrogramOverrides,
-    spectrogramWorkerApi: spectrogramWorkerReady ? spectrogramWorkerRef.current : null,
+    mono,
   };
 
   // Combined value for backwards compatibility

--- a/packages/browser/src/components/PlaylistVisualization.tsx
+++ b/packages/browser/src/components/PlaylistVisualization.tsx
@@ -11,6 +11,7 @@ import {
   TrackControlsContext,
   DevicePixelRatioProvider,
   SmartScale,
+  CloseButton,
   Controls,
   Header,
   Button,
@@ -387,22 +388,7 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                   <Controls onClick={() => selectTrack(trackIndex)}>
                     <Header style={{ justifyContent: 'center', position: 'relative' }}>
                       {onRemoveTrack && (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); onRemoveTrack(trackIndex); }}
-                          title="Remove track"
-                          style={{
-                            position: 'absolute', left: 0, top: 0,
-                            border: 'none', background: 'transparent',
-                            color: 'inherit', cursor: 'pointer',
-                            fontSize: 16, padding: '2px 4px',
-                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            opacity: 0.7, transition: 'opacity 0.15s, color 0.15s',
-                          }}
-                          onMouseEnter={(e) => { e.currentTarget.style.opacity = '1'; e.currentTarget.style.color = '#dc3545'; }}
-                          onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.7'; e.currentTarget.style.color = 'inherit'; }}
-                        >
-                          ×
-                        </button>
+                        <CloseButton onClick={(e) => { e.stopPropagation(); onRemoveTrack(trackIndex); }} />
                       )}
                       <span style={{
                         overflow: 'hidden',

--- a/packages/browser/src/components/PlaylistVisualization.tsx
+++ b/packages/browser/src/components/PlaylistVisualization.tsx
@@ -35,9 +35,9 @@ import { usePlaybackAnimation, usePlaylistState, usePlaylistControls, usePlaylis
 import type { Peaks } from '@waveform-playlist/webaudio-peaks';
 import { AnimatedPlayhead } from './AnimatedPlayhead';
 import { ChannelWithProgress } from './ChannelWithProgress';
-import type { SpectrogramConfig, ColorMapValue, RenderMode } from '@waveform-playlist/core';
+import type { SpectrogramConfig } from '@waveform-playlist/core';
 import type { AnnotationData, GetAnnotationBoxLabelFn } from '../types/annotations';
-import { getColorMap, getFrequencyScale, SpectrogramMenuItems, SpectrogramSettingsModal } from '@waveform-playlist/spectrogram';
+import { useSpectrogramIntegration } from '../SpectrogramIntegrationContext';
 
 // Default duration in seconds for empty tracks (used for recording workflow)
 const DEFAULT_EMPTY_TRACK_DURATION = 60;
@@ -129,10 +129,6 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
     setSelectedTrackId,
     setCurrentTime,
     setLoopRegion,
-    setTrackRenderMode,
-    setTrackSpectrogramConfig,
-    registerSpectrogramCanvases,
-    unregisterSpectrogramCanvases,
   } = usePlaylistControls();
   const {
     audioBuffers,
@@ -149,43 +145,42 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
     barWidth,
     barGap,
     isReady,
-    spectrogramDataMap,
-    spectrogramConfig,
-    spectrogramColorMap,
-    trackSpectrogramOverrides,
-    spectrogramWorkerApi,
   } = usePlaylistData();
 
-  // Per-track spectrogram rendering helpers (memoized)
+  // Optional spectrogram integration (only available when SpectrogramProvider is present)
+  const spectrogram = useSpectrogramIntegration();
+
+  // Per-track spectrogram rendering helpers (memoized) — only computed when spectrogram is available
   const perTrackSpectrogramHelpers = useMemo(() => {
+    if (!spectrogram) return new Map<string, { colorLUT: Uint8Array; frequencyScaleFn: (f: number, minF: number, maxF: number) => number; config: SpectrogramConfig | undefined }>();
     const helpers = new Map<string, {
       colorLUT: Uint8Array;
       frequencyScaleFn: (f: number, minF: number, maxF: number) => number;
       config: SpectrogramConfig | undefined;
     }>();
     tracks.forEach((track) => {
-      const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+      const mode = spectrogram.trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
       if (mode === 'waveform') return;
-      const overrides = trackSpectrogramOverrides.get(track.id);
-      const cm = overrides?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap ?? 'viridis';
-      const cfg = overrides?.config ?? track.spectrogramConfig ?? spectrogramConfig;
+      const overrides = spectrogram.trackSpectrogramOverrides.get(track.id);
+      const cm = overrides?.colorMap ?? track.spectrogramColorMap ?? spectrogram.spectrogramColorMap ?? 'viridis';
+      const cfg = overrides?.config ?? track.spectrogramConfig ?? spectrogram.spectrogramConfig;
       helpers.set(track.id, {
-        colorLUT: getColorMap(cm),
-        frequencyScaleFn: getFrequencyScale(cfg?.frequencyScale ?? 'mel'),
+        colorLUT: spectrogram.getColorMap(cm),
+        frequencyScaleFn: spectrogram.getFrequencyScale(cfg?.frequencyScale ?? 'mel'),
         config: cfg,
       });
     });
     return helpers;
-  }, [tracks, trackSpectrogramOverrides, spectrogramConfig, spectrogramColorMap]);
+  }, [tracks, spectrogram]);
 
   // Worker canvas API for SpectrogramChannel (stable reference)
   const workerCanvasApi = useMemo(() => {
-    if (!spectrogramWorkerApi) return undefined;
+    if (!spectrogram?.spectrogramWorkerApi) return undefined;
     return {
-      registerCanvas: spectrogramWorkerApi.registerCanvas.bind(spectrogramWorkerApi),
-      unregisterCanvas: spectrogramWorkerApi.unregisterCanvas.bind(spectrogramWorkerApi),
+      registerCanvas: spectrogram.spectrogramWorkerApi.registerCanvas.bind(spectrogram.spectrogramWorkerApi),
+      unregisterCanvas: spectrogram.spectrogramWorkerApi.unregisterCanvas.bind(spectrogram.spectrogramWorkerApi),
     };
-  }, [spectrogramWorkerApi]);
+  }, [spectrogram?.spectrogramWorkerApi]);
 
   // State for spectrogram settings modal
   const [settingsModalTrackId, setSettingsModalTrackId] = useState<string | null>(null);
@@ -244,7 +239,7 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
       const rawCh = trackClipPeaks.length > 0
         ? Math.max(...trackClipPeaks.map(clip => clip.peaks.data.length))
         : 1;
-      const trackMode = trackSpectrogramOverrides.get(tracks[i]?.id)?.renderMode ?? tracks[i]?.renderMode ?? 'waveform';
+      const trackMode = spectrogram?.trackSpectrogramOverrides.get(tracks[i]?.id)?.renderMode ?? tracks[i]?.renderMode ?? 'waveform';
       const effectiveCh = trackMode === 'both' ? rawCh * 2 : rawCh;
       const trackHeight = effectiveCh * waveHeight + (showClipHeaders ? 22 : 0);
 
@@ -380,7 +375,7 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                   pan: 0,
                 };
 
-                const effectiveRenderMode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+                const effectiveRenderMode = spectrogram?.trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
 
                 const trackControls = renderTrackControls ? (
                   renderTrackControls(trackIndex)
@@ -399,16 +394,18 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                       }}>
                         {trackState.name || `Track ${trackIndex + 1}`}
                       </span>
-                      <span style={{ position: 'absolute', right: 0, top: 0 }}>
-                        <TrackMenu
-                          items={(onClose) => SpectrogramMenuItems({
-                            renderMode: effectiveRenderMode,
-                            onRenderModeChange: (mode) => setTrackRenderMode(track.id, mode),
-                            onOpenSettings: () => setSettingsModalTrackId(track.id),
-                            onClose,
-                          })}
-                        />
-                      </span>
+                      {spectrogram?.renderMenuItems && (
+                        <span style={{ position: 'absolute', right: 0, top: 0 }}>
+                          <TrackMenu
+                            items={(onClose) => spectrogram.renderMenuItems!({
+                              renderMode: effectiveRenderMode,
+                              onRenderModeChange: (mode) => spectrogram.setTrackRenderMode(track.id, mode),
+                              onOpenSettings: () => setSettingsModalTrackId(track.id),
+                              onClose,
+                            })}
+                          />
+                        </span>
+                      )}
                     </Header>
                     <ButtonGroup>
                       <Button
@@ -520,7 +517,7 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                             }}
                           >
                             {peaksData.data.map((channelPeaks: Peaks, channelIndex: number) => {
-                              const clipSpectrograms = spectrogramDataMap.get(clip.clipId);
+                              const clipSpectrograms = spectrogram?.spectrogramDataMap.get(clip.clipId);
                               const channelSpectrogram = clipSpectrograms?.[channelIndex] ?? clipSpectrograms?.[0];
                               const helpers = perTrackSpectrogramHelpers.get(track.id);
                               const trackCfg = helpers?.config;
@@ -544,9 +541,9 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                                   spectrogramMaxFrequency={trackCfg?.maxFrequency}
                                   spectrogramWorkerApi={workerCanvasApi}
                                   spectrogramClipId={clip.clipId}
-                                  spectrogramOnCanvasesReady={(canvasIds, canvasWidths) => {
-                                    registerSpectrogramCanvases(clip.clipId, channelIndex, canvasIds, canvasWidths);
-                                  }}
+                                  spectrogramOnCanvasesReady={spectrogram ? (canvasIds, canvasWidths) => {
+                                    spectrogram.registerSpectrogramCanvases(clip.clipId, channelIndex, canvasIds, canvasWidths);
+                                  } : undefined}
                                 />
                               );
                             })}
@@ -649,23 +646,23 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
             </>
           </Playlist>
       </PlaylistInfoContext.Provider>
-      {typeof document !== 'undefined' && createPortal(
-        <SpectrogramSettingsModal
+      {spectrogram?.SettingsModal && typeof document !== 'undefined' && createPortal(
+        <spectrogram.SettingsModal
           open={settingsModalTrackId !== null}
           onClose={() => setSettingsModalTrackId(null)}
           config={
             settingsModalTrackId !== null
-              ? (trackSpectrogramOverrides.get(settingsModalTrackId)?.config ?? tracks.find(t => t.id === settingsModalTrackId)?.spectrogramConfig ?? spectrogramConfig ?? {})
+              ? (spectrogram.trackSpectrogramOverrides.get(settingsModalTrackId)?.config ?? tracks.find(t => t.id === settingsModalTrackId)?.spectrogramConfig ?? spectrogram.spectrogramConfig ?? {})
               : {}
           }
           colorMap={
             settingsModalTrackId !== null
-              ? (trackSpectrogramOverrides.get(settingsModalTrackId)?.colorMap ?? tracks.find(t => t.id === settingsModalTrackId)?.spectrogramColorMap ?? spectrogramColorMap ?? 'viridis')
+              ? (spectrogram.trackSpectrogramOverrides.get(settingsModalTrackId)?.colorMap ?? tracks.find(t => t.id === settingsModalTrackId)?.spectrogramColorMap ?? spectrogram.spectrogramColorMap ?? 'viridis')
               : 'viridis'
           }
           onApply={(newConfig, newColorMap) => {
             if (settingsModalTrackId !== null) {
-              setTrackSpectrogramConfig(settingsModalTrackId, newConfig, newColorMap);
+              spectrogram.setTrackSpectrogramConfig(settingsModalTrackId, newConfig, newColorMap);
             }
           }}
         />,

--- a/packages/browser/src/index.tsx
+++ b/packages/browser/src/index.tsx
@@ -135,9 +135,9 @@ export type { RenderAnnotationItemProps, AnnotationData } from '@waveform-playli
 // Export annotation callback types for Waveform components
 export type { GetAnnotationBoxLabelFn, OnAnnotationUpdateFn } from './types/annotations';
 
-// Re-export spectrogram computation and utilities
-export { computeSpectrogram, computeSpectrogramMono, getColorMap, getFrequencyScale } from '@waveform-playlist/spectrogram';
-export type { FrequencyScaleName } from '@waveform-playlist/spectrogram';
+// Spectrogram integration context (for optional spectrogram support)
+export { SpectrogramIntegrationProvider, useSpectrogramIntegration } from './SpectrogramIntegrationContext';
+export type { SpectrogramIntegration } from './SpectrogramIntegrationContext';
 
 // Export waveform-data.js utilities
 export {

--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -54,6 +54,7 @@
     "fft.js": "^4.0.4"
   },
   "peerDependencies": {
+    "@waveform-playlist/browser": "workspace:*",
     "react": "^18.0.0",
     "styled-components": "^6.0.0"
   }

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -1,0 +1,640 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
+import type { SpectrogramData, SpectrogramConfig, SpectrogramComputeConfig, ColorMapValue, RenderMode, TrackSpectrogramOverrides } from '@waveform-playlist/core';
+import { computeSpectrogram, computeSpectrogramMono, getColorMap, getFrequencyScale } from './computation';
+import { createSpectrogramWorker, type SpectrogramWorkerApi } from './worker';
+import { SpectrogramMenuItems } from './components';
+import { SpectrogramSettingsModal } from './components';
+import { SpectrogramIntegrationProvider, type SpectrogramIntegration } from '@waveform-playlist/browser';
+import { usePlaylistData, usePlaylistControls } from '@waveform-playlist/browser';
+
+export interface SpectrogramProviderProps {
+  config?: SpectrogramConfig;
+  colorMap?: ColorMapValue;
+  children: ReactNode;
+}
+
+export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
+  config: spectrogramConfig,
+  colorMap: spectrogramColorMap,
+  children,
+}) => {
+  const {
+    tracks,
+    waveHeight,
+    samplesPerPixel,
+    isReady,
+    mono,
+    controls,
+  } = usePlaylistData();
+  const { scrollContainerRef } = usePlaylistControls();
+
+  // State
+  const [spectrogramDataMap, setSpectrogramDataMap] = useState<Map<string, SpectrogramData[]>>(new Map());
+  const [trackSpectrogramOverrides, setTrackSpectrogramOverrides] = useState<Map<string, TrackSpectrogramOverrides>>(new Map());
+
+  // OffscreenCanvas registry for worker-rendered spectrograms
+  const spectrogramCanvasRegistryRef = useRef<Map<string, Map<number, { canvasIds: string[]; canvasWidths: number[] }>>>(new Map());
+  const [spectrogramCanvasVersion, setSpectrogramCanvasVersion] = useState(0);
+
+  // Spectrogram refs
+  const prevSpectrogramConfigRef = useRef<Map<string, string>>(new Map());
+  const prevSpectrogramFFTKeyRef = useRef<Map<string, string>>(new Map());
+  const spectrogramWorkerRef = useRef<SpectrogramWorkerApi | null>(null);
+  const spectrogramGenerationRef = useRef(0);
+  const prevCanvasVersionRef = useRef(0);
+  const [spectrogramWorkerReady, setSpectrogramWorkerReady] = useState(false);
+  const clipCacheKeysRef = useRef<Map<string, string>>(new Map());
+  const backgroundRenderAbortRef = useRef<{ aborted: boolean } | null>(null);
+  const registeredAudioClipIdsRef = useRef<Set<string>>(new Set());
+
+  // Terminate worker on unmount
+  useEffect(() => {
+    return () => {
+      spectrogramWorkerRef.current?.terminate();
+      spectrogramWorkerRef.current = null;
+    };
+  }, []);
+
+  // Eagerly transfer audio data to worker when tracks load
+  useEffect(() => {
+    if (!isReady || tracks.length === 0) return;
+
+    let workerApi = spectrogramWorkerRef.current;
+    if (!workerApi) {
+      try {
+        const rawWorker = new Worker(
+          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
+          { type: 'module' }
+        );
+        workerApi = createSpectrogramWorker(rawWorker);
+        spectrogramWorkerRef.current = workerApi;
+        setSpectrogramWorkerReady(true);
+      } catch {
+        console.warn('Spectrogram Web Worker unavailable for pre-transfer');
+        return;
+      }
+    }
+
+    const currentClipIds = new Set<string>();
+
+    for (const track of tracks) {
+      for (const clip of track.clips) {
+        if (!clip.audioBuffer) continue;
+        currentClipIds.add(clip.id);
+
+        if (!registeredAudioClipIdsRef.current.has(clip.id)) {
+          const channelDataArrays: Float32Array[] = [];
+          for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
+            channelDataArrays.push(clip.audioBuffer.getChannelData(ch));
+          }
+          workerApi.registerAudioData(clip.id, channelDataArrays, clip.audioBuffer.sampleRate);
+          registeredAudioClipIdsRef.current.add(clip.id);
+        }
+      }
+    }
+
+    for (const clipId of registeredAudioClipIdsRef.current) {
+      if (!currentClipIds.has(clipId)) {
+        workerApi.unregisterAudioData(clipId);
+        registeredAudioClipIdsRef.current.delete(clipId);
+      }
+    }
+  }, [isReady, tracks]);
+
+  // Main spectrogram computation effect
+  useEffect(() => {
+    if (tracks.length === 0) return;
+
+    const currentKeys = new Map<string, string>();
+    const currentFFTKeys = new Map<string, string>();
+    tracks.forEach((track) => {
+      const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+      if (mode === 'waveform') return;
+      const cfg = trackSpectrogramOverrides.get(track.id)?.config ?? track.spectrogramConfig ?? spectrogramConfig;
+      const cm = trackSpectrogramOverrides.get(track.id)?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap;
+      currentKeys.set(track.id, JSON.stringify({ mode, cfg, cm, mono }));
+      const computeConfig: SpectrogramComputeConfig = {
+        fftSize: cfg?.fftSize, hopSize: cfg?.hopSize,
+        windowFunction: cfg?.windowFunction, alpha: cfg?.alpha,
+        zeroPaddingFactor: cfg?.zeroPaddingFactor,
+      };
+      currentFFTKeys.set(track.id, JSON.stringify({ mode, mono, ...computeConfig }));
+    });
+
+    const prevKeys = prevSpectrogramConfigRef.current;
+    const prevFFTKeys = prevSpectrogramFFTKeyRef.current;
+
+    let configChanged = currentKeys.size !== prevKeys.size;
+    if (!configChanged) {
+      for (const [idx, key] of currentKeys) {
+        if (prevKeys.get(idx) !== key) { configChanged = true; break; }
+      }
+    }
+
+    let fftKeyChanged = currentFFTKeys.size !== prevFFTKeys.size;
+    if (!fftKeyChanged) {
+      for (const [idx, key] of currentFFTKeys) {
+        if (prevFFTKeys.get(idx) !== key) { fftKeyChanged = true; break; }
+      }
+    }
+
+    const canvasVersionChanged = spectrogramCanvasVersion !== prevCanvasVersionRef.current;
+    prevCanvasVersionRef.current = spectrogramCanvasVersion;
+
+    if (!configChanged && !canvasVersionChanged) return;
+
+    if (configChanged) {
+      prevSpectrogramConfigRef.current = currentKeys;
+      prevSpectrogramFFTKeyRef.current = currentFFTKeys;
+    }
+
+    if (configChanged) {
+      setSpectrogramDataMap(prevMap => {
+        const activeClipIds = new Set<string>();
+        for (const track of tracks) {
+          const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+          if (mode === 'spectrogram' || mode === 'both') {
+            for (const clip of track.clips) {
+              activeClipIds.add(clip.id);
+            }
+          }
+        }
+        const newMap = new Map(prevMap);
+        for (const clipId of newMap.keys()) {
+          if (!activeClipIds.has(clipId)) {
+            newMap.delete(clipId);
+          }
+        }
+        return newMap;
+      });
+    }
+
+    if (backgroundRenderAbortRef.current) {
+      backgroundRenderAbortRef.current.aborted = true;
+    }
+
+    const generation = ++spectrogramGenerationRef.current;
+
+    let workerApi = spectrogramWorkerRef.current;
+    if (!workerApi) {
+      try {
+        const rawWorker = new Worker(
+          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
+          { type: 'module' }
+        );
+        workerApi = createSpectrogramWorker(rawWorker);
+        spectrogramWorkerRef.current = workerApi;
+        setSpectrogramWorkerReady(true);
+      } catch {
+        console.warn('Spectrogram Web Worker unavailable, falling back to synchronous computation');
+      }
+    }
+
+    const clipsNeedingFFT: Array<{
+      clipId: string;
+      trackIndex: number;
+      channelDataArrays: Float32Array[];
+      config: SpectrogramConfig;
+      sampleRate: number;
+      offsetSamples: number;
+      durationSamples: number;
+      clipStartSample: number;
+      monoFlag: boolean;
+      colorMap: ColorMapValue;
+    }> = [];
+    const clipsNeedingDisplayOnly: Array<{
+      clipId: string;
+      trackIndex: number;
+      config: SpectrogramConfig;
+      clipStartSample: number;
+      monoFlag: boolean;
+      colorMap: ColorMapValue;
+      numChannels: number;
+    }> = [];
+
+    tracks.forEach((track, i) => {
+      const mode = trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+      if (mode === 'waveform') return;
+
+      const trackConfigChanged = configChanged && (currentKeys.get(track.id) !== prevKeys.get(track.id));
+      const trackFFTChanged = fftKeyChanged && (currentFFTKeys.get(track.id) !== prevFFTKeys.get(track.id));
+      const hasRegisteredCanvases = canvasVersionChanged && track.clips.some(
+        clip => spectrogramCanvasRegistryRef.current.has(clip.id)
+      );
+      if (!trackConfigChanged && !hasRegisteredCanvases) return;
+
+      const cfg = trackSpectrogramOverrides.get(track.id)?.config ?? track.spectrogramConfig ?? spectrogramConfig ?? {};
+      const cm = trackSpectrogramOverrides.get(track.id)?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap ?? 'viridis';
+
+      for (const clip of track.clips) {
+        if (!clip.audioBuffer) continue;
+
+        const monoFlag = mono || clip.audioBuffer.numberOfChannels === 1;
+
+        if (!trackFFTChanged && !hasRegisteredCanvases && clipCacheKeysRef.current.has(clip.id)) {
+          clipsNeedingDisplayOnly.push({
+            clipId: clip.id,
+            trackIndex: i,
+            config: cfg,
+            clipStartSample: clip.startSample,
+            monoFlag,
+            colorMap: cm,
+            numChannels: monoFlag ? 1 : clip.audioBuffer.numberOfChannels,
+          });
+          continue;
+        }
+
+        const channelDataArrays: Float32Array[] = [];
+        for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
+          channelDataArrays.push(clip.audioBuffer.getChannelData(ch));
+        }
+
+        clipsNeedingFFT.push({
+          clipId: clip.id,
+          trackIndex: i,
+          channelDataArrays,
+          config: cfg,
+          sampleRate: clip.audioBuffer.sampleRate,
+          offsetSamples: clip.offsetSamples,
+          durationSamples: clip.durationSamples,
+          clipStartSample: clip.startSample,
+          monoFlag,
+          colorMap: cm,
+        });
+      }
+    });
+
+    if (clipsNeedingFFT.length === 0 && clipsNeedingDisplayOnly.length === 0) return;
+
+    if (!workerApi) {
+      setSpectrogramDataMap(prevMap => {
+        const newMap = new Map(prevMap);
+        for (const item of clipsNeedingFFT) {
+          const channelSpectrograms: SpectrogramData[] = [];
+          if (item.monoFlag) {
+            channelSpectrograms.push(
+              computeSpectrogramMono(
+                tracks.flatMap(t => t.clips).find(c => c.id === item.clipId)!.audioBuffer!,
+                item.config, item.offsetSamples, item.durationSamples
+              )
+            );
+          } else {
+            const clip = tracks.flatMap(t => t.clips).find(c => c.id === item.clipId)!;
+            for (let ch = 0; ch < clip.audioBuffer!.numberOfChannels; ch++) {
+              channelSpectrograms.push(
+                computeSpectrogram(clip.audioBuffer!, item.config, item.offsetSamples, item.durationSamples, ch)
+              );
+            }
+          }
+          newMap.set(item.clipId, channelSpectrograms);
+        }
+        return newMap;
+      });
+      return;
+    }
+
+    const getVisibleChunkRange = (canvasWidths: number[], clipPixelOffset = 0): { visibleIndices: number[]; remainingIndices: number[] } => {
+      const container = scrollContainerRef.current;
+      if (!container) {
+        return { visibleIndices: canvasWidths.map((_, i) => i), remainingIndices: [] };
+      }
+
+      const scrollLeft = container.scrollLeft;
+      const viewportWidth = container.clientWidth;
+      const controlWidth = controls.show ? controls.width : 0;
+
+      const visibleIndices: number[] = [];
+      const remainingIndices: number[] = [];
+      let offset = 0;
+
+      for (let i = 0; i < canvasWidths.length; i++) {
+        const chunkLeft = offset + controlWidth + clipPixelOffset;
+        const chunkRight = chunkLeft + canvasWidths[i];
+        if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
+          visibleIndices.push(i);
+        } else {
+          remainingIndices.push(i);
+        }
+        offset += canvasWidths[i];
+      }
+
+      return { visibleIndices, remainingIndices };
+    };
+
+    const renderChunkSubset = async (
+      api: SpectrogramWorkerApi,
+      cacheKey: string,
+      channelInfo: { canvasIds: string[]; canvasWidths: number[] },
+      indices: number[],
+      item: { config: SpectrogramConfig; colorMap: ColorMapValue },
+      channelIndex: number,
+    ) => {
+      if (indices.length === 0) return;
+
+      const canvasIds = indices.map(i => channelInfo.canvasIds[i]);
+      const canvasWidths = indices.map(i => channelInfo.canvasWidths[i]);
+
+      const globalPixelOffsets: number[] = [];
+      for (const idx of indices) {
+        let offset = 0;
+        for (let j = 0; j < idx; j++) {
+          offset += channelInfo.canvasWidths[j];
+        }
+        globalPixelOffsets.push(offset);
+      }
+
+      const colorLUT = getColorMap(item.colorMap);
+
+      await api.renderChunks({
+        cacheKey,
+        canvasIds,
+        canvasWidths,
+        globalPixelOffsets,
+        canvasHeight: waveHeight,
+        devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
+        samplesPerPixel,
+        colorLUT,
+        frequencyScale: item.config.frequencyScale ?? 'mel',
+        minFrequency: item.config.minFrequency ?? 0,
+        maxFrequency: item.config.maxFrequency ?? 0,
+        gainDb: item.config.gainDb ?? 20,
+        rangeDb: item.config.rangeDb ?? 80,
+        channelIndex,
+      });
+    };
+
+    const computeAsync = async () => {
+      const abortToken = { aborted: false };
+      backgroundRenderAbortRef.current = abortToken;
+
+      for (const item of clipsNeedingFFT) {
+        if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+        try {
+          const clipCanvasInfo = spectrogramCanvasRegistryRef.current.get(item.clipId);
+          if (clipCanvasInfo && clipCanvasInfo.size > 0) {
+            const numChannels = item.monoFlag ? 1 : item.channelDataArrays.length;
+            const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
+
+            const container = scrollContainerRef.current;
+            const windowSize = item.config.fftSize ?? 2048;
+            let visibleRange: { start: number; end: number } | undefined;
+
+            if (container) {
+              const scrollLeft = container.scrollLeft;
+              const viewportWidth = container.clientWidth;
+              const controlWidth = controls.show ? controls.width : 0;
+
+              const vpStartPx = Math.max(0, scrollLeft - controlWidth);
+              const vpEndPx = vpStartPx + viewportWidth;
+
+              const clipStartPx = clipPixelOffset;
+              const clipEndPx = clipStartPx + Math.ceil(item.durationSamples / samplesPerPixel);
+
+              const overlapStartPx = Math.max(vpStartPx, clipStartPx);
+              const overlapEndPx = Math.min(vpEndPx, clipEndPx);
+
+              if (overlapEndPx > overlapStartPx) {
+                const localStartPx = overlapStartPx - clipStartPx;
+                const localEndPx = overlapEndPx - clipStartPx;
+                const visStartSample = item.offsetSamples + Math.floor(localStartPx * samplesPerPixel);
+                const visEndSample = Math.min(
+                  item.offsetSamples + item.durationSamples,
+                  item.offsetSamples + Math.ceil(localEndPx * samplesPerPixel)
+                );
+                const paddedStart = Math.max(item.offsetSamples, visStartSample - windowSize);
+                const paddedEnd = Math.min(item.offsetSamples + item.durationSamples, visEndSample + windowSize);
+
+                if ((paddedEnd - paddedStart) < item.durationSamples * 0.8) {
+                  visibleRange = { start: paddedStart, end: paddedEnd };
+                }
+              }
+            }
+
+            const fullClipAlreadyCached = clipCacheKeysRef.current.has(item.clipId);
+            if (visibleRange && !fullClipAlreadyCached) {
+              const { cacheKey: visibleCacheKey } = await workerApi!.computeFFT({
+                clipId: item.clipId,
+                channelDataArrays: item.channelDataArrays,
+                config: item.config,
+                sampleRate: item.sampleRate,
+                offsetSamples: item.offsetSamples,
+                durationSamples: item.durationSamples,
+                mono: item.monoFlag,
+                sampleRange: visibleRange,
+              });
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+              for (let ch = 0; ch < numChannels; ch++) {
+                const channelInfo = clipCanvasInfo.get(ch);
+                if (!channelInfo) continue;
+
+                const { visibleIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
+                await renderChunkSubset(workerApi!, visibleCacheKey, channelInfo, visibleIndices, item, ch);
+              }
+
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+            }
+
+            const { cacheKey } = await workerApi!.computeFFT({
+              clipId: item.clipId,
+              channelDataArrays: item.channelDataArrays,
+              config: item.config,
+              sampleRate: item.sampleRate,
+              offsetSamples: item.offsetSamples,
+              durationSamples: item.durationSamples,
+              mono: item.monoFlag,
+            });
+
+            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+            clipCacheKeysRef.current.set(item.clipId, cacheKey);
+
+            for (let ch = 0; ch < numChannels; ch++) {
+              const channelInfo = clipCanvasInfo.get(ch);
+              if (!channelInfo) continue;
+
+              const { visibleIndices, remainingIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
+
+              await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
+
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+              const BATCH_SIZE = 4;
+              for (let batchStart = 0; batchStart < remainingIndices.length; batchStart += BATCH_SIZE) {
+                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+                const batch = remainingIndices.slice(batchStart, batchStart + BATCH_SIZE);
+
+                await new Promise<void>(resolve => {
+                  if (typeof requestIdleCallback === 'function') {
+                    requestIdleCallback(() => resolve());
+                  } else {
+                    setTimeout(resolve, 0);
+                  }
+                });
+
+                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+                await renderChunkSubset(workerApi!, cacheKey, channelInfo, batch, item, ch);
+              }
+            }
+          } else {
+            const spectrograms = await workerApi!.compute({
+              channelDataArrays: item.channelDataArrays,
+              config: item.config,
+              sampleRate: item.sampleRate,
+              offsetSamples: item.offsetSamples,
+              durationSamples: item.durationSamples,
+              mono: item.monoFlag,
+            });
+
+            if (spectrogramGenerationRef.current !== generation) return;
+
+            setSpectrogramDataMap(prevMap => {
+              const newMap = new Map(prevMap);
+              newMap.set(item.clipId, spectrograms);
+              return newMap;
+            });
+          }
+        } catch (err) {
+          console.warn('Spectrogram worker error for clip', item.clipId, err);
+        }
+      }
+
+      for (const item of clipsNeedingDisplayOnly) {
+        if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+        const cacheKey = clipCacheKeysRef.current.get(item.clipId);
+        if (!cacheKey) continue;
+
+        const clipCanvasInfo = spectrogramCanvasRegistryRef.current.get(item.clipId);
+        if (!clipCanvasInfo || clipCanvasInfo.size === 0) continue;
+
+        try {
+          const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
+          for (let ch = 0; ch < item.numChannels; ch++) {
+            const channelInfo = clipCanvasInfo.get(ch);
+            if (!channelInfo) continue;
+
+            const { visibleIndices, remainingIndices } = getVisibleChunkRange(channelInfo.canvasWidths, clipPixelOffset);
+
+            await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
+
+            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+            const BATCH_SIZE = 4;
+            for (let batchStart = 0; batchStart < remainingIndices.length; batchStart += BATCH_SIZE) {
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+              const batch = remainingIndices.slice(batchStart, batchStart + BATCH_SIZE);
+
+              await new Promise<void>(resolve => {
+                if (typeof requestIdleCallback === 'function') {
+                  requestIdleCallback(() => resolve());
+                } else {
+                  setTimeout(resolve, 0);
+                }
+              });
+
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+              await renderChunkSubset(workerApi!, cacheKey, channelInfo, batch, item, ch);
+            }
+          }
+        } catch (err) {
+          console.warn('Spectrogram display re-render error for clip', item.clipId, err);
+        }
+      }
+    };
+
+    computeAsync().catch(err => {
+      console.error('[waveform-playlist] Spectrogram computation failed:', err);
+    });
+  }, [tracks, mono, spectrogramConfig, spectrogramColorMap, trackSpectrogramOverrides, waveHeight, samplesPerPixel, spectrogramCanvasVersion, controls, scrollContainerRef]);
+
+  // Setters
+  const setTrackRenderMode = useCallback((trackId: string, mode: RenderMode) => {
+    setTrackSpectrogramOverrides(prev => {
+      const next = new Map(prev);
+      const existing = next.get(trackId);
+      next.set(trackId, { ...existing, renderMode: mode });
+      return next;
+    });
+  }, []);
+
+  const setTrackSpectrogramConfig = useCallback((trackId: string, config: SpectrogramConfig, colorMap?: ColorMapValue) => {
+    setTrackSpectrogramOverrides(prev => {
+      const next = new Map(prev);
+      const existing = next.get(trackId);
+      next.set(trackId, {
+        renderMode: existing?.renderMode ?? 'waveform',
+        config,
+        ...(colorMap !== undefined ? { colorMap } : { colorMap: existing?.colorMap }),
+      });
+      return next;
+    });
+  }, []);
+
+  const registerSpectrogramCanvases = useCallback((clipId: string, channelIndex: number, canvasIds: string[], canvasWidths: number[]) => {
+    const registry = spectrogramCanvasRegistryRef.current;
+    if (!registry.has(clipId)) {
+      registry.set(clipId, new Map());
+    }
+    registry.get(clipId)!.set(channelIndex, { canvasIds, canvasWidths });
+    setSpectrogramCanvasVersion(v => v + 1);
+  }, []);
+
+  const unregisterSpectrogramCanvases = useCallback((clipId: string, channelIndex: number) => {
+    const registry = spectrogramCanvasRegistryRef.current;
+    const clipChannels = registry.get(clipId);
+    if (clipChannels) {
+      clipChannels.delete(channelIndex);
+      if (clipChannels.size === 0) {
+        registry.delete(clipId);
+      }
+    }
+  }, []);
+
+  const renderMenuItems = useCallback((props: { renderMode: string; onRenderModeChange: (mode: RenderMode) => void; onOpenSettings: () => void; onClose?: () => void }) => {
+    return SpectrogramMenuItems({
+      renderMode: props.renderMode as RenderMode,
+      onRenderModeChange: props.onRenderModeChange,
+      onOpenSettings: props.onOpenSettings,
+      onClose: props.onClose,
+    });
+  }, []);
+
+  const value: SpectrogramIntegration = useMemo(() => ({
+    spectrogramDataMap,
+    trackSpectrogramOverrides,
+    spectrogramWorkerApi: spectrogramWorkerReady ? spectrogramWorkerRef.current : null,
+    spectrogramConfig,
+    spectrogramColorMap,
+    setTrackRenderMode,
+    setTrackSpectrogramConfig,
+    registerSpectrogramCanvases,
+    unregisterSpectrogramCanvases,
+    renderMenuItems,
+    SettingsModal: SpectrogramSettingsModal,
+    getColorMap,
+    getFrequencyScale: getFrequencyScale as (name: string) => (f: number, minF: number, maxF: number) => number,
+  }), [
+    spectrogramDataMap,
+    trackSpectrogramOverrides,
+    spectrogramWorkerReady,
+    spectrogramConfig,
+    spectrogramColorMap,
+    setTrackRenderMode,
+    setTrackSpectrogramConfig,
+    registerSpectrogramCanvases,
+    unregisterSpectrogramCanvases,
+    renderMenuItems,
+  ]);
+
+  return (
+    <SpectrogramIntegrationProvider value={value}>
+      {children}
+    </SpectrogramIntegrationProvider>
+  );
+};

--- a/packages/spectrogram/src/index.ts
+++ b/packages/spectrogram/src/index.ts
@@ -12,3 +12,7 @@ export type { TrackMenuItem } from './components';
 // Worker
 export { createSpectrogramWorker } from './worker';
 export type { SpectrogramWorkerApi, SpectrogramWorkerRenderParams } from './worker';
+
+// Provider
+export { SpectrogramProvider } from './SpectrogramProvider';
+export type { SpectrogramProviderProps } from './SpectrogramProvider';

--- a/packages/ui-components/src/components/TrackControls/CloseButton.tsx
+++ b/packages/ui-components/src/components/TrackControls/CloseButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import { X as XIcon } from '@phosphor-icons/react';
+
+const StyledCloseButton = styled.button`
+  position: absolute;
+  left: 0;
+  top: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity 0.15s, color 0.15s;
+
+  &:hover {
+    opacity: 1;
+    color: #dc3545;
+  }
+`;
+
+export interface CloseButtonProps {
+  onClick: (e: React.MouseEvent) => void;
+  title?: string;
+}
+
+export const CloseButton: React.FC<CloseButtonProps> = ({
+  onClick,
+  title = 'Remove track',
+}) => (
+  <StyledCloseButton onClick={onClick} title={title}>
+    <XIcon size={12} weight="bold" />
+  </StyledCloseButton>
+);

--- a/packages/ui-components/src/components/TrackControls/index.tsx
+++ b/packages/ui-components/src/components/TrackControls/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
+import { CloseButton } from './CloseButton';
 import { Controls } from './Controls';
 import { Header } from './Header';
 import { VolumeDownIcon } from './VolumeDownIcon';
@@ -12,6 +13,7 @@ import { SliderWrapper } from './SliderWrapper';
 export {
   Button,
   ButtonGroup,
+  CloseButton,
   Controls,
   Header,
   VolumeDownIcon,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       '@waveform-playlist/recording':
         specifier: workspace:*
         version: link:../recording
-      '@waveform-playlist/spectrogram':
-        specifier: workspace:*
-        version: link:../spectrogram
       '@waveform-playlist/ui-components':
         specifier: workspace:*
         version: link:../ui-components
@@ -224,6 +221,9 @@ importers:
 
   packages/spectrogram:
     dependencies:
+      '@waveform-playlist/browser':
+        specifier: workspace:*
+        version: link:../browser
       '@waveform-playlist/core':
         specifier: workspace:*
         version: link:../core

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -39,8 +39,6 @@ interface WaveformPlaylistProviderProps {
   barWidth?: number;                      // Default: 1
   barGap?: number;                        // Default: 0
   progressBarWidth?: number;              // Default: barWidth + barGap
-  spectrogramConfig?: SpectrogramConfig;  // Global spectrogram config
-  spectrogramColorMap?: ColorMapValue;    // Global color map. Default: 'viridis'
 }
 ```
 
@@ -569,6 +567,24 @@ All button/control components connect to context automatically. No props require
 
 ## Spectrogram (@waveform-playlist/spectrogram)
 
+Spectrogram is an **optional** package. Integrate via `SpectrogramProvider`:
+
+```typescript
+import { SpectrogramProvider } from '@waveform-playlist/spectrogram';
+
+<WaveformPlaylistProvider tracks={tracks}>
+  <SpectrogramProvider config={spectrogramConfig} colorMap="viridis">
+    <Waveform />
+  </SpectrogramProvider>
+</WaveformPlaylistProvider>
+
+interface SpectrogramProviderProps {
+  config?: SpectrogramConfig;
+  colorMap?: ColorMapValue;
+  children: ReactNode;
+}
+```
+
 ```typescript
 // From @waveform-playlist/core
 type FFTSize = 256 | 512 | 1024 | 2048 | 4096 | 8192;
@@ -625,9 +641,14 @@ interface SpectrogramWorkerApi {
 }
 
 // Key exports
+export { SpectrogramProvider } from '@waveform-playlist/spectrogram';
 export { computeSpectrogram, computeSpectrogramMono, getColorMap, getFrequencyScale } from '@waveform-playlist/spectrogram';
 export { createSpectrogramWorker } from '@waveform-playlist/spectrogram';
 export { SpectrogramMenuItems, SpectrogramSettingsModal } from '@waveform-playlist/spectrogram';
+
+// Integration context (from @waveform-playlist/browser)
+export { useSpectrogramIntegration, SpectrogramIntegrationProvider } from '@waveform-playlist/browser';
+export type { SpectrogramIntegration, SpectrogramWorkerApi } from '@waveform-playlist/browser';
 ```
 
 ---

--- a/website/src/components/examples/EffectsExample.tsx
+++ b/website/src/components/examples/EffectsExample.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { XIcon } from '@phosphor-icons/react';
+
 import JSZip from 'jszip';
 import { createTrack, createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
 import {
@@ -35,6 +35,7 @@ import {
   VolumeDownIcon,
   VolumeUpIcon,
   BaseControlButton,
+  CloseButton,
 } from '@waveform-playlist/ui-components';
 import { useDocusaurusTheme } from '../../hooks/useDocusaurusTheme';
 import { EffectRack, TrackEffectControls } from '../effects';
@@ -170,31 +171,6 @@ const HiddenFileInput = styled.input`
   display: none;
 `;
 
-const DeleteButton = styled.button`
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  background: var(--ifm-color-danger, #dc3545);
-  color: white;
-  border: none;
-  border-radius: 3px;
-  padding: 0;
-  width: 16px;
-  height: 16px;
-  font-size: 12px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.7;
-  transition: opacity 0.2s, background 0.2s;
-
-  &:hover {
-    opacity: 1;
-    background: var(--ifm-color-danger-dark, #c82333);
-  }
-`;
 
 const ControlsWrapper = styled.div`
   position: relative;
@@ -409,9 +385,7 @@ const CustomTrackControls: React.FC<CustomTrackControlsProps> = ({
 
   return (
     <ControlsWrapper>
-      <DeleteButton onClick={() => onDeleteTrack(trackIndex)} title="Delete track">
-        <XIcon size={10} weight="bold" />
-      </DeleteButton>
+      <CloseButton onClick={() => onDeleteTrack(trackIndex)} title="Delete track" />
       <Controls>
         <Header style={{ justifyContent: 'center' }}>
           {trackState.name || `Track ${trackIndex + 1}`}

--- a/website/src/components/examples/MirSpectrogramExample.tsx
+++ b/website/src/components/examples/MirSpectrogramExample.tsx
@@ -17,6 +17,7 @@ import {
 } from '@waveform-playlist/browser';
 import type { SpectrogramConfig, RenderMode, ClipTrack } from '@waveform-playlist/core';
 import { createTrack, createClipFromSeconds } from '@waveform-playlist/core';
+import { SpectrogramProvider } from '@waveform-playlist/spectrogram';
 import type { AudioTrackConfig } from '@waveform-playlist/browser';
 import { useDocusaurusTheme } from '../../hooks/useDocusaurusTheme';
 import { FolderOpenIcon, MusicNotesIcon } from '@phosphor-icons/react';
@@ -213,8 +214,8 @@ export function MirSpectrogramExample() {
           barGap={2}
           zoomLevels={[512, 1024, 2048, 4096, 8192, 16384, 32768]}
           controls={{ show: true, width: 180 }}
-          spectrogramColorMap="viridis"
         >
+          <SpectrogramProvider colorMap="viridis">
           <MirSpectrogramInner />
           <ControlBar>
             <RewindButton />
@@ -230,6 +231,7 @@ export function MirSpectrogramExample() {
             </ClearButton>
           </ControlBar>
           <Waveform onRemoveTrack={handleRemoveTrack} showClipHeaders />
+          </SpectrogramProvider>
         </WaveformPlaylistProvider>
       )}
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -26,7 +26,7 @@ waveform-playlist is a React component library for building browser-based audio 
 - `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
 - `@waveform-playlist/media-element-playout` — HTMLAudioElement playback with pitch-preserving speed control
-- `@waveform-playlist/spectrogram` — Spectrogram computation (FFT), worker-based rendering, color maps, frequency scales
+- `@waveform-playlist/spectrogram` — Optional spectrogram package: FFT computation, worker-based rendering, color maps, frequency scales. Integrates via `SpectrogramProvider` wrapper
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Introduce `SpectrogramIntegration` React context so `@waveform-playlist/spectrogram` is fully optional
- Move ~600 lines of spectrogram computation/state from browser into `SpectrogramProvider` in the spectrogram package
- Remove `@waveform-playlist/spectrogram` from browser's runtime dependencies (browser dist drops from bundling spectrogram code)
- Extract `CloseButton` into shared ui-components styled component

## Test plan
- [ ] `pnpm build` passes (browser dist: 269KB/67KB gzip, no spectrogram runtime code)
- [ ] `pnpm typecheck` passes across all packages
- [ ] `pnpm --filter website build` succeeds
- [ ] E2E tests: 171 passed (2 pre-existing flaky failures)
- [ ] MIR Spectrogram example works with `<SpectrogramProvider>` wrapper
- [ ] Non-spectrogram examples render without spectrogram menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)