### PR TITLE
chore: set barGap to 0 on all examples except styling page

### DIFF
--- a/website/src/components/examples/FadesExample.tsx
+++ b/website/src/components/examples/FadesExample.tsx
@@ -111,7 +111,7 @@ function FadePlayer({ fadeType, title, description }: FadePlayerProps) {
     <FadeCard>
       <FadeTitle>{title}</FadeTitle>
       <FadeDescription>{description}</FadeDescription>
-      <WaveformPlaylistProvider tracks={tracks} samplesPerPixel={512} mono theme={theme} barWidth={4} barGap={2}>
+      <WaveformPlaylistProvider tracks={tracks} samplesPerPixel={512} mono theme={theme} barWidth={4} barGap={0}>
         <Controls>
           <PlayButton />
           <PauseButton />

--- a/website/src/components/examples/MediaElementExample.tsx
+++ b/website/src/components/examples/MediaElementExample.tsx
@@ -221,7 +221,7 @@ export function MediaElementExample() {
         waveHeight={120}
         theme={theme}
         barWidth={2}
-        barGap={1}
+        barGap={0}
       >
         <PlaybackControls />
         <MediaElementWaveform />

--- a/website/src/components/examples/MobileAnnotationsExample.tsx
+++ b/website/src/components/examples/MobileAnnotationsExample.tsx
@@ -419,7 +419,7 @@ export function MobileAnnotationsExample() {
       theme={theme}
       timescale
       barWidth={4}
-      barGap={2}
+      barGap={0}
       annotationList={{
         annotations: annotations,
         editable: true,

--- a/website/src/components/examples/MobileMultiClipExample.tsx
+++ b/website/src/components/examples/MobileMultiClipExample.tsx
@@ -334,7 +334,7 @@ export function MobileMultiClipExample() {
         theme={theme}
         timescale
         barWidth={4}
-        barGap={2}
+        barGap={0}
       >
         <PlaylistWithDrag tracks={tracks} onTracksChange={setTracks} />
       </WaveformPlaylistProvider>

--- a/website/src/components/examples/MultiClipExample.tsx
+++ b/website/src/components/examples/MultiClipExample.tsx
@@ -310,7 +310,7 @@ export function MultiClipExample() {
       theme={theme}
       timescale
       barWidth={4}
-      barGap={2}
+      barGap={0}
     >
       <PlaylistWithDrag tracks={tracks} onTracksChange={setTracks} loading={loading} loadedCount={loadedCount} totalCount={audioFiles.length} />
     </WaveformPlaylistProvider>

--- a/website/src/components/examples/NewTracksExample.tsx
+++ b/website/src/components/examples/NewTracksExample.tsx
@@ -202,7 +202,7 @@ export function NewTracksExample() {
           theme={theme}
           timescale
           barWidth={4}
-          barGap={2}
+          barGap={0}
         >
           <Controls>
             <ControlGroup>

--- a/website/src/components/examples/StemTracksExample.tsx
+++ b/website/src/components/examples/StemTracksExample.tsx
@@ -131,7 +131,7 @@ export function StemTracksExample() {
         theme={theme}
         timescale
         barWidth={4}
-        barGap={2}
+        barGap={0}
       >
         <PlaybackShortcuts />
         <Controls>

--- a/website/src/components/examples/StereoExample.tsx
+++ b/website/src/components/examples/StereoExample.tsx
@@ -70,7 +70,7 @@ export function StereoExample() {
       samplesPerPixel={1000}
       theme={theme}
       barWidth={2}
-      barGap={1}
+      barGap={0}
       controls={{ show: true, width: 200 }}
     >
       <Controls>

--- a/website/src/components/examples/WaveformDataExample.tsx
+++ b/website/src/components/examples/WaveformDataExample.tsx
@@ -239,7 +239,7 @@ export function WaveformDataExample() {
         theme={theme}
         timescale
         barWidth={4}
-        barGap={2}
+        barGap={0}
       >
         <Controls>
           <ControlGroup>


### PR DESCRIPTION
## Summary

- Set `barGap={0}` on 9 example pages to prevent flickering during browser repaints
- StylingExample left unchanged — it showcases `barGap` customization with various values

## Changed examples

StereoExample, StemTracksExample, WaveformDataExample, FadesExample, MobileAnnotationsExample, NewTracksExample, MultiClipExample, MobileMultiClipExample, MediaElementExample

## Test plan

- [ ] Visually verify examples render without flickering
- [ ] Verify StylingExample still shows barGap variations

🤖 Generated with [Claude Code](https://claude.com/claude-code)