### PR TITLE
fix(ui-components): use clip-origin coords for chunk visibility

### DIFF
--- a/packages/ui-components/src/components/Channel.tsx
+++ b/packages/ui-components/src/components/Channel.tsx
@@ -1,14 +1,19 @@
-import React, { FunctionComponent, useLayoutEffect } from 'react';
-import styled from 'styled-components';
-import type { Peaks, Bits } from '@waveform-playlist/core';
-import { WaveformColor, WaveformDrawMode, isWaveformGradient, waveformColorToCss } from '../wfpl-theme';
-import { useVisibleChunkIndices } from '../contexts/ScrollViewport';
-import { useChunkedCanvasRefs } from '../hooks/useChunkedCanvasRefs';
-import { MAX_CANVAS_WIDTH } from '@waveform-playlist/core';
+import type { Bits, Peaks } from "@waveform-playlist/core";
+import { MAX_CANVAS_WIDTH } from "@waveform-playlist/core";
+import { type FunctionComponent, useLayoutEffect } from "react";
+import styled from "styled-components";
+import { useClipViewportOrigin } from "../contexts/ClipViewportOrigin";
+import { useVisibleChunkIndices } from "../contexts/ScrollViewport";
+import { useChunkedCanvasRefs } from "../hooks/useChunkedCanvasRefs";
+import {
+  isWaveformGradient,
+  WaveformColor,
+  WaveformDrawMode,
+  waveformColorToCss,
+} from "../wfpl-theme";
 
 // Re-export WaveformColor for consumers
-export type { WaveformColor } from '../wfpl-theme';
-export type { WaveformDrawMode } from '../wfpl-theme';
+export type { WaveformColor, WaveformDrawMode } from "../wfpl-theme";
 
 /**
  * Creates a Canvas gradient from a WaveformColor configuration
@@ -17,14 +22,14 @@ function createCanvasFillStyle(
   ctx: CanvasRenderingContext2D,
   color: WaveformColor,
   width: number,
-  height: number
+  height: number,
 ): string | CanvasGradient {
   if (!isWaveformGradient(color)) {
     return color;
   }
 
   let gradient: CanvasGradient;
-  if (color.direction === 'vertical') {
+  if (color.direction === "vertical") {
     gradient = ctx.createLinearGradient(0, 0, 0, height);
   } else {
     gradient = ctx.createLinearGradient(0, 0, width, 0);
@@ -115,16 +120,21 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
     className,
     devicePixelRatio = 1,
     waveHeight = 80,
-    waveOutlineColor = '#E0EFF1',
-    waveFillColor = 'grey',
+    waveOutlineColor = "#E0EFF1",
+    waveFillColor = "grey",
     barWidth = 1,
     barGap = 0,
     transparentBackground = false,
-    drawMode = 'inverted',
+    drawMode = "inverted",
   } = props;
   const { canvasRef, canvasMapRef } = useChunkedCanvasRefs();
+  const clipOriginX = useClipViewportOrigin();
 
-  const visibleChunkIndices = useVisibleChunkIndices(length, MAX_CANVAS_WIDTH);
+  const visibleChunkIndices = useVisibleChunkIndices(
+    length,
+    MAX_CANVAS_WIDTH,
+    clipOriginX,
+  );
 
   // Draw waveform bars on visible canvas chunks.
   // visibleChunkIndices changes only when chunks mount/unmount, not on every scroll pixel.
@@ -134,7 +144,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
     for (const [canvasIdx, canvas] of canvasMapRef.current.entries()) {
       const globalPixelOffset = canvasIdx * MAX_CANVAS_WIDTH;
 
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext("2d");
       const h2 = Math.floor(waveHeight / 2);
       const maxValue = 2 ** (bits - 1);
 
@@ -150,7 +160,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
 
         // Choose canvas fill color based on draw mode:
         let fillColor: WaveformColor;
-        if (drawMode === 'normal') {
+        if (drawMode === "normal") {
           // Normal: canvas draws the bars directly
           fillColor = waveFillColor;
         } else {
@@ -161,7 +171,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
           ctx,
           fillColor,
           canvasWidth,
-          waveHeight
+          waveHeight,
         );
 
         // Calculate where bars should be drawn in this canvas
@@ -173,10 +183,15 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
         // A bar at position X extends from X to X+barWidth-1
         // So we need bars where barStart + barWidth > canvasStartGlobal
         // Which means barStart > canvasStartGlobal - barWidth
-        const firstBarGlobal = Math.floor((canvasStartGlobal - barWidth + step) / step) * step;
+        const firstBarGlobal =
+          Math.floor((canvasStartGlobal - barWidth + step) / step) * step;
 
         // Draw bars at the correct positions
-        for (let barGlobal = Math.max(0, firstBarGlobal); barGlobal < canvasEndGlobal; barGlobal += step) {
+        for (
+          let barGlobal = Math.max(0, firstBarGlobal);
+          barGlobal < canvasEndGlobal;
+          barGlobal += step
+        ) {
           const x = barGlobal - canvasStartGlobal; // Local x position in this canvas
 
           // Skip if the entire bar would be before this canvas
@@ -191,7 +206,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
             const min = Math.abs(minPeak * h2);
             const max = Math.abs(maxPeak * h2);
 
-            if (drawMode === 'normal') {
+            if (drawMode === "normal") {
               // Normal mode: draw the actual peak bars
               // Draw from h2-max to h2+min (the actual waveform shape)
               ctx.fillRect(x, h2 - max, barWidth, max + min);
@@ -246,7 +261,9 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
   // - normal: waveFillColor is background, canvas draws waveOutlineColor bars on top
   // - inverted: waveFillColor is background, canvas masks with it to reveal waveOutlineColor (bars)
   const bgColor = waveFillColor;
-  const backgroundCss = transparentBackground ? 'transparent' : waveformColorToCss(bgColor);
+  const backgroundCss = transparentBackground
+    ? "transparent"
+    : waveformColorToCss(bgColor);
 
   return (
     <Wrapper

--- a/packages/ui-components/src/components/Clip.tsx
+++ b/packages/ui-components/src/components/Clip.tsx
@@ -1,11 +1,12 @@
-import React, { FunctionComponent, ReactNode } from 'react';
-import styled from 'styled-components';
-import { useDraggable } from '@dnd-kit/core';
-import { CSS } from '@dnd-kit/utilities';
-import { ClipHeader } from './ClipHeader';
-import { ClipBoundary } from './ClipBoundary';
-import { FadeOverlay } from './FadeOverlay';
-import type { Fade } from '@waveform-playlist/core';
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import type { Fade } from "@waveform-playlist/core";
+import type { FunctionComponent, MouseEvent, ReactNode } from "react";
+import styled from "styled-components";
+import { ClipViewportOriginProvider } from "../contexts/ClipViewportOrigin";
+import { ClipBoundary } from "./ClipBoundary";
+import { ClipHeader } from "./ClipHeader";
+import { FadeOverlay } from "./FadeOverlay";
 
 interface ClipContainerProps {
   readonly $left?: number; // Horizontal position in pixels (optional for DragOverlay)
@@ -15,15 +16,17 @@ interface ClipContainerProps {
 }
 
 const ClipContainer = styled.div.attrs<ClipContainerProps>((props) => ({
-  style: props.$isOverlay ? {} : {
-    left: `${props.$left}px`,
-    width: `${props.$width}px`,
-  },
+  style: props.$isOverlay
+    ? {}
+    : {
+        left: `${props.$left}px`,
+        width: `${props.$width}px`,
+      },
 }))<ClipContainerProps>`
-  position: ${props => props.$isOverlay ? 'relative' : 'absolute'};
+  position: ${(props) => (props.$isOverlay ? "relative" : "absolute")};
   top: 0;
-  height: ${props => props.$isOverlay ? 'auto' : '100%'};
-  width: ${props => props.$isOverlay ? `${props.$width}px` : 'auto'};
+  height: ${(props) => (props.$isOverlay ? "auto" : "100%")};
+  width: ${(props) => (props.$isOverlay ? `${props.$width}px` : "auto")};
   display: flex;
   flex-direction: column;
   background: rgba(255, 255, 255, 0.05);
@@ -42,7 +45,7 @@ interface ChannelsWrapperProps {
 const ChannelsWrapper = styled.div<ChannelsWrapperProps>`
   flex: 1;
   position: relative;
-  overflow: ${props => props.$isOverlay ? 'visible' : 'hidden'};
+  overflow: ${(props) => (props.$isOverlay ? "visible" : "hidden")};
 `;
 
 export interface ClipProps {
@@ -61,7 +64,7 @@ export interface ClipProps {
   isOverlay?: boolean; // Rendering in DragOverlay (disables absolute positioning)
   // Track selection
   isSelected?: boolean; // Whether the track is selected
-  onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void; // Called when clip is pressed (for track selection - fires before drag)
+  onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void; // Called when clip is pressed (for track selection - fires before drag)
   trackId?: string; // Track ID for identifying which track this clip belongs to
   // Fade configuration
   fadeIn?: Fade; // Fade in effect
@@ -108,7 +111,9 @@ export const Clip: FunctionComponent<ClipProps> = ({
 
   // Calculate width as the difference between end and start pixel positions
   // This ensures clips are perfectly adjacent with no gaps
-  const endPixel = Math.floor((startSample + durationSamples) / samplesPerPixel);
+  const endPixel = Math.floor(
+    (startSample + durationSamples) / samplesPerPixel,
+  );
   const width = endPixel - left;
 
   // Use draggable only if header is shown and drag is enabled
@@ -116,7 +121,14 @@ export const Clip: FunctionComponent<ClipProps> = ({
 
   // Main clip draggable (for moving entire clip)
   const draggableId = `clip-${trackIndex}-${clipIndex}`;
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, isDragging } = useDraggable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    isDragging,
+  } = useDraggable({
     id: draggableId,
     data: { clipId, trackIndex, clipIndex },
     disabled: !enableDrag,
@@ -131,7 +143,7 @@ export const Clip: FunctionComponent<ClipProps> = ({
     isDragging: isLeftBoundaryDragging,
   } = useDraggable({
     id: leftBoundaryId,
-    data: { clipId, trackIndex, clipIndex, boundary: 'left' },
+    data: { clipId, trackIndex, clipIndex, boundary: "left" },
     disabled: !enableDrag,
   });
 
@@ -144,15 +156,17 @@ export const Clip: FunctionComponent<ClipProps> = ({
     isDragging: isRightBoundaryDragging,
   } = useDraggable({
     id: rightBoundaryId,
-    data: { clipId, trackIndex, clipIndex, boundary: 'right' },
+    data: { clipId, trackIndex, clipIndex, boundary: "right" },
     disabled: !enableDrag,
   });
 
   // Apply transform for dragging
-  const style = transform ? {
-    transform: CSS.Translate.toString(transform),
-    zIndex: isDragging ? 100 : undefined, // Below controls (z-index: 999) but above other clips
-  } : undefined;
+  const style = transform
+    ? {
+        transform: CSS.Translate.toString(transform),
+        zIndex: isDragging ? 100 : undefined, // Below controls (z-index: 999) but above other clips
+      }
+    : undefined;
 
   return (
     <ClipContainer
@@ -174,29 +188,42 @@ export const Clip: FunctionComponent<ClipProps> = ({
           trackName={trackName}
           isSelected={isSelected}
           disableDrag={disableHeaderDrag}
-          dragHandleProps={enableDrag ? { attributes, listeners, setActivatorNodeRef } : undefined}
+          dragHandleProps={
+            enableDrag
+              ? { attributes, listeners, setActivatorNodeRef }
+              : undefined
+          }
         />
       )}
-      <ChannelsWrapper $isOverlay={isOverlay}>
-        {children}
-        {/* Fade overlays */}
-        {showFades && fadeIn && fadeIn.duration > 0 && (
-          <FadeOverlay
-            left={0}
-            width={Math.floor((fadeIn.duration * sampleRate) / samplesPerPixel)}
-            type="fadeIn"
-            curveType={fadeIn.type}
-          />
-        )}
-        {showFades && fadeOut && fadeOut.duration > 0 && (
-          <FadeOverlay
-            left={width - Math.floor((fadeOut.duration * sampleRate) / samplesPerPixel)}
-            width={Math.floor((fadeOut.duration * sampleRate) / samplesPerPixel)}
-            type="fadeOut"
-            curveType={fadeOut.type}
-          />
-        )}
-      </ChannelsWrapper>
+      <ClipViewportOriginProvider originX={left}>
+        <ChannelsWrapper $isOverlay={isOverlay}>
+          {children}
+          {/* Fade overlays */}
+          {showFades && fadeIn && fadeIn.duration > 0 && (
+            <FadeOverlay
+              left={0}
+              width={Math.floor(
+                (fadeIn.duration * sampleRate) / samplesPerPixel,
+              )}
+              type="fadeIn"
+              curveType={fadeIn.type}
+            />
+          )}
+          {showFades && fadeOut && fadeOut.duration > 0 && (
+            <FadeOverlay
+              left={
+                width -
+                Math.floor((fadeOut.duration * sampleRate) / samplesPerPixel)
+              }
+              width={Math.floor(
+                (fadeOut.duration * sampleRate) / samplesPerPixel,
+              )}
+              type="fadeOut"
+              curveType={fadeOut.type}
+            />
+          )}
+        </ChannelsWrapper>
+      </ClipViewportOriginProvider>
       {/* Clip boundaries - outside ChannelsWrapper to avoid overflow:hidden clipping */}
       {showHeader && !disableHeaderDrag && !isOverlay && (
         <>

--- a/packages/ui-components/src/components/SpectrogramChannel.tsx
+++ b/packages/ui-components/src/components/SpectrogramChannel.tsx
@@ -1,10 +1,18 @@
-import React, { FunctionComponent, useLayoutEffect, useRef, useEffect } from 'react';
-import styled from 'styled-components';
-import type { SpectrogramData } from '@waveform-playlist/core';
-import { useVisibleChunkIndices } from '../contexts/ScrollViewport';
-import { useChunkedCanvasRefs } from '../hooks/useChunkedCanvasRefs';
-import { MAX_CANVAS_WIDTH } from '@waveform-playlist/core';
-const LINEAR_FREQUENCY_SCALE = (f: number, minF: number, maxF: number) => (f - minF) / (maxF - minF);
+import type { SpectrogramData } from "@waveform-playlist/core";
+import { MAX_CANVAS_WIDTH } from "@waveform-playlist/core";
+import {
+  type FunctionComponent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import styled from "styled-components";
+import { useClipViewportOrigin } from "../contexts/ClipViewportOrigin";
+import { useVisibleChunkIndices } from "../contexts/ScrollViewport";
+import { useChunkedCanvasRefs } from "../hooks/useChunkedCanvasRefs";
+
+const LINEAR_FREQUENCY_SCALE = (f: number, minF: number, maxF: number) =>
+  (f - minF) / (maxF - minF);
 
 interface WrapperProps {
   readonly $index: number;
@@ -113,14 +121,21 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
   const channelIndex = channelIndexProp ?? index;
   const { canvasRef, canvasMapRef } = useChunkedCanvasRefs();
   const registeredIdsRef = useRef<string[]>([]);
-  const transferredCanvasesRef = useRef<WeakSet<HTMLCanvasElement>>(new WeakSet());
+  const transferredCanvasesRef = useRef<WeakSet<HTMLCanvasElement>>(
+    new WeakSet(),
+  );
   const workerApiRef = useRef(workerApi);
   const onCanvasesReadyRef = useRef(onCanvasesReady);
 
   // Track whether we're in worker mode (canvas transferred)
   const isWorkerMode = !!(workerApi && clipId);
+  const clipOriginX = useClipViewportOrigin();
 
-  const visibleChunkIndices = useVisibleChunkIndices(length, MAX_CANVAS_WIDTH);
+  const visibleChunkIndices = useVisibleChunkIndices(
+    length,
+    MAX_CANVAS_WIDTH,
+    clipOriginX,
+  );
 
   const lut = colorLUT ?? DEFAULT_COLOR_LUT;
   const maxF = maxFrequency ?? (data ? data.sampleRate / 2 : 22050);
@@ -150,7 +165,10 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
     const remaining: string[] = [];
     for (const id of registeredIdsRef.current) {
       const match = id.match(/chunk(\d+)$/);
-      if (!match) { remaining.push(id); continue; }
+      if (!match) {
+        remaining.push(id);
+        continue;
+      }
       const chunkIdx = parseInt(match[1], 10);
       const canvas = canvasMapRef.current.get(chunkIdx);
       if (canvas && canvas.isConnected) {
@@ -177,7 +195,10 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
       try {
         offscreen = canvas.transferControlToOffscreen();
       } catch (err) {
-        console.warn(`[spectrogram] transferControlToOffscreen failed for ${canvasId}:`, err);
+        console.warn(
+          `[spectrogram] transferControlToOffscreen failed for ${canvasId}:`,
+          err,
+        );
         continue;
       }
 
@@ -188,7 +209,10 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
         currentWorkerApi.registerCanvas(canvasId, offscreen);
         newIds.push(canvasId);
       } catch (err) {
-        console.warn(`[spectrogram] registerCanvas failed for ${canvasId}:`, err);
+        console.warn(
+          `[spectrogram] registerCanvas failed for ${canvasId}:`,
+          err,
+        );
         continue;
       }
     }
@@ -198,10 +222,11 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
     }
 
     // Step 3: Notify provider when canvas set changed (added or removed).
-    const canvasSetChanged = newIds.length > 0 || remaining.length < previousCount;
+    const canvasSetChanged =
+      newIds.length > 0 || remaining.length < previousCount;
     if (canvasSetChanged) {
       const allIds = registeredIdsRef.current;
-      const allWidths = allIds.map(id => {
+      const allWidths = allIds.map((id) => {
         const match = id.match(/chunk(\d+)$/);
         if (!match) {
           console.warn(`[spectrogram] Unexpected canvas ID format: ${id}`);
@@ -212,7 +237,14 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
       });
       onCanvasesReadyRef.current?.(allIds, allWidths);
     }
-  }, [canvasMapRef, isWorkerMode, clipId, channelIndex, length, visibleChunkIndices]);
+  }, [
+    canvasMapRef,
+    isWorkerMode,
+    clipId,
+    channelIndex,
+    length,
+    visibleChunkIndices,
+  ]);
 
   // Unregister all canvases from worker on component unmount
   useEffect(() => {
@@ -235,16 +267,24 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
   useLayoutEffect(() => {
     if (isWorkerMode || !data) return;
 
-    const { frequencyBinCount, frameCount, hopSize, sampleRate, gainDb, rangeDb: rawRangeDb } = data;
+    const {
+      frequencyBinCount,
+      frameCount,
+      hopSize,
+      sampleRate,
+      gainDb,
+      rangeDb: rawRangeDb,
+    } = data;
     const rangeDb = rawRangeDb === 0 ? 1 : rawRangeDb;
 
     // Pre-compute Y mapping: for each pixel row, which frequency bin(s) to sample
-    const binToFreq = (bin: number) => (bin / frequencyBinCount) * (sampleRate / 2);
+    const binToFreq = (bin: number) =>
+      (bin / frequencyBinCount) * (sampleRate / 2);
 
     for (const [canvasIdx, canvas] of canvasMapRef.current.entries()) {
       const globalPixelOffset = canvasIdx * MAX_CANVAS_WIDTH;
 
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext("2d");
       if (!ctx) continue;
 
       const canvasWidth = canvas.width / devicePixelRatio;
@@ -301,7 +341,10 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
 
           // Get dB value and normalize to [0, 1]
           const db = data.data[frameOffset + bin];
-          const normalized = Math.max(0, Math.min(1, (db + rangeDb + gainDb) / rangeDb));
+          const normalized = Math.max(
+            0,
+            Math.min(1, (db + rangeDb + gainDb) / rangeDb),
+          );
 
           // Map to color via LUT (0-255 index)
           const colorIdx = Math.floor(normalized * 255);
@@ -320,10 +363,10 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
       // Scale up to fill canvas
       if (devicePixelRatio !== 1) {
         // Draw the image data at 1:1, then scale
-        const tmpCanvas = document.createElement('canvas');
+        const tmpCanvas = document.createElement("canvas");
         tmpCanvas.width = canvasWidth;
         tmpCanvas.height = canvasHeight;
-        const tmpCtx = tmpCanvas.getContext('2d');
+        const tmpCtx = tmpCanvas.getContext("2d");
         if (!tmpCtx) continue;
         tmpCtx.putImageData(imgData, 0, 0);
 
@@ -331,10 +374,22 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
         ctx.imageSmoothingEnabled = false;
         ctx.drawImage(tmpCanvas, 0, 0, canvas.width, canvas.height);
       }
-
     }
-
-  }, [canvasMapRef, isWorkerMode, data, length, waveHeight, devicePixelRatio, samplesPerPixel, lut, minFrequency, maxF, scaleFn, hasCustomFrequencyScale, visibleChunkIndices]);
+  }, [
+    canvasMapRef,
+    isWorkerMode,
+    data,
+    length,
+    waveHeight,
+    devicePixelRatio,
+    samplesPerPixel,
+    lut,
+    minFrequency,
+    maxF,
+    scaleFn,
+    hasCustomFrequencyScale,
+    visibleChunkIndices,
+  ]);
 
   // Build visible canvas chunk elements
   const canvases = visibleChunkIndices.map((i) => {

--- a/packages/ui-components/src/contexts/ClipViewportOrigin.tsx
+++ b/packages/ui-components/src/contexts/ClipViewportOrigin.tsx
@@ -1,0 +1,23 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+const ClipViewportOriginContext = createContext<number>(0);
+
+interface ClipViewportOriginProviderProps {
+  originX: number;
+  children: ReactNode;
+}
+
+export function ClipViewportOriginProvider({
+  originX,
+  children,
+}: ClipViewportOriginProviderProps) {
+  return (
+    <ClipViewportOriginContext.Provider value={originX}>
+      {children}
+    </ClipViewportOriginContext.Provider>
+  );
+}
+
+export function useClipViewportOrigin(): number {
+  return useContext(ClipViewportOriginContext);
+}

--- a/packages/ui-components/src/contexts/ScrollViewport.tsx
+++ b/packages/ui-components/src/contexts/ScrollViewport.tsx
@@ -1,13 +1,13 @@
 import React, {
   createContext,
+  ReactNode,
+  useCallback,
   useContext,
   useEffect,
-  useCallback,
   useMemo,
   useRef,
   useSyncExternalStore,
-  ReactNode,
-} from 'react';
+} from "react";
 
 export interface ScrollViewport {
   scrollLeft: number;
@@ -104,7 +104,7 @@ export const ScrollViewportProvider = ({
     measure();
 
     // Scroll listener throttled via requestAnimationFrame
-    el.addEventListener('scroll', scheduleUpdate, { passive: true });
+    el.addEventListener("scroll", scheduleUpdate, { passive: true });
 
     // ResizeObserver for container width changes
     const resizeObserver = new ResizeObserver(() => {
@@ -113,7 +113,7 @@ export const ScrollViewportProvider = ({
     resizeObserver.observe(el);
 
     return () => {
-      el.removeEventListener('scroll', scheduleUpdate);
+      el.removeEventListener("scroll", scheduleUpdate);
       resizeObserver.disconnect();
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);
@@ -168,7 +168,11 @@ export function useScrollViewportSelector<T>(
  * @param totalWidth Total width in CSS pixels of the content being chunked.
  * @param chunkWidth Width of each chunk in CSS pixels (typically MAX_CANVAS_WIDTH, 1000).
  */
-export function useVisibleChunkIndices(totalWidth: number, chunkWidth: number): number[] {
+export function useVisibleChunkIndices(
+  totalWidth: number,
+  chunkWidth: number,
+  originX: number = 0,
+): number[] {
   const visibleChunkKey = useScrollViewportSelector((viewport) => {
     const totalChunks = Math.ceil(totalWidth / chunkWidth);
     const indices: number[] = [];
@@ -178,8 +182,12 @@ export function useVisibleChunkIndices(totalWidth: number, chunkWidth: number): 
       const thisChunkWidth = Math.min(totalWidth - chunkLeft, chunkWidth);
 
       if (viewport) {
-        const chunkEnd = chunkLeft + thisChunkWidth;
-        if (chunkEnd <= viewport.visibleStart || chunkLeft >= viewport.visibleEnd) {
+        const chunkLeftGlobal = originX + chunkLeft;
+        const chunkEndGlobal = chunkLeftGlobal + thisChunkWidth;
+        if (
+          chunkEndGlobal <= viewport.visibleStart ||
+          chunkLeftGlobal >= viewport.visibleEnd
+        ) {
           continue;
         }
       }
@@ -187,13 +195,13 @@ export function useVisibleChunkIndices(totalWidth: number, chunkWidth: number): 
       indices.push(i);
     }
 
-    return indices.join(',');
+    return indices.join(",");
   });
 
   // Memoize on the key string so the returned array is referentially stable
   // between renders — safe to use directly in useLayoutEffect dependency arrays.
   return useMemo(
-    () => visibleChunkKey ? visibleChunkKey.split(',').map(Number) : [],
+    () => (visibleChunkKey ? visibleChunkKey.split(",").map(Number) : []),
     [visibleChunkKey],
   );
 }


### PR DESCRIPTION
## Problem
When a track contains multiple clips (or any clip with a non-zero `startSample`), waveform/spectrogram canvas chunks can incorrectly disappear while scrolling.

The virtualization logic (`useVisibleChunkIndices`) was comparing:
- chunk bounds in **clip-local** coordinates (0..clipWidth)
against
- viewport bounds (`visibleStart/visibleEnd`) in **global playlist** coordinates.

This makes chunks look "out of view" when `scrollLeft` is past the clip-local origin, even if the clip is actually visible on the timeline.

Example debug output from the bug:
```text
Skipping chunk 0 (chunkLeft: 0, chunkEnd: 463, visibleStart: 517, visibleEnd: 4853)
totalChunks: 1, visible chunks:
```

## Repro
1. Create a track with 2 clips separated by time (second clip has `startSample > 0`).
2. Scroll horizontally so that the second clip should be in view.
3. Observe that the clip's waveform/spectrogram chunks fail to render (or flicker/disappear).

## Fix
- Add an `originX` offset to `useVisibleChunkIndices` so chunk visibility is evaluated in the same coordinate space as the viewport.
- Provide clip origin (`left` in pixels) to descendant channels via a lightweight provider, and pass it into `useVisibleChunkIndices` in `Channel` and `SpectrogramChannel`.
- Keep timescale behavior unchanged (`originX = 0`).

## Demo
**Before (broken)**

https://github.com/user-attachments/assets/c75ca4c3-f184-4d54-a210-8d312a884aff



**After (fixed)**

https://github.com/user-attachments/assets/7179281f-0645-4fad-8332-7635650239fd



## Notes
This change is intentionally scoped to virtualization visibility only; it does not change waveform/spectrogram drawing math.
EOF