### PR TITLE
docs: document virtual scrolling & ClipViewportOrigin

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -125,7 +125,10 @@ const clip = createClipFromSeconds({
   │   ├── Selection.tsx
   │   ├── AnnotationBox.tsx
   │   └── TrackControls/
-  ├── contexts/          # React contexts (theme, playlist info, playout, scroll viewport)
+  ├── contexts/          # React contexts
+  │   ├── ScrollViewport.tsx    # Virtual scrolling: viewport state, chunk visibility
+  │   ├── ClipViewportOrigin.tsx # Clip pixel offset for correct chunk culling
+  │   └── ...                   # Theme, playlist info, playout contexts
   ├── utils/             # Utilities (time formatting, conversions)
   ├── styled/            # Shared styled components
   │   ├── CheckboxStyles.tsx  # Checkbox, label, wrapper
@@ -186,6 +189,13 @@ const clip = createClipFromSeconds({
   - `AutomaticScrollCheckbox` - Auto-scroll toggle
   - `TrackMenu` - Per-track dropdown menu
   - `TrackControls/` - Mute, solo, volume, pan controls
+- **Virtual Scrolling:**
+  - `ScrollViewportProvider` wraps the scrollable container, tracks scroll position via `useSyncExternalStore` with RAF-throttled listener + ResizeObserver
+  - `useScrollViewport()` returns full viewport state; `useScrollViewportSelector()` for fine-grained subscriptions
+  - `useVisibleChunkIndices(totalWidth, chunkWidth, originX?)` returns memoized array of visible chunk indices. `originX` converts local chunk coordinates to global viewport space
+  - `ClipViewportOriginProvider` wraps each clip's channels, supplying the clip's pixel `left` offset. Without it, clips not at position 0 get incorrect chunk culling
+  - 1.5x viewport overscan buffer on each side; 100px scroll threshold skips updates that won't affect chunk visibility
+  - Components affected: `TimeScale`, `Channel`, `SpectrogramChannel` — all use absolute positioning (`left: chunkIndex * 1000px`)
 
 #### `@waveform-playlist/browser`
 

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -609,6 +609,51 @@ Catches render errors in child components. Uses plain CSS (works without ThemePr
 
 ---
 
+## Virtual Scrolling (@waveform-playlist/ui-components)
+
+Viewport-aware canvas rendering — only mounts canvas chunks visible in the scroll container plus a 1.5x overscan buffer.
+
+```typescript
+// ScrollViewport — viewport state
+interface ScrollViewport {
+  scrollLeft: number;
+  containerWidth: number;
+  visibleStart: number;  // Left edge including overscan buffer
+  visibleEnd: number;    // Right edge including overscan buffer
+}
+
+// ScrollViewportProvider — wraps scrollable container
+interface ScrollViewportProviderProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  children: React.ReactNode;
+}
+const ScrollViewportProvider: React.FC<ScrollViewportProviderProps>;
+
+// useScrollViewport — full viewport state (re-renders on every scroll update)
+function useScrollViewport(): ScrollViewport | null;
+
+// useScrollViewportSelector — fine-grained subscription (re-renders only when selector result changes)
+function useScrollViewportSelector<T>(selector: (viewport: ScrollViewport | null) => T): T;
+
+// useVisibleChunkIndices — which canvas chunks are visible
+// originX converts local chunk coords to global viewport space (for clips not at position 0)
+function useVisibleChunkIndices(totalWidth: number, chunkWidth: number, originX?: number): number[];
+
+// ClipViewportOriginProvider — provides clip's pixel offset to descendant Channel/SpectrogramChannel
+interface ClipViewportOriginProviderProps {
+  originX: number;       // Clip's pixel-space left offset within the timeline
+  children: React.ReactNode;
+}
+const ClipViewportOriginProvider: React.FC<ClipViewportOriginProviderProps>;
+
+// useClipViewportOrigin — read clip's pixel offset (defaults to 0 outside provider)
+function useClipViewportOrigin(): number;
+```
+
+Used internally by `Channel`, `SpectrogramChannel`, and `TimeScale`. Returns `null` without provider (backwards compatible).
+
+---
+
 ## Spectrogram (@waveform-playlist/spectrogram)
 
 Spectrogram is an **optional** package. Integrate via `SpectrogramProvider`:

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -21,7 +21,7 @@ waveform-playlist is a React component library for building browser-based audio 
 - `@waveform-playlist/browser` — Main package: React components, hooks, effects
 - `@waveform-playlist/core` — Data model: ClipTrack, AudioClip, sample-based math
 - `@waveform-playlist/playout` — Audio engine: Tone.js playback, global AudioContext
-- `@waveform-playlist/ui-components` — Styled primitives, theming, playhead components, PlaylistErrorBoundary
+- `@waveform-playlist/ui-components` — Styled primitives, theming, virtual scrolling contexts, playhead components, PlaylistErrorBoundary
 - `@waveform-playlist/annotations` — Annotation parsing, rendering, keyboard controls
 - `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter, integrated recording hook
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
@@ -77,6 +77,12 @@ Both providers use React Context with 4 split contexts for performance.
 - `useExportWav()` — Offline WAV export with effects support
 - `useKeyboardShortcuts(opts)` — Custom keyboard shortcuts
 - `usePlaybackShortcuts(opts)` — Default playback shortcuts (Space, Escape, 0)
+
+### Virtual Scrolling Hooks (from `@waveform-playlist/ui-components`)
+
+- `useScrollViewport()` — Current scroll position and viewport dimensions (with 1.5x overscan buffer)
+- `useVisibleChunkIndices(totalWidth, chunkWidth, originX?)` — Memoized array of visible chunk indices for canvas virtualization
+- `useClipViewportOrigin()` — Clip's pixel offset in the timeline (for correct chunk visibility in multi-clip tracks)
 
 ### Recording Hooks (from `@waveform-playlist/recording`)
 


### PR DESCRIPTION
## Summary

- Added virtual scrolling hooks (`useScrollViewport`, `useVisibleChunkIndices`, `useClipViewportOrigin`) to `llms.txt`
- Added full TypeScript interface documentation for `ScrollViewport`, `ScrollViewportProvider`, `ClipViewportOriginProvider`, and selector hooks to `llm-reference.md`
- Expanded `PROJECT_STRUCTURE.md` with virtual scrolling architecture details (contexts listing, provider chain, overscan buffer, affected components)

## Test plan

- [x] `pnpm --filter website build` passes (no broken links, only pre-existing CSS calc warnings)
- [ ] Verify rendered docs at `/docs/api/llm-reference` show the new Virtual Scrolling section
- [ ] Verify `/llms.txt` includes the virtual scrolling hooks subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)