### PR TITLE
ci: add multi-React version unit testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -28,3 +28,38 @@ jobs:
 
       - name: Lint and check formatting
         run: pnpm lint
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        react-version: [18, 19]
+    name: Unit Tests (React ${{ matrix.react-version }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Override React version
+        if: matrix.react-version == 19
+        run: |
+          pnpm add -Dw react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
+          pnpm add -D --filter @waveform-playlist/browser react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
+          pnpm add -D --filter @waveform-playlist/ui-components react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run unit tests
+        run: pnpm test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,19 @@ jobs:
       - name: Override React version
         if: matrix.react-version == 19
         run: |
-          pnpm add -Dw react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
-          pnpm add -D --filter @waveform-playlist/browser react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
-          pnpm add -D --filter @waveform-playlist/ui-components react@^19.0.0 react-dom@^19.0.0 @types/react@^19.0.0 @types/react-dom@^19.0.0
+          node -e "
+            const pkg = require('./package.json');
+            pkg.pnpm = pkg.pnpm || {};
+            pkg.pnpm.overrides = {
+              ...pkg.pnpm.overrides,
+              'react': '^19.0.0',
+              'react-dom': '^19.0.0',
+              '@types/react': '^19.0.0',
+              '@types/react-dom': '^19.0.0'
+            };
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          pnpm install --no-frozen-lockfile
 
       - name: Build packages
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check": "prettier --check \"packages/**/src/**/*.{ts,tsx}\"",
     "lint": "prettier --check \"packages/**/src/**/*.{ts,tsx}\" && eslint \"packages/**/src/**/*.{ts,tsx}\"",
     "website": "pnpm --filter website start",
+    "test:unit": "pnpm -r --filter './packages/*' --if-present run test",
     "website:build": "pnpm --filter website build",
     "version:bump": "node scripts/bump-version.js"
   },

--- a/packages/ui-components/src/components/Playlist.tsx
+++ b/packages/ui-components/src/components/Playlist.tsx
@@ -98,10 +98,10 @@ const ClickOverlay = styled.div<ClickOverlayProps>`
 
 export interface PlaylistProps {
   readonly theme: DefaultTheme;
-  readonly children?: JSX.Element | JSX.Element[];
+  readonly children?: React.ReactNode;
   readonly backgroundColor?: string;
   readonly timescaleBackgroundColor?: string;
-  readonly timescale?: JSX.Element;
+  readonly timescale?: React.ReactElement;
   readonly timescaleWidth?: number;
   readonly tracksWidth?: number;
   readonly controlsWidth?: number;


### PR DESCRIPTION
## Summary
- Add `unit-tests` CI job with a React version matrix (`[18, 19]`)
- React 18 tests use the lockfile as-is; React 19 overrides `react`, `react-dom`, and `@types/react*` in browser and ui-components packages
- Bump Node.js to 24 for all CI jobs
- Add root `test:unit` script (`pnpm -r --filter './packages/*' --if-present run test`)

## Test plan
- [ ] `validate` job passes (build + lint)
- [ ] `Unit Tests (React 18)` job passes
- [ ] `Unit Tests (React 19)` job passes (build + typecheck + vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)