### PR TITLE
Eliminate all any types across packages

### DIFF
--- a/packages/browser/src/AnnotationIntegrationContext.tsx
+++ b/packages/browser/src/AnnotationIntegrationContext.tsx
@@ -1,5 +1,54 @@
 import { createContext, useContext } from 'react';
-import type { AnnotationData } from '@waveform-playlist/core';
+import type {
+  AnnotationData,
+  AnnotationAction,
+  AnnotationActionOptions,
+  RenderAnnotationItemProps,
+} from '@waveform-playlist/core';
+
+/**
+ * Props the browser package passes to the AnnotationText component.
+ * Mirrors what PlaylistAnnotationList and MediaElementAnnotationList actually use.
+ */
+export interface AnnotationTextIntegrationProps {
+  annotations: AnnotationData[];
+  activeAnnotationId?: string;
+  shouldScrollToActive?: boolean;
+  scrollActivePosition?: ScrollLogicalPosition;
+  scrollActiveContainer?: 'nearest' | 'all';
+  editable?: boolean;
+  controls?: AnnotationAction[];
+  annotationListConfig?: AnnotationActionOptions;
+  height?: number;
+  onAnnotationUpdate?: (updatedAnnotations: AnnotationData[]) => void;
+  renderAnnotationItem?: (props: RenderAnnotationItemProps) => React.ReactNode;
+}
+
+/**
+ * Props the browser package passes to the AnnotationBox component.
+ * Mirrors what PlaylistVisualization and MediaElementPlaylist actually use.
+ */
+export interface AnnotationBoxIntegrationProps {
+  annotationId: string;
+  annotationIndex: number;
+  startPosition: number;
+  endPosition: number;
+  label?: string;
+  color?: string;
+  isActive?: boolean;
+  onClick?: () => void;
+  editable?: boolean;
+}
+
+/**
+ * Props the browser package passes to the AnnotationBoxesWrapper component.
+ * Mirrors what PlaylistVisualization and MediaElementPlaylist actually use.
+ */
+export interface AnnotationBoxesWrapperIntegrationProps {
+  children?: React.ReactNode;
+  height?: number;
+  width?: number;
+}
 
 /**
  * Interface for annotation integration provided by @waveform-playlist/annotations.
@@ -12,13 +61,10 @@ export interface AnnotationIntegration {
   parseAeneas: (data: unknown) => AnnotationData;
   serializeAeneas: (annotation: AnnotationData) => unknown;
 
-  // Visualization components (typed loosely since browser controls invocation)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AnnotationText: React.ComponentType<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AnnotationBox: React.ComponentType<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AnnotationBoxesWrapper: React.ComponentType<any>;
+  // Visualization components (typed with the props the browser package actually passes)
+  AnnotationText: React.ComponentType<AnnotationTextIntegrationProps>;
+  AnnotationBox: React.ComponentType<AnnotationBoxIntegrationProps>;
+  AnnotationBoxesWrapper: React.ComponentType<AnnotationBoxesWrapperIntegrationProps>;
 
   // Control components
   ContinuousPlayCheckbox: React.ComponentType<{ checked: boolean; onChange: (checked: boolean) => void; className?: string }>;

--- a/packages/browser/src/MediaElementPlaylistContext.tsx
+++ b/packages/browser/src/MediaElementPlaylistContext.tsx
@@ -20,6 +20,7 @@ import {
 } from '@waveform-playlist/ui-components';
 import type { AnnotationData } from '@waveform-playlist/core';
 import { extractPeaksFromWaveformData } from './waveformDataLoader';
+import type WaveformData from 'waveform-data';
 import type { PeakData } from '@waveform-playlist/webaudio-peaks';
 import type { ClipPeaks, TrackClipPeaks } from './WaveformPlaylistContext';
 
@@ -108,7 +109,7 @@ export interface MediaElementPlaylistProviderProps {
   controls?: { show: boolean; width: number };
   /** Annotations */
   annotationList?: {
-    annotations?: any[];
+    annotations?: AnnotationData[];
     isContinuousPlay?: boolean;
   };
   /** Width of waveform bars */
@@ -172,7 +173,7 @@ export const MediaElementPlaylistProvider: React.FC<
   const annotations = useMemo(() => {
     if (!annotationList?.annotations) return [];
     if (process.env.NODE_ENV !== 'production' && annotationList.annotations.length > 0) {
-      const first = annotationList.annotations[0] as Record<string, unknown>;
+      const first = annotationList.annotations[0] as unknown as Record<string, unknown>;
       if (typeof first.start !== 'number' || typeof first.end !== 'number') {
         console.error(
           '[waveform-playlist] Annotations must have numeric start/end values. ' +
@@ -182,7 +183,7 @@ export const MediaElementPlaylistProvider: React.FC<
         return [];
       }
     }
-    return annotationList.annotations as AnnotationData[];
+    return annotationList.annotations;
   }, [annotationList?.annotations]);
 
   // Ref for animation loop (avoids restarting loop on annotation change)
@@ -283,7 +284,7 @@ export const MediaElementPlaylistProvider: React.FC<
   // Generate peaks from waveform data
   useEffect(() => {
     const extractedPeaks = extractPeaksFromWaveformData(
-      track.waveformData as any,
+      track.waveformData as WaveformData,
       samplesPerPixel,
       0, // channel index
       0, // offset

--- a/packages/browser/src/components/ContextualControls.tsx
+++ b/packages/browser/src/components/ContextualControls.tsx
@@ -6,7 +6,6 @@ import {
   AutomaticScrollCheckbox as BaseAutomaticScrollCheckbox,
   SelectionTimeInputs as BaseSelectionTimeInputs,
   formatTime,
-  type TimeFormat,
 } from '@waveform-playlist/ui-components';
 import styled from 'styled-components';
 import { usePlaybackAnimation, usePlaylistState, usePlaylistControls, usePlaylistData } from '../WaveformPlaylistContext';
@@ -36,8 +35,8 @@ export const TimeFormatSelect: React.FC<{ className?: string }> = ({ className }
 
   return (
     <BaseTimeFormatSelect
-      value={timeFormat as any}
-      onChange={setTimeFormat as any}
+      value={timeFormat}
+      onChange={setTimeFormat}
       className={className}
     />
   );
@@ -60,8 +59,7 @@ export const AudioPosition: React.FC<{ className?: string }> = ({ className }) =
   const timeRef = useRef<HTMLSpanElement>(null);
   const animationFrameRef = useRef<number | null>(null);
   const { isPlaying, currentTimeRef, playbackStartTimeRef, audioStartPositionRef } = usePlaybackAnimation();
-  const { timeFormat } = usePlaylistData();
-  const format = timeFormat as TimeFormat;
+  const { timeFormat: format } = usePlaylistData();
 
   useEffect(() => {
     const updateTime = () => {

--- a/packages/browser/src/effects/effectFactory.ts
+++ b/packages/browser/src/effects/effectFactory.ts
@@ -44,28 +44,33 @@ export interface EffectInstance {
 // permissive constructor signature to unify them in a single lookup map.
 type EffectConstructor = new (options?: Record<string, number | string | boolean>) => ToneAudioNode;
 
+/** Centralizes the single unavoidable cast from a specific Tone.js effect constructor to EffectConstructor. */
+function asEffectConstructor(ctor: new (...args: never[]) => ToneAudioNode): EffectConstructor {
+  return ctor as unknown as EffectConstructor;
+}
+
 // Map of effect IDs to their Tone.js constructors
 const effectConstructors: Record<string, EffectConstructor> = {
-  reverb: Reverb as unknown as EffectConstructor,
-  freeverb: Freeverb as unknown as EffectConstructor,
-  jcReverb: JCReverb as unknown as EffectConstructor,
-  feedbackDelay: FeedbackDelay as unknown as EffectConstructor,
-  pingPongDelay: PingPongDelay as unknown as EffectConstructor,
-  chorus: Chorus as unknown as EffectConstructor,
-  phaser: Phaser as unknown as EffectConstructor,
-  tremolo: Tremolo as unknown as EffectConstructor,
-  vibrato: Vibrato as unknown as EffectConstructor,
-  autoPanner: AutoPanner as unknown as EffectConstructor,
-  autoFilter: AutoFilter as unknown as EffectConstructor,
-  autoWah: AutoWah as unknown as EffectConstructor,
-  eq3: EQ3 as unknown as EffectConstructor,
-  distortion: Distortion as unknown as EffectConstructor,
-  bitCrusher: BitCrusher as unknown as EffectConstructor,
-  chebyshev: Chebyshev as unknown as EffectConstructor,
-  compressor: Compressor as unknown as EffectConstructor,
-  limiter: Limiter as unknown as EffectConstructor,
-  gate: Gate as unknown as EffectConstructor,
-  stereoWidener: StereoWidener as unknown as EffectConstructor,
+  reverb: asEffectConstructor(Reverb),
+  freeverb: asEffectConstructor(Freeverb),
+  jcReverb: asEffectConstructor(JCReverb),
+  feedbackDelay: asEffectConstructor(FeedbackDelay),
+  pingPongDelay: asEffectConstructor(PingPongDelay),
+  chorus: asEffectConstructor(Chorus),
+  phaser: asEffectConstructor(Phaser),
+  tremolo: asEffectConstructor(Tremolo),
+  vibrato: asEffectConstructor(Vibrato),
+  autoPanner: asEffectConstructor(AutoPanner),
+  autoFilter: asEffectConstructor(AutoFilter),
+  autoWah: asEffectConstructor(AutoWah),
+  eq3: asEffectConstructor(EQ3),
+  distortion: asEffectConstructor(Distortion),
+  bitCrusher: asEffectConstructor(BitCrusher),
+  chebyshev: asEffectConstructor(Chebyshev),
+  compressor: asEffectConstructor(Compressor),
+  limiter: asEffectConstructor(Limiter),
+  gate: asEffectConstructor(Gate),
+  stereoWidener: asEffectConstructor(StereoWidener),
 };
 
 // Generate unique instance ID
@@ -112,7 +117,7 @@ export function createEffectInstance(
         effect.disconnect();
         effect.dispose();
       } catch (e) {
-        // Ignore errors during cleanup
+        console.warn(`[waveform-playlist] Error disposing effect "${definition.id}" (${instanceId}):`, e);
       }
     },
 
@@ -161,7 +166,7 @@ export function createEffectInstance(
       try {
         effect.disconnect();
       } catch (e) {
-        // Ignore disconnect errors
+        console.warn(`[waveform-playlist] Error disconnecting effect "${definition.id}" (${instanceId}):`, e);
       }
     },
   };

--- a/packages/browser/src/hooks/useAnnotationDragHandlers.ts
+++ b/packages/browser/src/hooks/useAnnotationDragHandlers.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { DragStartEvent, DragMoveEvent } from '@dnd-kit/core';
 import type { AnnotationData } from '@waveform-playlist/core';
 
 const LINK_THRESHOLD = 0.01; // Consider edges "linked" if within 10ms
@@ -57,7 +58,7 @@ export function useAnnotationDragHandlers({
   } | null>(null);
 
   const onDragStart = React.useCallback(
-    (event: { active: any }) => {
+    (event: DragStartEvent) => {
       const { active } = event;
       const data = active.data.current as {
         annotationId: string;
@@ -83,7 +84,7 @@ export function useAnnotationDragHandlers({
   );
 
   const onDragMove = React.useCallback(
-    (event: { active: any; delta: { x: number; y: number } }) => {
+    (event: DragMoveEvent) => {
       const { active, delta } = event;
 
       if (!originalAnnotationStateRef.current) {

--- a/packages/browser/src/hooks/useAudioEffects.ts
+++ b/packages/browser/src/hooks/useAudioEffects.ts
@@ -10,7 +10,7 @@ import { Analyser } from 'tone';
  * For more advanced effects (reverb, delay, filters, etc.), use useDynamicEffects instead.
  */
 export const useMasterAnalyser = (fftSize: number = 256) => {
-  const analyserRef = useRef<any>(null);
+  const analyserRef = useRef<Analyser | null>(null);
 
   const masterEffects: EffectsFunction = useCallback((masterGainNode, destination, _isOffline) => {
     // Create analyser and connect it in parallel to monitor the output

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { DragEndEvent } from '@dnd-kit/core';
+import type { DragEndEvent, DragStartEvent, DragMoveEvent, Modifier } from '@dnd-kit/core';
 import type { ClipTrack } from '@waveform-playlist/core';
 
 interface UseClipDragHandlersOptions {
@@ -51,7 +51,7 @@ export function useClipDragHandlers({
 
   // Custom modifier for real-time collision detection during clip movement
   const collisionModifier = React.useCallback(
-    (args: { transform: { x: number; y: number }; active: any }) => {
+    (args: Parameters<Modifier>[0]) => {
       const { transform, active } = args;
 
       if (!active?.data?.current) return { ...transform, scaleX: 1, scaleY: 1 };
@@ -123,7 +123,7 @@ export function useClipDragHandlers({
   );
 
   const onDragStart = React.useCallback(
-    (event: { active: any }) => {
+    (event: DragStartEvent) => {
       const { active } = event;
       const { boundary } = active.data.current as { boundary?: 'left' | 'right' };
 
@@ -156,7 +156,7 @@ export function useClipDragHandlers({
   );
 
   const onDragMove = React.useCallback(
-    (event: { active: any; delta: { x: number; y: number } }) => {
+    (event: DragMoveEvent) => {
       const { active, delta } = event;
 
       // Only update for boundary trimming operations (not clip movement)

--- a/packages/browser/src/hooks/useDynamicEffects.ts
+++ b/packages/browser/src/hooks/useDynamicEffects.ts
@@ -9,7 +9,7 @@ import {
   createEffectInstance,
   type EffectInstance,
 } from '../effects/effectFactory';
-import { Analyser } from 'tone';
+import { Analyser, Volume, ToneAudioNode } from 'tone';
 
 export interface ActiveEffect {
   instanceId: string;
@@ -42,7 +42,7 @@ export interface UseDynamicEffectsReturn {
   createOfflineEffectsFunction: () => EffectsFunction | undefined;
 
   // Analyser for visualization
-  analyserRef: React.RefObject<any>;
+  analyserRef: React.RefObject<Analyser | null>;
 }
 
 /**
@@ -60,13 +60,13 @@ export function useDynamicEffects(fftSize: number = 256): UseDynamicEffectsRetur
   const effectInstancesRef = useRef<Map<string, EffectInstance>>(new Map());
 
   // Analyser for visualization
-  const analyserRef = useRef<any>(null);
+  const analyserRef = useRef<Analyser | null>(null);
 
   // Reference to the current audio graph nodes
   const graphNodesRef = useRef<{
-    masterGainNode: any;
-    destination: any;
-    analyserNode: any;
+    masterGainNode: Volume;
+    destination: ToneAudioNode;
+    analyserNode: Analyser;
   } | null>(null);
 
   // Rebuild the effect chain when effects change
@@ -95,7 +95,7 @@ export function useDynamicEffects(fftSize: number = 256): UseDynamicEffectsRetur
       analyserNode.connect(destination);
     } else {
       // Connect: masterGain -> effect1 -> effect2 -> ... -> analyser -> destination
-      let currentNode: any = masterGainNode;
+      let currentNode: ToneAudioNode = masterGainNode;
 
       instances.forEach((inst) => {
         try {
@@ -254,7 +254,7 @@ export function useDynamicEffects(fftSize: number = 256): UseDynamicEffectsRetur
         analyserNode.connect(destination);
       } else {
         // Connect: masterGain -> effect1 -> effect2 -> ... -> analyser -> destination
-        let currentNode: any = masterGainNode;
+        let currentNode: ToneAudioNode = masterGainNode;
 
         instances.forEach((inst) => {
           currentNode.connect(inst.effect);
@@ -297,7 +297,7 @@ export function useDynamicEffects(fftSize: number = 256): UseDynamicEffectsRetur
     }
 
     // Return a function that creates fresh effect instances
-    return (masterGainNode: any, destination: any, _isOffline: boolean) => {
+    return (masterGainNode: Volume, destination: ToneAudioNode, _isOffline: boolean) => {
       // Create fresh effect instances for offline context
       const offlineInstances: EffectInstance[] = [];
 
@@ -311,7 +311,7 @@ export function useDynamicEffects(fftSize: number = 256): UseDynamicEffectsRetur
         masterGainNode.connect(destination);
       } else {
         // Connect: masterGain -> effect1 -> effect2 -> ... -> destination
-        let currentNode: any = masterGainNode;
+        let currentNode: ToneAudioNode = masterGainNode;
 
         offlineInstances.forEach((inst) => {
           currentNode.connect(inst.effect);

--- a/packages/browser/src/hooks/useExportWav.ts
+++ b/packages/browser/src/hooks/useExportWav.ts
@@ -1,18 +1,10 @@
 import { useState, useCallback } from 'react';
 import type { ClipTrack, AudioClip, FadeType } from '@waveform-playlist/core';
-import type { EffectsFunction } from '@waveform-playlist/playout';
+import { type EffectsFunction, getUnderlyingAudioParam } from '@waveform-playlist/playout';
 import { encodeWav, downloadBlob, type WavEncoderOptions } from '../utils/wavEncoder';
 
 /** Function type for per-track effects (same as in @waveform-playlist/core) */
 export type TrackEffectsFunction = (graphEnd: unknown, destination: unknown, isOffline: boolean) => void | (() => void);
-
-/**
- * Access the underlying Web Audio AudioParam from a Tone.js Signal/Param wrapper.
- * Tone.js wraps native AudioParam via its Signal class; `_param` is a private Tone.js 15.x internal.
- */
-function getUnderlyingAudioParam(signal: unknown): AudioParam | undefined {
-  return (signal as { _param?: AudioParam })._param;
-}
 
 export interface ExportOptions extends WavEncoderOptions {
   /** Filename for download (without extension) */

--- a/packages/browser/src/hooks/useTrackDynamicEffects.ts
+++ b/packages/browser/src/hooks/useTrackDynamicEffects.ts
@@ -9,6 +9,7 @@ import {
   createEffectInstance,
   type EffectInstance,
 } from '../effects/effectFactory';
+import { Gain, ToneAudioNode } from 'tone';
 
 export interface TrackActiveEffect {
   instanceId: string;
@@ -67,8 +68,8 @@ export function useTrackDynamicEffects(): UseTrackDynamicEffectsReturn {
     Map<
       string,
       {
-        graphEnd: any;
-        masterGainNode: any;
+        graphEnd: Gain;
+        masterGainNode: ToneAudioNode;
       }
     >
   >(new Map());
@@ -99,7 +100,7 @@ export function useTrackDynamicEffects(): UseTrackDynamicEffectsReturn {
       graphEnd.connect(masterGainNode);
     } else {
       // Connect: graphEnd -> effect1 -> effect2 -> ... -> masterGainNode
-      let currentNode: any = graphEnd;
+      let currentNode: ToneAudioNode = graphEnd;
 
       instances.forEach((inst) => {
         try {
@@ -284,7 +285,7 @@ export function useTrackDynamicEffects(): UseTrackDynamicEffectsReturn {
           graphEnd.connect(masterGainNode);
         } else {
           // Connect: graphEnd -> effect1 -> effect2 -> ... -> masterGainNode
-          let currentNode: any = graphEnd;
+          let currentNode: ToneAudioNode = graphEnd;
 
           instances.forEach((inst) => {
             currentNode.connect(inst.effect);
@@ -337,7 +338,7 @@ export function useTrackDynamicEffects(): UseTrackDynamicEffectsReturn {
       }
 
       // Return a function that creates fresh effect instances
-      return (graphEnd: any, masterGainNode: any, _isOffline: boolean) => {
+      return (graphEnd: Gain, masterGainNode: ToneAudioNode, _isOffline: boolean) => {
         // Create fresh effect instances for offline context
         const offlineInstances: EffectInstance[] = [];
 
@@ -351,7 +352,7 @@ export function useTrackDynamicEffects(): UseTrackDynamicEffectsReturn {
           graphEnd.connect(masterGainNode);
         } else {
           // Connect: graphEnd -> effect1 -> effect2 -> ... -> masterGainNode
-          let currentNode: any = graphEnd;
+          let currentNode: ToneAudioNode = graphEnd;
 
           offlineInstances.forEach((inst) => {
             currentNode.connect(inst.effect);

--- a/packages/media-element-playout/src/MediaElementTrack.ts
+++ b/packages/media-element-playout/src/MediaElementTrack.ts
@@ -1,5 +1,15 @@
 import type { WaveformDataObject } from '@waveform-playlist/core';
 
+/**
+ * Extended HTMLAudioElement with vendor-prefixed preservesPitch properties.
+ * `preservesPitch` is standard; the `moz` and `webkit` prefixes are for older browsers.
+ */
+interface VendorPrefixedPitch {
+  preservesPitch?: boolean;
+  mozPreservesPitch?: boolean;
+  webkitPreservesPitch?: boolean;
+}
+
 export interface MediaElementTrackOptions {
   /** The audio source - can be a URL, Blob URL, or HTMLAudioElement */
   source: string | HTMLAudioElement;
@@ -60,14 +70,16 @@ export class MediaElementTrack {
 
     // Preserve pitch when changing playback rate (default in modern browsers)
     // Some older browsers may not support this, but it's the default behavior
+    // Vendor-prefixed properties are non-standard; cast once for type safety.
+    const audio = this.audioElement as unknown as VendorPrefixedPitch;
     if ('preservesPitch' in this.audioElement) {
-      (this.audioElement as any).preservesPitch = true;
+      audio.preservesPitch = true;
     } else if ('mozPreservesPitch' in this.audioElement) {
       // Firefox prefix
-      (this.audioElement as any).mozPreservesPitch = true;
+      audio.mozPreservesPitch = true;
     } else if ('webkitPreservesPitch' in this.audioElement) {
       // Safari prefix
-      (this.audioElement as any).webkitPreservesPitch = true;
+      audio.webkitPreservesPitch = true;
     }
 
     // Set up event listeners

--- a/packages/media-element-playout/src/types.ts
+++ b/packages/media-element-playout/src/types.ts
@@ -44,5 +44,5 @@ export interface PlaybackRateEngine extends PlayoutEngine {
  * Type guard to check if an engine supports playback rate.
  */
 export function supportsPlaybackRate(engine: PlayoutEngine): engine is PlaybackRateEngine {
-  return 'setPlaybackRate' in engine && typeof (engine as any).setPlaybackRate === 'function';
+  return 'setPlaybackRate' in engine && typeof (engine as Record<string, unknown>).setPlaybackRate === 'function';
 }

--- a/packages/playout/src/ToneTrack.ts
+++ b/packages/playout/src/ToneTrack.ts
@@ -9,7 +9,7 @@ import {
   now,
 } from 'tone';
 import { Track, type Fade } from '@waveform-playlist/core';
-import { applyFadeIn, applyFadeOut } from './fades';
+import { applyFadeIn, applyFadeOut, getUnderlyingAudioParam } from './fades';
 
 // Effects function no longer receives ToneLib - effects should import Tone themselves
 export type TrackEffectsFunction = (graphEnd: Gain, masterGainNode: ToneAudioNode, isOffline: boolean) => void | (() => void);
@@ -117,7 +117,8 @@ export class ToneTrack {
    */
   private scheduleFades(clipPlayer: ClipPlayer, clipStartTime: number, clipOffset: number = 0): void {
     const { clipInfo, fadeGain } = clipPlayer;
-    const audioParam = (fadeGain.gain as any)._param as AudioParam;
+    const audioParam = getUnderlyingAudioParam(fadeGain.gain);
+    if (!audioParam) return;
 
     // Cancel any previous automation
     audioParam.cancelScheduledValues(0);
@@ -215,8 +216,8 @@ export class ToneTrack {
     // Signal wrapper doesn't propagate to the underlying AudioParam until the
     // context resumes, causing a brief audio glitch (e.g., all tracks audible
     // before solo muting takes effect).
-    const audioParam = (this.muteGain.gain as any)._param as AudioParam;
-    audioParam.setValueAtTime(value, 0);
+    const audioParam = getUnderlyingAudioParam(this.muteGain.gain);
+    audioParam?.setValueAtTime(value, 0);
     this.muteGain.gain.value = value;
   }
 

--- a/packages/playout/src/fades.ts
+++ b/packages/playout/src/fades.ts
@@ -18,8 +18,19 @@
  * @param signal - A Tone.js Signal or Param wrapper (e.g., `gain.gain`)
  * @returns The underlying AudioParam, or undefined if not found
  */
+let hasWarned = false;
+
 export function getUnderlyingAudioParam(signal: unknown): AudioParam | undefined {
-  return (signal as { _param?: AudioParam })._param;
+  const param = (signal as { _param?: AudioParam })._param;
+  if (!param && !hasWarned) {
+    hasWarned = true;
+    console.warn(
+      '[waveform-playlist] Unable to access Tone.js internal _param. ' +
+      'This likely means the Tone.js version is incompatible. ' +
+      'Fades and mute scheduling may not work correctly.'
+    );
+  }
+  return param;
 }
 
 export type FadeType = 'linear' | 'logarithmic' | 'exponential' | 'sCurve';

--- a/packages/playout/src/fades.ts
+++ b/packages/playout/src/fades.ts
@@ -5,6 +5,23 @@
  * using various curve types.
  */
 
+/**
+ * Access the underlying Web Audio AudioParam from a Tone.js Signal/Param wrapper.
+ *
+ * Tone.js wraps native AudioParam in its Signal class, but sometimes we need
+ * direct access to the raw AudioParam for setValueAtTime/cancelScheduledValues
+ * (e.g., when the AudioContext is suspended and Tone.js Signal doesn't propagate).
+ *
+ * This uses `_param` which is a private Tone.js 15.x internal.
+ * Pin the Tone.js version carefully if upgrading.
+ *
+ * @param signal - A Tone.js Signal or Param wrapper (e.g., `gain.gain`)
+ * @returns The underlying AudioParam, or undefined if not found
+ */
+export function getUnderlyingAudioParam(signal: unknown): AudioParam | undefined {
+  return (signal as { _param?: AudioParam })._param;
+}
+
 export type FadeType = 'linear' | 'logarithmic' | 'exponential' | 'sCurve';
 
 /**

--- a/packages/playout/src/index.ts
+++ b/packages/playout/src/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   applyFadeIn,
   applyFadeOut,
+  getUnderlyingAudioParam,
   type FadeConfig,
   type FadeType,
 } from './fades';

--- a/packages/spectrogram/src/computation/fft.ts
+++ b/packages/spectrogram/src/computation/fft.ts
@@ -3,10 +3,10 @@ import FFT from 'fft.js';
 /**
  * Cache fft.js instances per size (pre-computes twiddle factors).
  */
-const fftInstances = new Map<number, any>();
-const complexBuffers = new Map<number, any>();
+const fftInstances = new Map<number, FFT>();
+const complexBuffers = new Map<number, number[]>();
 
-function getFftInstance(size: number): any {
+function getFftInstance(size: number): FFT {
   let instance = fftInstances.get(size);
   if (!instance) {
     instance = new FFT(size);
@@ -16,8 +16,12 @@ function getFftInstance(size: number): any {
   return instance;
 }
 
-function getComplexBuffer(size: number): any {
-  return complexBuffers.get(size);
+function getComplexBuffer(size: number): number[] {
+  const buffer = complexBuffers.get(size);
+  if (!buffer) {
+    throw new Error(`No complex buffer for size ${size}. Call getFftInstance first.`);
+  }
+  return buffer;
 }
 
 /**

--- a/packages/spectrogram/src/types/fft.js.d.ts
+++ b/packages/spectrogram/src/types/fft.js.d.ts
@@ -1,0 +1,35 @@
+declare module 'fft.js' {
+  /**
+   * Radix-4 FFT implementation.
+   * Complex arrays are interleaved [re0, im0, re1, im1, ...].
+   */
+  class FFT {
+    constructor(size: number);
+
+    readonly size: number;
+    readonly table: number[];
+
+    /** Create a zero-filled interleaved complex array of length `2 * size`. */
+    createComplexArray(): number[];
+
+    /** Extract real parts from an interleaved complex array. */
+    fromComplexArray(complex: number[], storage?: number[]): number[];
+
+    /** Convert a real array to interleaved complex format (imaginary parts set to 0). */
+    toComplexArray(input: number[], storage?: number[]): number[];
+
+    /** Mirror positive frequencies to complete the spectrum (in-place). */
+    completeSpectrum(spectrum: number[]): void;
+
+    /** Forward FFT on interleaved complex data. `out` and `data` must be different arrays. */
+    transform(out: number[], data: number[]): void;
+
+    /** Forward FFT optimised for real-valued input. `out` and `data` must be different arrays. */
+    realTransform(out: number[], data: number[] | Float32Array): void;
+
+    /** Inverse FFT on interleaved complex data. `out` and `data` must be different arrays. */
+    inverseTransform(out: number[], data: number[]): void;
+  }
+
+  export default FFT;
+}

--- a/packages/spectrogram/src/worker/createSpectrogramWorker.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorker.ts
@@ -57,6 +57,14 @@ type ComputeResponse =
   | { id: string; type: 'done' }
   | { id: string; type: 'error'; error: string };
 
+/** Union of all values that worker resolve callbacks receive. */
+type PendingResolveValue = SpectrogramData[] | { cacheKey: string } | undefined;
+
+interface PendingEntry {
+  resolve: (value: PendingResolveValue) => void;
+  reject: (reason: unknown) => void;
+}
+
 export interface SpectrogramWorkerApi {
   compute(params: SpectrogramWorkerComputeParams): Promise<SpectrogramData[]>;
   computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }>;
@@ -84,10 +92,7 @@ let idCounter = 0;
  * ```
  */
 export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
-  const pending = new Map<string, {
-    resolve: (value: any) => void;
-    reject: (reason: unknown) => void;
-  }>();
+  const pending = new Map<string, PendingEntry>();
 
   // Track which clipIds have pre-registered audio data in the worker
   const registeredClipIds = new Set<string>();
@@ -131,7 +136,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
       const id = String(++idCounter);
 
       return new Promise<SpectrogramData[]>((resolve, reject) => {
-        pending.set(id, { resolve, reject });
+        pending.set(id, { resolve: resolve as PendingEntry['resolve'], reject });
 
         // Slice channel data so we can transfer without detaching the original AudioBuffer views
         const transferableArrays = params.channelDataArrays.map(arr => arr.slice());
@@ -157,7 +162,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
       const id = String(++idCounter);
 
       return new Promise<{ cacheKey: string }>((resolve, reject) => {
-        pending.set(id, { resolve, reject });
+        pending.set(id, { resolve: resolve as PendingEntry['resolve'], reject });
 
         // Skip transfer if audio data is pre-registered in the worker
         const isPreRegistered = registeredClipIds.has(params.clipId);
@@ -187,7 +192,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
       const id = String(++idCounter);
 
       return new Promise<void>((resolve, reject) => {
-        pending.set(id, { resolve, reject });
+        pending.set(id, { resolve: resolve as PendingEntry['resolve'], reject });
 
         worker.postMessage({
           type: 'render-chunks',
@@ -241,7 +246,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
       const id = String(++idCounter);
 
       return new Promise<void>((resolve, reject) => {
-        pending.set(id, { resolve, reject });
+        pending.set(id, { resolve: resolve as PendingEntry['resolve'], reject });
 
         const transferableArrays = params.channelDataArrays.map(arr => arr.slice());
         const transferables: Transferable[] = transferableArrays.map(arr => arr.buffer);

--- a/packages/ui-components/src/stories/Hooks.stories.tsx
+++ b/packages/ui-components/src/stories/Hooks.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from '@waveform-playlist/browser';
 import type { KeyboardShortcut } from '@waveform-playlist/browser';
 import { BaseButton, BaseSlider, BaseSelect } from '../styled';
+import type { TimeFormat } from '../utils/timeFormat';
 
 /**
  * Hook Testing Harness
@@ -58,7 +59,7 @@ const TimeFormatDemo: React.FC = () => {
         <label style={{ display: 'block', marginBottom: '0.5rem' }}>Format:</label>
         <BaseSelect
           value={timeFormat}
-          onChange={(e) => setTimeFormat(e.target.value as any)}
+          onChange={(e) => setTimeFormat(e.target.value as TimeFormat)}
           style={{ width: '200px' }}
         >
           <option value="seconds">Seconds</option>


### PR DESCRIPTION
## Summary
- Replace ~35 `any` annotations and `as any` casts with proper types across 6 packages (20 files changed, 274 insertions, 116 deletions)
- Add typed ambient module declaration for `fft.js` library
- Add `getUnderlyingAudioParam()` utility for safe Tone.js `_param` access
- Add `VendorPrefixedPitch` interface for cross-browser `preservesPitch` support
- Add typed annotation integration prop interfaces in `AnnotationIntegrationContext`

### Type replacements by area
| Area | Types used |
|------|-----------|
| Tone.js effects | `ToneAudioNode`, `Volume`, `Gain`, `Analyser`, `InputNode` |
| @dnd-kit drag handlers | `DragStartEvent`, `DragMoveEvent`, `Parameters<Modifier>` |
| FFT/spectrogram | `FFT` class declaration, `PendingResolveValue` union |
| Provider contexts | `AnnotationData[]`, `AnnotationAction[]`, `WaveformData`, `TimeFormat` |
| Media element | `VendorPrefixedPitch` interface, `Record<string, unknown>` |

## Test plan
- [x] `pnpm typecheck` passes (all 10 packages)
- [x] `pnpm build` passes (all 10 packages)
- [x] Zero `: any` annotations in source
- [x] Zero `as any` casts in source
- [ ] Manual smoke test of playback, effects, drag-and-drop, spectrogram

🤖 Generated with [Claude Code](https://claude.com/claude-code)