### PR TITLE
Fix styled-components DOM warnings and class explosion

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -137,6 +137,21 @@ pnpm publish --filter @waveform-playlist/NEW-PACKAGE --no-git-checks --access pu
 
 - Use transient props (prefix with `$`) for props that shouldn't pass to DOM
 - Example: `$left`, `$width`, `$color`
+- **Use `.attrs()` for frequently changing props** — props that change on every render (positions, sizes, colors) must use `.attrs()` with a `style` object. Putting them in the template literal generates a new CSS class per render, causing "over 200 classes generated" warnings and memory bloat.
+  ```typescript
+  // ✅ GOOD - inline style via .attrs(), single CSS class reused
+  const Box = styled.div.attrs<{ $left: number }>((props) => ({
+    style: { left: `${props.$left}px` },
+  }))<{ $left: number }>`
+    position: absolute;
+  `;
+
+  // ❌ BAD - new CSS class generated on every render
+  const Box = styled.div<{ $left: number }>`
+    position: absolute;
+    left: ${(props) => props.$left}px;
+  `;
+  ```
 
 ### Building and Testing
 

--- a/packages/browser/src/components/AnimatedPlayhead.tsx
+++ b/packages/browser/src/components/AnimatedPlayhead.tsx
@@ -3,12 +3,15 @@ import styled from 'styled-components';
 import { getContext } from 'tone';
 import { usePlaybackAnimation, usePlaylistData } from '../WaveformPlaylistContext';
 
-const PlayheadLine = styled.div<{ $color: string; $width: number }>`
+const PlayheadLine = styled.div.attrs<{ $color: string; $width: number }>((props) => ({
+  style: {
+    width: `${props.$width}px`,
+    background: props.$color,
+  },
+}))<{ $color: string; $width: number }>`
   position: absolute;
   top: 0;
   left: 0;
-  width: ${(props) => props.$width}px;
-  background: ${(props) => props.$color};
   height: 100%;
   z-index: 100; /* Below sticky controls (z-index: 101) so playhead is hidden when scrolled behind controls */
   pointer-events: none;

--- a/packages/browser/src/components/ChannelWithProgress.tsx
+++ b/packages/browser/src/components/ChannelWithProgress.tsx
@@ -15,13 +15,16 @@ interface BackgroundProps {
   readonly $width: number;
 }
 
-const Background = styled.div<BackgroundProps>`
+const Background = styled.div.attrs<BackgroundProps>((props) => ({
+  style: {
+    top: `${props.$top}px`,
+    width: `${props.$width}px`,
+    height: `${props.$height}px`,
+    background: props.$color,
+  },
+}))<BackgroundProps>`
   position: absolute;
-  top: ${(props) => props.$top}px;
   left: 0;
-  width: ${(props) => props.$width}px;
-  height: ${(props) => props.$height}px;
-  background: ${(props) => props.$color};
   z-index: 0;
   /* Force GPU compositing layer to prevent gradient flickering during scroll */
   transform: translateZ(0);
@@ -35,12 +38,15 @@ interface ProgressOverlayProps {
   readonly $top: number;
 }
 
-const ProgressOverlay = styled.div<ProgressOverlayProps>`
+const ProgressOverlay = styled.div.attrs<ProgressOverlayProps>((props) => ({
+  style: {
+    top: `${props.$top}px`,
+    height: `${props.$height}px`,
+    background: props.$color,
+  },
+}))<ProgressOverlayProps>`
   position: absolute;
-  top: ${(props) => props.$top}px;
   left: 0;
-  height: ${(props) => props.$height}px;
-  background: ${(props) => props.$color};
   pointer-events: none;
   z-index: 1;
   will-change: width;

--- a/packages/browser/src/components/ZoomControls.tsx
+++ b/packages/browser/src/components/ZoomControls.tsx
@@ -7,7 +7,7 @@ export const ZoomInButton: React.FC<{ className?: string; disabled?: boolean }> 
   const { canZoomIn } = usePlaylistData();
 
   return (
-    <BaseControlButton variant="success" onClick={zoomIn} disabled={disabled || !canZoomIn} className={className}>
+    <BaseControlButton onClick={zoomIn} disabled={disabled || !canZoomIn} className={className}>
       Zoom In
     </BaseControlButton>
   );
@@ -18,7 +18,7 @@ export const ZoomOutButton: React.FC<{ className?: string; disabled?: boolean }>
   const { canZoomOut } = usePlaylistData();
 
   return (
-    <BaseControlButton variant="success" onClick={zoomOut} disabled={disabled || !canZoomOut} className={className}>
+    <BaseControlButton onClick={zoomOut} disabled={disabled || !canZoomOut} className={className}>
       Zoom Out
     </BaseControlButton>
   );

--- a/packages/ui-components/src/styled/BaseControlButton.tsx
+++ b/packages/ui-components/src/styled/BaseControlButton.tsx
@@ -1,18 +1,12 @@
 import styled from 'styled-components';
 
-export interface ControlButtonProps {
-  variant?: 'primary' | 'success' | 'info';
-}
-
 /**
- * ControlButton - A colored action button (primary/success/info variants)
- *
- * This is used for prominent actions like Play, Pause, Record.
+ * ControlButton - A colored action button for prominent actions like Play, Pause, Record.
  * For neutral buttons, use BaseButton from the styled primitives.
  *
  * Uses theme colors when available, with fallbacks for standalone use.
  */
-export const BaseControlButton = styled.button<ControlButtonProps>`
+export const BaseControlButton = styled.button`
   padding: 0.5rem 1rem;
   background: ${(props) => props.theme.buttonBackground || '#007bff'};
   color: ${(props) => props.theme.buttonText || 'white'};


### PR DESCRIPTION
## Summary
- Remove unused `variant` prop from `BaseControlButton` — was being forwarded to the DOM, triggering React warnings
- Convert `PlayheadLine`, `Background`, and `ProgressOverlay` to use `.attrs()` for frequently changing props — fixes "over 200 classes generated" warnings
- Document `.attrs()` pattern in CLAUDE.md

## Test plan
- [ ] Recording example no longer shows "unknown prop variant" warning
- [ ] No "over 200 classes generated" warnings during playback
- [ ] Playhead and progress overlay render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)