### PR TITLE
docs: update for engine state ownership and clip operations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,17 @@
 
 Multi-track audio editor roadmap for waveform-playlist.
 
-**Branch:** `main` | **Last Updated:** 2026-02-01
+**Branch:** `main` | **Last Updated:** 2026-02-28
+
+---
+
+## ✅ Recently Completed
+
+### Engine State Ownership & Clip Operations (2026-02-28)
+
+- **PR #291:** Engine as single source of truth for selection, loop, volume, selectedTrackId
+- **PR #292:** Extracted useSelectionState, useLoopState, useSelectedTrack, useZoomControls, useMasterVolume hooks with onEngineState() pattern
+- **PR #293:** Delegated clip operations (move, trim, split) to PlaylistEngine — hooks call engine methods instead of inline mutation logic. Added `onTracksChange` prop, `isDraggingRef` for trim safety, `onDragCancel` handler.
 
 ---
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -20,7 +20,8 @@ waveform-playlist is a React component library for building browser-based audio 
 
 - `@waveform-playlist/browser` — Main package: React components, hooks, effects
 - `@waveform-playlist/core` — Data model: ClipTrack, AudioClip, sample-based math
-- `@waveform-playlist/playout` — Audio engine: Tone.js playback, global AudioContext
+- `@waveform-playlist/engine` — Framework-agnostic timeline engine: PlaylistEngine class, pure clip/timeline operations, event emitter. Owns selection, loop, zoom, volume, selectedTrackId, and clip mutation state.
+- `@waveform-playlist/playout` — Audio playback: Tone.js adapter (implements PlayoutAdapter from engine), global AudioContext
 - `@waveform-playlist/ui-components` — Styled primitives, theming, virtual scrolling contexts, playhead components, PlaylistErrorBoundary
 - `@waveform-playlist/annotations` — Annotation parsing, rendering, keyboard controls
 - `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter, integrated recording hook
@@ -58,7 +59,7 @@ Both providers use React Context with 4 split contexts for performance.
 1. **usePlaybackAnimation()** — High-frequency: isPlaying, currentTime, timing refs
 2. **usePlaylistState()** — Medium-frequency: selection, loop, annotations, settings
 3. **usePlaylistControls()** — Stable: play/pause/stop/seekTo, track controls, zoom, settings setters
-4. **usePlaylistData()** — Stable: duration, tracks, trackStates, display config, isReady
+4. **usePlaylistData()** — Stable: duration, tracks, trackStates, playoutRef (PlaylistEngine), isDraggingRef, display config, isReady
 
 **MediaElementPlaylistProvider** (single-track, HTMLAudioElement):
 1. **useMediaElementAnimation()** — isPlaying, currentTime
@@ -72,8 +73,8 @@ Both providers use React Context with 4 split contexts for performance.
 - `useDynamicTracks()` — Imperative hook for runtime track additions (drag-and-drop, file picker). Creates placeholder tracks instantly while audio decodes in parallel
 - `useDynamicEffects()` — Master effects chain with runtime add/remove/parameter updates
 - `useTrackDynamicEffects()` — Per-track effects management
-- `useClipDragHandlers(opts)` — Drag-to-move and boundary trimming with collision detection
-- `useClipSplitting(opts)` — Split clips at playhead position
+- `useClipDragHandlers(opts)` — Drag-to-move and boundary trimming, delegates to engine.moveClip()/trimClip()
+- `useClipSplitting(opts)` — Split clips at playhead, delegates to engine.splitClip()
 - `useExportWav()` — Offline WAV export with effects support
 - `useKeyboardShortcuts(opts)` — Custom keyboard shortcuts
 - `usePlaybackShortcuts(opts)` — Default playback shortcuts (Space, Escape, 0)
@@ -93,7 +94,7 @@ Both providers use React Context with 4 split contexts for performance.
 
 ## Key Components
 
-- `WaveformPlaylistProvider` — Multi-track provider (Web Audio API / Tone.js). Props: tracks, timescale, controls, theme, effects, annotationList, onAnnotationsChange, onReady, barWidth, barGap, waveHeight, samplesPerPixel, zoomLevels
+- `WaveformPlaylistProvider` — Multi-track provider (Web Audio API / Tone.js). Props: tracks, timescale, controls, theme, effects, annotationList, onAnnotationsChange, onTracksChange, onReady, barWidth, barGap, waveHeight, samplesPerPixel, zoomLevels, mono
 - `MediaElementPlaylistProvider` — Single-track provider (HTMLAudioElement). Props: track, playbackRate, timescale, controls, theme, annotationList, onAnnotationsChange, onReady, barWidth, barGap, waveHeight, samplesPerPixel. Use for language learning, podcasts, single-track viewers.
 - `Waveform` — Main visualization. Props: showClipHeaders, interactiveClips, renderPlayhead, renderTrackControls, showFades, touchOptimized
 - Buttons: PlayButton, PauseButton, StopButton, RewindButton, FastForwardButton, LoopButton, SetLoopRegionButton, ZoomInButton, ZoomOutButton, ExportWavButton


### PR DESCRIPTION
## Summary

- **PROJECT_STRUCTURE.md**: Added `@waveform-playlist/engine` package section, updated data flow diagrams to show PlaylistEngine in the audio chain, added clip mutation flow diagram, updated hooks listing with engine-delegation hooks (useSelectionState, useLoopState, useSelectedTrack, etc.), fixed playoutRef type from TonePlayout to PlaylistEngine
- **llm-reference.md**: Fixed PlaylistDataContextValue (added isDraggingRef, mono, corrected playoutRef type), updated useClipDragHandlers interface (added engineRef, isDraggingRef, onDragCancel), updated useClipSplitting interface (removed stale onTracksChange, added engineRef), added engine types section, added onTracksChange to provider props
- **llms.txt**: Added engine package to packages list, updated hook descriptions to mention engine delegation, added onTracksChange and mono to provider props
- **TODO.md**: Added "Recently Completed" section for PRs #291-#293

## Test plan

- [x] `pnpm --filter website build` passes (no broken links)
- [ ] Verify rendered docs on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)