### PR TITLE
fix(browser): dedupe waveform peak generation by AudioBuffer

### DIFF
--- a/packages/browser/src/hooks/useWaveformDataCache.ts
+++ b/packages/browser/src/hooks/useWaveformDataCache.ts
@@ -161,6 +161,10 @@ export function useWaveformDataCache(
 
     return () => {
       cancelled = true;
+      inflightByBufferRef.current = new WeakMap();
+      subscribersByBufferRef.current = new WeakMap();
+      pendingCountRef.current = 0;
+      setIsGenerating(false);
     };
   }, [tracks, baseScale, getWorker]);
 


### PR DESCRIPTION
## Issue
In `@waveform-playlist/browser`, rapid clip/track updates on large timelines can trigger `RangeError: Array buffer allocation failed` during waveform peak generation, especially when rendering is still catching up and new updates keep arriving.

### Common use case
- A long recording is loaded into one track.
- The app splits that track into many clips (for example sentence/segment clips).
- Clips share the same underlying `AudioBuffer`.
- Rapid clip list updates (edits/re-segmentation/state sync) can repeatedly schedule peak generation for the same source buffer.

## Root cause
Peak generation was effectively keyed per clip, not per source `AudioBuffer`. Under bursty updates this caused:
- duplicate worker jobs for the same audio source
- repeated full-channel cloning (`Float32Array.slice()`) before worker posting
- memory spikes and eventual allocation failure

<img width="1135" height="305" alt="Screenshot 2026-03-04 at 9 59 33 AM" src="https://github.com/user-attachments/assets/ee17b67a-ce59-4a56-b767-deef02d3a26a" />

## Fix
Updated `useWaveformDataCache` to dedupe by buffer identity and share work/results:
- cache generated peaks with `WeakMap<AudioBuffer, WaveformData>`
- dedupe in-flight generation with `WeakMap<AudioBuffer, Promise<void>>`
- track subscribers by buffer and fan out one generated `WaveformData` to all clip IDs using that buffer
- keep worker lifecycle behavior intact and harden effect cleanup by resetting transient in-flight/subscriber state

## Result
For clips sharing the same `AudioBuffer`, peak data is generated once per buffer and reused across clips, significantly reducing duplicate allocation pressure during rapid timeline updates.