### PR TITLE
refactor: extract useVisibleChunkIndices hook (Rule of Three)

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -381,6 +381,7 @@ const LazyExample = createLazyExample(
 - `useAnnotationKeyboardControls` - Annotation navigation, editing, auto-scroll, and playback
 - `useDynamicEffects` - Master effects chain with runtime parameter updates
 - `useTrackDynamicEffects` - Per-track effects management
+- `useDynamicTracks` - Runtime track additions with placeholder-then-replace pattern
 - `usePlaybackControls`, `useTimeFormat`, `useZoomControls`, etc.
 
 **Location:** `packages/browser/src/hooks/`
@@ -630,7 +631,9 @@ const analyser = context.createAnalyser();
 14. **Context Value Memoization** - All context value objects in providers must be wrapped with `useMemo`. Extract inline callbacks into `useCallback` first to avoid dependency churn.
 15. **Error Boundary Available** - `PlaylistErrorBoundary` from `@waveform-playlist/ui-components` catches render errors. Uses plain CSS (no styled-components) so it works without ThemeProvider.
 16. **Audio Disconnect Diagnostics** - Use `console.warn('[waveform-playlist] ...')` in catch blocks for audio node disconnect errors, never silently swallow.
-17. **Fetch Cleanup with AbortController** - `useAudioTracks` uses AbortController to cancel in-flight fetches on cleanup. Follow this pattern for any fetch in useEffect.
+17. **Fetch Cleanup with AbortController** - `useAudioTracks` uses AbortController to cancel in-flight fetches on cleanup. Follow this pattern for any fetch in useEffect. For per-item abort (e.g., removing one loading track), use `Map<id, AbortController>` instead of `Set<AbortController>`.
+18. **Derive Render Guards from Props, Not Effect State** - Don't use effect-set state (e.g., `audioBuffers`) in render guards. Effect state lags props by one+ renders, causing content to flash/disappear. Compute values synchronously from props instead.
+19. **Copy Refs in useEffect Body** - When accessing a ref in `useEffect` cleanup, copy `.current` to a local variable inside the effect body. ESLint's `react-hooks/exhaustive-deps` rule flags refs that may change between render and cleanup.
 
 ### Playlist Loading Detection
 

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -467,6 +467,10 @@ const LazyExample = createLazyExample(
 - `SpectrogramChannel` — only mounts visible chunks (biggest memory win)
 - All use absolute positioning (`left: chunkIndex * 1000px`) instead of `float: left`
 
+**Shared hooks:**
+- `useVisibleChunkIndices(totalWidth, chunkWidth)` — returns memoized array of visible chunk indices. Uses string-key comparison internally for re-render gating. Exported from `ui-components`.
+- `useChunkedCanvasRefs()` — callback ref + Map storage + stale cleanup for chunked canvases. Internal only (not exported from package public API). Uses `Map<number, HTMLCanvasElement>` instead of sparse arrays.
+
 **Backwards compatibility:** `useScrollViewport()` returns `null` without provider. All components default to rendering everything when viewport is `null`.
 
 ### Web Worker Peak Generation (2026-02-13)
@@ -634,6 +638,8 @@ const analyser = context.createAnalyser();
 17. **Fetch Cleanup with AbortController** - `useAudioTracks` uses AbortController to cancel in-flight fetches on cleanup. Follow this pattern for any fetch in useEffect. For per-item abort (e.g., removing one loading track), use `Map<id, AbortController>` instead of `Set<AbortController>`.
 18. **Derive Render Guards from Props, Not Effect State** - Don't use effect-set state (e.g., `audioBuffers`) in render guards. Effect state lags props by one+ renders, causing content to flash/disappear. Compute values synchronously from props instead.
 19. **Copy Refs in useEffect Body** - When accessing a ref in `useEffect` cleanup, copy `.current` to a local variable inside the effect body. ESLint's `react-hooks/exhaustive-deps` rule flags refs that may change between render and cleanup.
+20. **Refs from Custom Hooks in Dep Arrays** - When a `useRef` is returned from a custom hook, ESLint's `exhaustive-deps` can't trace its stability. Include it in the dep array (harmless, never triggers) rather than using `eslint-disable-next-line` which would mask real missing dependencies.
+21. **Every-Render Cleanup Effects** - `useChunkedCanvasRefs` and SpectrogramChannel's worker cleanup use `useEffect` with no dependency array intentionally. The virtualizer can unmount canvases between any render. Do NOT add `[]` or other deps — this would break stale ref pruning.
 
 ### Playlist Loading Detection
 

--- a/packages/browser/src/components/PlaylistVisualization.tsx
+++ b/packages/browser/src/components/PlaylistVisualization.tsx
@@ -459,10 +459,9 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                   </Controls>
                 );
 
-                const rawChannels = trackClipPeaks.length > 0
+                const maxChannels = trackClipPeaks.length > 0
                   ? Math.max(1, ...trackClipPeaks.map(clip => clip.peaks.data.length))
                   : 1;
-                const maxChannels = rawChannels;
 
                 return (
                   <TrackControlsContext.Provider key={track.id} value={trackControls}>

--- a/packages/ui-components/src/contexts/ScrollViewport.tsx
+++ b/packages/ui-components/src/contexts/ScrollViewport.tsx
@@ -166,7 +166,7 @@ export function useScrollViewportSelector<T>(
  * Only triggers a re-render when the set of visible chunks changes, not on every scroll pixel.
  *
  * @param totalWidth Total width in CSS pixels of the content being chunked.
- * @param chunkWidth Width of each chunk in CSS pixels. Defaults to MAX_CANVAS_WIDTH (1000).
+ * @param chunkWidth Width of each chunk in CSS pixels (typically MAX_CANVAS_WIDTH, 1000).
  */
 export function useVisibleChunkIndices(totalWidth: number, chunkWidth: number): number[] {
   const visibleChunkKey = useScrollViewportSelector((viewport) => {

--- a/packages/ui-components/src/contexts/index.tsx
+++ b/packages/ui-components/src/contexts/index.tsx
@@ -3,7 +3,7 @@ import { usePlaylistInfo, PlaylistInfoContext } from './PlaylistInfo';
 import { useTheme } from './Theme';
 import { useTrackControls, TrackControlsContext } from './TrackControls';
 import { PlayoutProvider, usePlayoutStatus, usePlayoutStatusUpdate } from './Playout';
-import { useScrollViewport, useScrollViewportSelector, ScrollViewportProvider } from './ScrollViewport';
+import { useScrollViewport, useScrollViewportSelector, useVisibleChunkIndices, ScrollViewportProvider } from './ScrollViewport';
 export type { ScrollViewport } from './ScrollViewport';
 
 export {
@@ -19,5 +19,6 @@ export {
   usePlayoutStatusUpdate,
   useScrollViewport,
   useScrollViewportSelector,
+  useVisibleChunkIndices,
   ScrollViewportProvider,
 };

--- a/packages/ui-components/src/hooks/useChunkedCanvasRefs.ts
+++ b/packages/ui-components/src/hooks/useChunkedCanvasRefs.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Manages canvas element refs for chunked virtual-scroll rendering.
+ *
+ * Provides a callback ref (for `ref={canvasRef}`) that stores canvases
+ * by their `data-index` chunk index, and automatically cleans up refs
+ * for canvases that have been unmounted by the virtualizer.
+ *
+ * Used by Channel, TimeScale, and SpectrogramChannel.
+ *
+ * @returns
+ * - `canvasRef` — Callback ref to attach to each `<canvas data-index={i}>` element.
+ * - `canvasMapRef` — Stable ref to a `Map<number, HTMLCanvasElement>` for iterating
+ *   over mounted canvases during draw effects.
+ */
+export function useChunkedCanvasRefs() {
+  const canvasMapRef = useRef<Map<number, HTMLCanvasElement>>(new Map());
+
+  const canvasRef = useCallback((canvas: HTMLCanvasElement | null) => {
+    if (canvas !== null) {
+      const idx = parseInt(canvas.dataset.index!, 10);
+      canvasMapRef.current.set(idx, canvas);
+    }
+  }, []);
+
+  // Clean up stale refs for unmounted chunks.
+  // Intentionally has no dependency array — runs after every render because
+  // the virtualizer can unmount canvases at any time, and drawing effects
+  // need the map pruned before they iterate it.
+  useEffect(() => {
+    const map = canvasMapRef.current;
+    for (const [idx, canvas] of map.entries()) {
+      if (!canvas.isConnected) {
+        map.delete(idx);
+      }
+    }
+  });
+
+  return { canvasRef, canvasMapRef };
+}


### PR DESCRIPTION
## Summary

- Extract identical chunk visibility selector from `Channel`, `TimeScale`, and `SpectrogramChannel` into shared `useVisibleChunkIndices` hook
- The hook uses `useMemo` on the internal string key for referentially stable return values (safe as effect dependencies)
- Remove unnecessary `maxChannels = rawChannels` alias in `PlaylistVisualization`
- Include CLAUDE.md pattern updates from the useDynamicTracks work (patterns 17-19)

**Net: -40 lines** (93 removed, 53 added)

## Test plan

- [x] `pnpm typecheck` — all 10 packages pass
- [x] `pnpm lint` — no violations
- [x] `pnpm --filter website build` — builds successfully
- [ ] Manual: verify waveform rendering with virtual scrolling still works (zoom, scroll, spectrogram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)