### PR TITLE
test: tier 3 tests + extract pure logic from hooks/classes

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "pnpm typecheck && vite build",
     "dev": "vite build --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "keywords": [
     "waveform",

--- a/packages/browser/src/__tests__/ClipCollisionModifier.test.ts
+++ b/packages/browser/src/__tests__/ClipCollisionModifier.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@waveform-playlist/engine', () => ({
+  constrainClipDrag: vi.fn(),
+}));
+
+// Must import after mock setup
+import { ClipCollisionModifier } from '../modifiers/ClipCollisionModifier';
+import { constrainClipDrag } from '@waveform-playlist/engine';
+import type { ClipTrack, AudioClip } from '@waveform-playlist/core';
+
+const mockedConstrainClipDrag = vi.mocked(constrainClipDrag);
+
+/** Helper to build a minimal AudioClip for testing. */
+function makeClip(overrides: Partial<AudioClip> & { id: string }): AudioClip {
+  return {
+    startSample: 0,
+    durationSamples: 44100,
+    offsetSamples: 0,
+    ...overrides,
+  } as AudioClip;
+}
+
+/** Helper to build a minimal ClipTrack for testing. */
+function makeTrack(clips: AudioClip[]): ClipTrack {
+  return {
+    id: 'track-1',
+    name: 'Track 1',
+    clips,
+    muted: false,
+    soloed: false,
+  } as ClipTrack;
+}
+
+/** Creates a modifier instance with the given options. */
+function createModifier(options?: { tracks: ClipTrack[]; samplesPerPixel: number }) {
+  // ClipCollisionModifier extends Modifier which requires a manager.
+  // We only test apply(), so pass a minimal stub as the manager.
+  const manager = {} as ConstructorParameters<typeof ClipCollisionModifier>[0];
+  const modifier = new ClipCollisionModifier(manager, options);
+  return modifier;
+}
+
+/** Builds a DragOperation-like object that apply() consumes. */
+function makeOperation(overrides: {
+  transform?: { x: number; y: number };
+  sourceData?: Record<string, unknown> | null;
+}) {
+  const { transform = { x: 0, y: 0 }, sourceData } = overrides;
+  return {
+    transform,
+    source: sourceData === null ? null : sourceData ? { data: sourceData } : undefined,
+  } as Parameters<ClipCollisionModifier['apply']>[0];
+}
+
+describe('ClipCollisionModifier', () => {
+  beforeEach(() => {
+    mockedConstrainClipDrag.mockReset();
+  });
+
+  describe('boundary trim operations', () => {
+    it('returns zero transform when boundary is "left"', () => {
+      const clip = makeClip({ id: 'c1' });
+      const track = makeTrack([clip]);
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 1000,
+      });
+
+      const op = makeOperation({
+        transform: { x: 50, y: 10 },
+        sourceData: { boundary: 'left', trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 0, y: 0 });
+    });
+
+    it('returns zero transform when boundary is "right"', () => {
+      const clip = makeClip({ id: 'c1' });
+      const track = makeTrack([clip]);
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 1000,
+      });
+
+      const op = makeOperation({
+        transform: { x: -30, y: 5 },
+        sourceData: { boundary: 'right', trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 0, y: 0 });
+    });
+
+    it('does not call constrainClipDrag for boundary operations', () => {
+      const clip = makeClip({ id: 'c1' });
+      const track = makeTrack([clip]);
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 1000,
+      });
+
+      const op = makeOperation({
+        transform: { x: 100, y: 0 },
+        sourceData: { boundary: 'left', trackIndex: 0, clipIndex: 0 },
+      });
+
+      modifier.apply(op);
+      expect(mockedConstrainClipDrag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clip move operations', () => {
+    it('converts pixel delta to samples and back', () => {
+      const clip = makeClip({ id: 'c1', startSample: 0 });
+      const track = makeTrack([clip]);
+      const samplesPerPixel = 500;
+
+      // constrainClipDrag returns exactly what we give it (unconstrained)
+      mockedConstrainClipDrag.mockReturnValue(25000); // 50px * 500spp
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel,
+      });
+
+      const op = makeOperation({
+        transform: { x: 50, y: 10 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+
+      // deltaSamples = 50 * 500 = 25000
+      expect(mockedConstrainClipDrag).toHaveBeenCalledWith(clip, 25000, expect.any(Array), 0);
+
+      // result.x = 25000 / 500 = 50
+      expect(result.x).toBe(50);
+      // y is always locked to 0 for clip moves
+      expect(result.y).toBe(0);
+    });
+
+    it('constrains movement and converts back to pixels', () => {
+      const clip = makeClip({ id: 'c1', startSample: 1000 });
+      const track = makeTrack([clip]);
+      const samplesPerPixel = 100;
+
+      // Constrain: requested -2000 samples, but limited to -1000
+      mockedConstrainClipDrag.mockReturnValue(-1000);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel,
+      });
+
+      const op = makeOperation({
+        transform: { x: -20, y: 5 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+
+      expect(mockedConstrainClipDrag).toHaveBeenCalledWith(
+        clip,
+        -2000, // -20 * 100
+        expect.any(Array),
+        0
+      );
+
+      // Constrained: -1000 / 100 = -10
+      expect(result.x).toBe(-10);
+      expect(result.y).toBe(0);
+    });
+
+    it('sorts clips by startSample before passing to constrainClipDrag', () => {
+      const clipA = makeClip({ id: 'a', startSample: 88200 });
+      const clipB = makeClip({ id: 'b', startSample: 0 });
+      const clipC = makeClip({ id: 'c', startSample: 44100 });
+
+      // Track has clips in non-sorted order
+      const track = makeTrack([clipA, clipB, clipC]);
+
+      mockedConstrainClipDrag.mockReturnValue(0);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 100,
+      });
+
+      // Drag clipA (index 0 in the track's clips array)
+      const op = makeOperation({
+        transform: { x: 10, y: 0 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      modifier.apply(op);
+
+      // Sorted order: B(0), C(44100), A(88200)
+      const sortedClips = mockedConstrainClipDrag.mock.calls[0][2];
+      expect(sortedClips[0].id).toBe('b');
+      expect(sortedClips[1].id).toBe('c');
+      expect(sortedClips[2].id).toBe('a');
+
+      // clipA is at sortedIndex 2
+      const sortedIndex = mockedConstrainClipDrag.mock.calls[0][3];
+      expect(sortedIndex).toBe(2);
+    });
+
+    it('passes correct sortedIndex when dragging a middle clip', () => {
+      const clipA = makeClip({ id: 'a', startSample: 0, durationSamples: 10000 });
+      const clipB = makeClip({ id: 'b', startSample: 20000, durationSamples: 10000 });
+      const clipC = makeClip({ id: 'c', startSample: 40000, durationSamples: 10000 });
+
+      const track = makeTrack([clipA, clipB, clipC]);
+      mockedConstrainClipDrag.mockReturnValue(0);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 100,
+      });
+
+      // Drag clipB (index 1)
+      const op = makeOperation({
+        transform: { x: 5, y: 0 },
+        sourceData: { trackIndex: 0, clipIndex: 1 },
+      });
+
+      modifier.apply(op);
+
+      // clipB is at sorted index 1 (clips are already sorted)
+      const sortedIndex = mockedConstrainClipDrag.mock.calls[0][3];
+      expect(sortedIndex).toBe(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns original transform when source is null', () => {
+      const modifier = createModifier({
+        tracks: [],
+        samplesPerPixel: 100,
+      });
+
+      const op = makeOperation({
+        transform: { x: 42, y: 7 },
+        sourceData: null,
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 42, y: 7 });
+      expect(mockedConstrainClipDrag).not.toHaveBeenCalled();
+    });
+
+    it('returns original transform when source.data is missing', () => {
+      const modifier = createModifier({
+        tracks: [],
+        samplesPerPixel: 100,
+      });
+
+      // source exists but data is falsy
+      const op = {
+        transform: { x: 42, y: 7 },
+        source: { data: undefined },
+      } as unknown as Parameters<ClipCollisionModifier['apply']>[0];
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 42, y: 7 });
+    });
+
+    it('returns original transform when options are not set', () => {
+      const modifier = createModifier(undefined);
+
+      const op = makeOperation({
+        transform: { x: 10, y: 3 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 10, y: 3 });
+      expect(mockedConstrainClipDrag).not.toHaveBeenCalled();
+    });
+
+    it('returns original transform when trackIndex is out of bounds', () => {
+      const clip = makeClip({ id: 'c1' });
+      const track = makeTrack([clip]);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 100,
+      });
+
+      const op = makeOperation({
+        transform: { x: 15, y: 2 },
+        sourceData: { trackIndex: 5, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 15, y: 2 });
+      expect(mockedConstrainClipDrag).not.toHaveBeenCalled();
+    });
+
+    it('returns original transform when clipIndex is out of bounds', () => {
+      const clip = makeClip({ id: 'c1' });
+      const track = makeTrack([clip]);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 100,
+      });
+
+      const op = makeOperation({
+        transform: { x: 15, y: 2 },
+        sourceData: { trackIndex: 0, clipIndex: 99 },
+      });
+
+      const result = modifier.apply(op);
+      expect(result).toEqual({ x: 15, y: 2 });
+      expect(mockedConstrainClipDrag).not.toHaveBeenCalled();
+    });
+
+    it('handles zero pixel transform', () => {
+      const clip = makeClip({ id: 'c1', startSample: 1000 });
+      const track = makeTrack([clip]);
+
+      mockedConstrainClipDrag.mockReturnValue(0);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel: 256,
+      });
+
+      const op = makeOperation({
+        transform: { x: 0, y: 0 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+
+      expect(mockedConstrainClipDrag).toHaveBeenCalledWith(clip, 0, [clip], 0);
+      expect(result).toEqual({ x: 0, y: 0 });
+    });
+
+    it('handles fractional pixel result from sample conversion', () => {
+      const clip = makeClip({ id: 'c1', startSample: 0 });
+      const track = makeTrack([clip]);
+      const samplesPerPixel = 300;
+
+      // Return a value that does not divide evenly by samplesPerPixel
+      mockedConstrainClipDrag.mockReturnValue(1000);
+
+      const modifier = createModifier({
+        tracks: [track],
+        samplesPerPixel,
+      });
+
+      const op = makeOperation({
+        transform: { x: 10, y: 0 },
+        sourceData: { trackIndex: 0, clipIndex: 0 },
+      });
+
+      const result = modifier.apply(op);
+
+      // 1000 / 300 = 3.333...
+      expect(result.x).toBeCloseTo(1000 / 300);
+      expect(result.y).toBe(0);
+    });
+  });
+});

--- a/packages/browser/src/__tests__/boundaryTrim.test.ts
+++ b/packages/browser/src/__tests__/boundaryTrim.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from 'vitest';
+import type { AudioClip } from '@waveform-playlist/core';
+import { calculateBoundaryTrim } from '../utils/boundaryTrim';
+
+const SAMPLE_RATE = 44100;
+const SAMPLES_PER_PIXEL = 1000;
+
+function makeClip(
+  overrides: Partial<AudioClip> & {
+    id: string;
+    startSample: number;
+    durationSamples: number;
+  }
+): AudioClip {
+  return {
+    offsetSamples: 0,
+    sampleRate: SAMPLE_RATE,
+    sourceDurationSamples: 441000, // 10 seconds of audio
+    gain: 1,
+    ...overrides,
+  };
+}
+
+describe('calculateBoundaryTrim', () => {
+  describe('zero delta returns unchanged values', () => {
+    it('left boundary with zero delta', () => {
+      const clip = makeClip({ id: 'c1', startSample: 44100, durationSamples: 88200 });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 0,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'left',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(originalClip.startSample);
+      expect(result.durationSamples).toBe(originalClip.durationSamples);
+      expect(result.offsetSamples).toBe(originalClip.offsetSamples);
+    });
+
+    it('right boundary with zero delta', () => {
+      const clip = makeClip({ id: 'c1', startSample: 44100, durationSamples: 88200 });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 0,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(originalClip.startSample);
+      expect(result.durationSamples).toBe(originalClip.durationSamples);
+      expect(result.offsetSamples).toBe(originalClip.offsetSamples);
+    });
+  });
+
+  describe('left boundary drag', () => {
+    it('dragging right increases offset and startSample, decreases duration', () => {
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 44100,
+        durationSamples: 88200,
+        offsetSamples: 0,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag right by 10 pixels = 10000 samples
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 10,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'left',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(44100 + 10000);
+      expect(result.durationSamples).toBe(88200 - 10000);
+      expect(result.offsetSamples).toBe(0 + 10000);
+    });
+
+    it('dragging left decreases offset and startSample, increases duration', () => {
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 44100,
+        durationSamples: 44100,
+        offsetSamples: 44100,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag left by 10 pixels = -10000 samples
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: -10,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'left',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(44100 - 10000);
+      expect(result.durationSamples).toBe(44100 + 10000);
+      expect(result.offsetSamples).toBe(44100 - 10000);
+    });
+  });
+
+  describe('right boundary drag', () => {
+    it('dragging right increases only durationSamples', () => {
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 44100,
+        offsetSamples: 0,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag right by 10 pixels = 10000 samples
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 10,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(0);
+      expect(result.durationSamples).toBe(44100 + 10000);
+      expect(result.offsetSamples).toBe(0);
+    });
+
+    it('dragging left decreases only durationSamples', () => {
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 88200,
+        offsetSamples: 0,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag left by 10 pixels = -10000 samples
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: -10,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.startSample).toBe(0);
+      expect(result.durationSamples).toBe(88200 - 10000);
+      expect(result.offsetSamples).toBe(0);
+    });
+  });
+
+  describe('minimum duration constraint', () => {
+    it('left boundary cannot shrink clip below minimum duration', () => {
+      // Minimum duration = floor(0.1 * 44100) = 4410 samples
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 10000,
+        offsetSamples: 0,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Try to drag right by 100 pixels = 100000 samples (far exceeds clip duration)
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 100,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'left',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      const minDuration = Math.floor(0.1 * SAMPLE_RATE); // 4410
+      expect(result.durationSamples).toBe(minDuration);
+      // The constrained delta = durationSamples - minDuration = 10000 - 4410 = 5590
+      expect(result.startSample).toBe(0 + (10000 - minDuration));
+      expect(result.offsetSamples).toBe(0 + (10000 - minDuration));
+    });
+
+    it('right boundary cannot shrink clip below minimum duration', () => {
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 10000,
+        offsetSamples: 0,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Try to drag left by 100 pixels = -100000 samples (far exceeds clip duration)
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: -100,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      const minDuration = Math.floor(0.1 * SAMPLE_RATE); // 4410
+      expect(result.durationSamples).toBe(minDuration);
+      expect(result.startSample).toBe(0);
+      expect(result.offsetSamples).toBe(0);
+    });
+  });
+
+  describe('offset cannot go below 0', () => {
+    it('left boundary drag left is clamped when offset would go negative', () => {
+      // Clip with offsetSamples = 5000, so dragging left by more than 5000 samples
+      // would push offset below 0
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 44100,
+        durationSamples: 44100,
+        offsetSamples: 5000,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag left by 10 pixels = -10000 samples, but offset is only 5000
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: -10,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'left',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      // Constrained delta should be -5000 (clamped by offset >= 0)
+      expect(result.offsetSamples).toBe(0);
+      expect(result.startSample).toBe(44100 - 5000);
+      expect(result.durationSamples).toBe(44100 + 5000);
+    });
+  });
+
+  describe('duration cannot exceed source audio length', () => {
+    it('right boundary drag right is clamped by source duration', () => {
+      // sourceDurationSamples = 441000, offset = 0, duration = 400000
+      // Max expansion = 441000 - 0 - 400000 = 41000 samples
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 400000,
+        offsetSamples: 0,
+        sourceDurationSamples: 441000,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag right by 100 pixels = 100000 samples, but only 41000 available
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 100,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      expect(result.durationSamples).toBe(441000); // offset + duration = sourceDuration
+      expect(result.startSample).toBe(0);
+      expect(result.offsetSamples).toBe(0);
+    });
+
+    it('right boundary drag right is clamped by source duration with offset', () => {
+      // sourceDurationSamples = 441000, offset = 100000, duration = 200000
+      // Max expansion = 441000 - 100000 - 200000 = 141000 samples
+      const clip = makeClip({
+        id: 'c1',
+        startSample: 0,
+        durationSamples: 200000,
+        offsetSamples: 100000,
+        sourceDurationSamples: 441000,
+      });
+      const originalClip = {
+        startSample: clip.startSample,
+        durationSamples: clip.durationSamples,
+        offsetSamples: clip.offsetSamples,
+      };
+
+      // Drag right by 200 pixels = 200000 samples, but only 141000 available
+      const result = calculateBoundaryTrim({
+        originalClip,
+        clip,
+        pixelDelta: 200,
+        samplesPerPixel: SAMPLES_PER_PIXEL,
+        sampleRate: SAMPLE_RATE,
+        boundary: 'right',
+        sortedClips: [clip],
+        sortedIndex: 0,
+      });
+
+      // offset + duration should equal sourceDuration
+      expect(result.durationSamples).toBe(441000 - 100000);
+      expect(result.offsetSamples).toBe(100000);
+    });
+  });
+});

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -5,8 +5,8 @@ import type {
   DragEndEvent as DragEndCallback,
 } from '@dnd-kit/abstract';
 import type { ClipTrack } from '@waveform-playlist/core';
-import { constrainBoundaryTrim } from '@waveform-playlist/engine';
 import type { PlaylistEngine } from '@waveform-playlist/engine';
+import { calculateBoundaryTrim } from '../utils/boundaryTrim';
 
 interface UseClipDragHandlersOptions {
   tracks: ClipTrack[];
@@ -138,7 +138,6 @@ export function useClipDragHandlers({
       const currentX = event.to?.x ?? event.operation.position.current.x;
       const rawDeltaX = currentX - event.operation.position.initial.x;
       const sampleDelta = rawDeltaX * samplesPerPixel;
-      const MIN_DURATION_SAMPLES = Math.floor(0.1 * sampleRate); // 0.1 seconds minimum
 
       // Get original clip state (stored on drag start)
       const originalClip = originalClipStateRef.current;
@@ -153,55 +152,23 @@ export function useClipDragHandlers({
         const newClips = track.clips.map((clip, cIdx) => {
           if (cIdx !== clipIndex) return clip;
 
-          if (boundary === 'left') {
-            // Use constrainBoundaryTrim from engine for the left boundary.
-            // Build a temporary clip with original state for constraint calculation.
-            const tempClip = {
-              ...clip,
-              startSample: originalClip.startSample,
-              offsetSamples: originalClip.offsetSamples,
-              durationSamples: originalClip.durationSamples,
-            };
-            const constrainedDelta = constrainBoundaryTrim(
-              tempClip,
-              Math.floor(sampleDelta),
-              'left',
-              sortedClips,
-              sortedIndex,
-              MIN_DURATION_SAMPLES
-            );
+          const trimResult = calculateBoundaryTrim({
+            originalClip,
+            clip,
+            pixelDelta: rawDeltaX,
+            samplesPerPixel,
+            sampleRate,
+            boundary,
+            sortedClips,
+            sortedIndex,
+          });
 
-            const newOffsetSamples = originalClip.offsetSamples + constrainedDelta;
-            const newDurationSamples = originalClip.durationSamples - constrainedDelta;
-            const newStartSample = originalClip.startSample + constrainedDelta;
-
-            return {
-              ...clip,
-              offsetSamples: newOffsetSamples,
-              durationSamples: newDurationSamples,
-              startSample: newStartSample,
-            };
-          } else {
-            // Right boundary - use constrainBoundaryTrim from engine
-            const tempClip = {
-              ...clip,
-              startSample: originalClip.startSample,
-              offsetSamples: originalClip.offsetSamples,
-              durationSamples: originalClip.durationSamples,
-            };
-            const constrainedDelta = constrainBoundaryTrim(
-              tempClip,
-              Math.floor(sampleDelta),
-              'right',
-              sortedClips,
-              sortedIndex,
-              MIN_DURATION_SAMPLES
-            );
-
-            const newDurationSamples = originalClip.durationSamples + constrainedDelta;
-
-            return { ...clip, durationSamples: newDurationSamples };
-          }
+          return {
+            ...clip,
+            startSample: trimResult.startSample,
+            durationSamples: trimResult.durationSamples,
+            offsetSamples: trimResult.offsetSamples,
+          };
         });
 
         return { ...track, clips: newClips };

--- a/packages/browser/src/utils/boundaryTrim.ts
+++ b/packages/browser/src/utils/boundaryTrim.ts
@@ -1,0 +1,88 @@
+import type { AudioClip } from '@waveform-playlist/core';
+import { constrainBoundaryTrim } from '@waveform-playlist/engine';
+
+/**
+ * Result of a boundary trim calculation — the new clip dimensions
+ * after dragging a left or right boundary by a given pixel delta.
+ */
+export interface BoundaryTrimResult {
+  startSample: number;
+  durationSamples: number;
+  offsetSamples: number;
+}
+
+export interface CalculateBoundaryTrimParams {
+  /** The original clip state captured at drag start */
+  originalClip: Pick<AudioClip, 'startSample' | 'durationSamples' | 'offsetSamples'>;
+  /** The current clip with full AudioClip shape (used for constraint calculation) */
+  clip: AudioClip;
+  /** Raw pixel delta from drag start (positive = rightward) */
+  pixelDelta: number;
+  /** Samples per pixel (zoom level) */
+  samplesPerPixel: number;
+  /** Audio sample rate (used to compute minimum duration) */
+  sampleRate: number;
+  /** Which boundary is being dragged */
+  boundary: 'left' | 'right';
+  /** Clips on the same track, sorted by startSample (for collision detection) */
+  sortedClips: AudioClip[];
+  /** Index of the clip being trimmed within sortedClips */
+  sortedIndex: number;
+}
+
+/**
+ * Pure function that calculates new clip dimensions after a boundary trim drag.
+ *
+ * Converts a pixel delta to sample delta, constrains it via the engine's
+ * `constrainBoundaryTrim`, and applies the constrained delta to the original
+ * clip snapshot to produce new startSample, durationSamples, and offsetSamples.
+ *
+ * For left boundary: startSample and offsetSamples increase by the constrained delta,
+ * durationSamples decreases by the same amount.
+ *
+ * For right boundary: only durationSamples changes (increases by the constrained delta).
+ */
+export function calculateBoundaryTrim({
+  originalClip,
+  clip,
+  pixelDelta,
+  samplesPerPixel,
+  sampleRate,
+  boundary,
+  sortedClips,
+  sortedIndex,
+}: CalculateBoundaryTrimParams): BoundaryTrimResult {
+  const sampleDelta = pixelDelta * samplesPerPixel;
+  const MIN_DURATION_SAMPLES = Math.floor(0.1 * sampleRate);
+
+  // Build a temporary clip with original state for constraint calculation
+  const tempClip: AudioClip = {
+    ...clip,
+    startSample: originalClip.startSample,
+    offsetSamples: originalClip.offsetSamples,
+    durationSamples: originalClip.durationSamples,
+  };
+
+  const constrainedDelta = constrainBoundaryTrim(
+    tempClip,
+    Math.floor(sampleDelta),
+    boundary,
+    sortedClips,
+    sortedIndex,
+    MIN_DURATION_SAMPLES
+  );
+
+  if (boundary === 'left') {
+    return {
+      startSample: originalClip.startSample + constrainedDelta,
+      durationSamples: originalClip.durationSamples - constrainedDelta,
+      offsetSamples: originalClip.offsetSamples + constrainedDelta,
+    };
+  } else {
+    return {
+      startSample: originalClip.startSample,
+      durationSamples: originalClip.durationSamples + constrainedDelta,
+      offsetSamples: originalClip.offsetSamples,
+    };
+  }
+}

--- a/packages/loaders/src/__tests__/BlobLoader.test.ts
+++ b/packages/loaders/src/__tests__/BlobLoader.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { BlobLoader } from '../BlobLoader';
+import { LoaderState } from '../Loader';
+
+// Polyfill ProgressEvent for Node.js environment
+beforeAll(() => {
+  if (typeof globalThis.ProgressEvent === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).ProgressEvent = class ProgressEvent extends Event {
+      readonly lengthComputable: boolean;
+      readonly loaded: number;
+      readonly total: number;
+
+      constructor(
+        type: string,
+        init?: { lengthComputable?: boolean; loaded?: number; total?: number }
+      ) {
+        super(type);
+        this.lengthComputable = init?.lengthComputable ?? false;
+        this.loaded = init?.loaded ?? 0;
+        this.total = init?.total ?? 0;
+      }
+    };
+  }
+});
+
+// Fake AudioBuffer returned by mock decodeAudioData
+const fakeAudioBuffer = {
+  length: 44100,
+  duration: 1,
+  sampleRate: 44100,
+  numberOfChannels: 1,
+  getChannelData: () => new Float32Array(44100),
+  copyFromChannel: vi.fn(),
+  copyToChannel: vi.fn(),
+} as unknown as AudioBuffer;
+
+// Mock AudioContext with decodeAudioData
+function createMockAudioContext(options: { shouldDecode?: boolean } = {}): BaseAudioContext {
+  const { shouldDecode = true } = options;
+  return {
+    decodeAudioData: vi.fn().mockImplementation(() => {
+      if (shouldDecode) {
+        return Promise.resolve(fakeAudioBuffer);
+      }
+      return Promise.reject(new Error('Unable to decode audio data'));
+    }),
+  } as unknown as BaseAudioContext;
+}
+
+// ---- Mock FileReader ----
+
+type FREventHandler = (ev: ProgressEvent) => void;
+
+class MockFileReader {
+  result: ArrayBuffer | null = new ArrayBuffer(1024);
+
+  private listeners: Record<string, FREventHandler[]> = {};
+
+  addEventListener(event: string, handler: FREventHandler) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event].push(handler);
+  }
+
+  readAsArrayBuffer = vi.fn().mockImplementation(() => {
+    // Default: immediately fire load
+    this.fireLoad();
+  });
+
+  // Test helpers
+  fireProgress(loaded: number, total: number) {
+    const ev = new ProgressEvent('progress', {
+      lengthComputable: true,
+      loaded,
+      total,
+    });
+    this.listeners['progress']?.forEach((h) => h(ev));
+  }
+
+  fireLoad() {
+    const ev = new ProgressEvent('load');
+    this.listeners['load']?.forEach((h) => h(ev));
+  }
+
+  fireError() {
+    const ev = new ProgressEvent('error');
+    this.listeners['error']?.forEach((h) => h(ev));
+  }
+}
+
+let mockFileReaderInstance: MockFileReader;
+
+beforeEach(() => {
+  mockFileReaderInstance = new MockFileReader();
+  class StubFileReader {
+    constructor() {
+      return mockFileReaderInstance;
+    }
+  }
+  vi.stubGlobal('FileReader', StubFileReader);
+});
+
+describe('BlobLoader', () => {
+  describe('constructor', () => {
+    it('accepts a Blob and starts in UNINITIALIZED state', () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      expect(loader.getState()).toBe(LoaderState.UNINITIALIZED);
+      expect(loader.getAudioBuffer()).toBeUndefined();
+    });
+  });
+
+  describe('audio mime type validation', () => {
+    it('accepts audio/wav', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+
+    it('accepts audio/mp3', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/mp3' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+
+    it('accepts audio/ogg', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/ogg' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+
+    it('accepts audio/mpeg', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/mpeg' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+
+    it('accepts video/ogg (Firefox compatibility)', async () => {
+      const blob = new Blob(['fake audio'], { type: 'video/ogg' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+
+    it('rejects non-audio mime types (text/plain)', async () => {
+      const blob = new Blob(['not audio'], { type: 'text/plain' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      await expect(loader.load()).rejects.toThrow('Unsupported file type: text/plain');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Unsupported file type: text/plain',
+        })
+      );
+    });
+
+    it('rejects application/json', async () => {
+      const blob = new Blob(['{}'], { type: 'application/json' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      await expect(loader.load()).rejects.toThrow('Unsupported file type: application/json');
+    });
+
+    it('rejects video/mp4 (only video/ogg is allowed)', async () => {
+      const blob = new Blob(['video data'], { type: 'video/mp4' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      await expect(loader.load()).rejects.toThrow('Unsupported file type: video/mp4');
+    });
+
+    it('rejects empty mime type', async () => {
+      const blob = new Blob(['data'], { type: '' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      await expect(loader.load()).rejects.toThrow('Unsupported file type: ');
+    });
+  });
+
+  describe('FileReader progress events', () => {
+    it('emits loadprogress with percentage', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const progressSpy = vi.fn();
+      loader.on('loadprogress', progressSpy);
+
+      mockFileReaderInstance.readAsArrayBuffer.mockImplementation(() => {
+        mockFileReaderInstance.fireProgress(256, 1024);
+        mockFileReaderInstance.fireProgress(1024, 1024);
+        mockFileReaderInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(progressSpy).toHaveBeenCalledTimes(2);
+      expect(progressSpy).toHaveBeenNthCalledWith(1, 25, blob);
+      expect(progressSpy).toHaveBeenNthCalledWith(2, 100, blob);
+    });
+  });
+
+  describe('FileReader errors', () => {
+    it('rejects and emits error when FileReader fails', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockFileReaderInstance.readAsArrayBuffer.mockImplementation(() => {
+        mockFileReaderInstance.fireError();
+      });
+
+      await expect(loader.load()).rejects.toThrow('Failed to read audio file');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Failed to read audio file' })
+      );
+    });
+  });
+
+  describe('state transitions', () => {
+    it('transitions through LOADING -> DECODING -> FINISHED on success', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const stateChanges: LoaderState[] = [];
+      loader.on('audiorequeststatechange', (state) => {
+        stateChanges.push(state);
+      });
+
+      mockFileReaderInstance.readAsArrayBuffer.mockImplementation(() => {
+        // Progress triggers LOADING state transition
+        mockFileReaderInstance.fireProgress(512, 1024);
+        mockFileReaderInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(stateChanges).toEqual([
+        LoaderState.LOADING,
+        LoaderState.DECODING,
+        LoaderState.FINISHED,
+      ]);
+    });
+
+    it('transitions to DECODING -> ERROR when decoding fails', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext({ shouldDecode: false });
+      const loader = new BlobLoader(blob, ac);
+
+      const stateChanges: LoaderState[] = [];
+      loader.on('audiorequeststatechange', (state) => {
+        stateChanges.push(state);
+      });
+      loader.on('error', () => {});
+
+      await expect(loader.load()).rejects.toThrow('Unable to decode audio data');
+
+      expect(stateChanges).toEqual([LoaderState.DECODING, LoaderState.ERROR]);
+    });
+
+    it('does not transition states on unsupported mime type', async () => {
+      const blob = new Blob(['not audio'], { type: 'image/png' });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(blob, ac);
+
+      const stateChanges: LoaderState[] = [];
+      loader.on('audiorequeststatechange', (state) => {
+        stateChanges.push(state);
+      });
+      loader.on('error', () => {});
+
+      await expect(loader.load()).rejects.toThrow('Unsupported file type');
+
+      // No state transitions occur — rejected immediately
+      expect(stateChanges).toEqual([]);
+      expect(loader.getState()).toBe(LoaderState.UNINITIALIZED);
+    });
+  });
+
+  describe('decode failure', () => {
+    it('emits error event and sets ERROR state when decodeAudioData fails', async () => {
+      const blob = new Blob(['fake audio'], { type: 'audio/wav' });
+      const ac = createMockAudioContext({ shouldDecode: false });
+      const loader = new BlobLoader(blob, ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      await expect(loader.load()).rejects.toThrow();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Unable to decode audio data' })
+      );
+      expect(loader.getState()).toBe(LoaderState.ERROR);
+    });
+  });
+
+  describe('File input (File extends Blob)', () => {
+    it('works with File objects that have audio mime type', async () => {
+      const file = new File(['fake audio'], 'track.mp3', {
+        type: 'audio/mp3',
+      });
+      const ac = createMockAudioContext();
+      const loader = new BlobLoader(file, ac);
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+      expect(mockFileReaderInstance.readAsArrayBuffer).toHaveBeenCalledWith(file);
+    });
+  });
+});

--- a/packages/loaders/src/__tests__/XHRLoader.test.ts
+++ b/packages/loaders/src/__tests__/XHRLoader.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { XHRLoader } from '../XHRLoader';
+import { LoaderState } from '../Loader';
+
+// Polyfill ProgressEvent for Node.js environment
+beforeAll(() => {
+  if (typeof globalThis.ProgressEvent === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).ProgressEvent = class ProgressEvent extends Event {
+      readonly lengthComputable: boolean;
+      readonly loaded: number;
+      readonly total: number;
+
+      constructor(
+        type: string,
+        init?: { lengthComputable?: boolean; loaded?: number; total?: number }
+      ) {
+        super(type);
+        this.lengthComputable = init?.lengthComputable ?? false;
+        this.loaded = init?.loaded ?? 0;
+        this.total = init?.total ?? 0;
+      }
+    };
+  }
+});
+
+// Fake AudioBuffer returned by mock decodeAudioData
+const fakeAudioBuffer = {
+  length: 44100,
+  duration: 1,
+  sampleRate: 44100,
+  numberOfChannels: 1,
+  getChannelData: () => new Float32Array(44100),
+  copyFromChannel: vi.fn(),
+  copyToChannel: vi.fn(),
+} as unknown as AudioBuffer;
+
+// Mock AudioContext with decodeAudioData
+function createMockAudioContext(options: { shouldDecode?: boolean } = {}): BaseAudioContext {
+  const { shouldDecode = true } = options;
+  return {
+    decodeAudioData: vi.fn().mockImplementation(() => {
+      if (shouldDecode) {
+        return Promise.resolve(fakeAudioBuffer);
+      }
+      return Promise.reject(new Error('Unable to decode audio data'));
+    }),
+  } as unknown as BaseAudioContext;
+}
+
+// ---- Mock XMLHttpRequest ----
+
+type XHREventHandler = (ev: ProgressEvent) => void;
+
+class MockXMLHttpRequest {
+  status = 200;
+  statusText = 'OK';
+  responseType = '';
+  response: ArrayBuffer | null = new ArrayBuffer(1024);
+
+  private listeners: Record<string, XHREventHandler[]> = {};
+
+  open = vi.fn();
+  send = vi.fn();
+
+  addEventListener(event: string, handler: XHREventHandler) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event].push(handler);
+  }
+
+  // Test helpers to fire events
+  fireProgress(loaded: number, total: number) {
+    this.fireProgressRaw(true, loaded, total);
+  }
+
+  fireProgressRaw(lengthComputable: boolean, loaded: number, total: number) {
+    const ev = new ProgressEvent('progress', {
+      lengthComputable,
+      loaded,
+      total,
+    });
+    this.listeners['progress']?.forEach((h) => h(ev));
+  }
+
+  fireLoad() {
+    const ev = new ProgressEvent('load');
+    // Attach target reference so the handler can read status/response
+    Object.defineProperty(ev, 'target', { value: this });
+    this.listeners['load']?.forEach((h) => h(ev));
+  }
+
+  fireError() {
+    const ev = new ProgressEvent('error');
+    this.listeners['error']?.forEach((h) => h(ev));
+  }
+
+  fireAbort() {
+    const ev = new ProgressEvent('abort');
+    this.listeners['abort']?.forEach((h) => h(ev));
+  }
+}
+
+let mockXHRInstance: MockXMLHttpRequest;
+
+beforeEach(() => {
+  mockXHRInstance = new MockXMLHttpRequest();
+  // Use a real class so `new XMLHttpRequest()` works as a constructor
+  class StubXHR {
+    constructor() {
+      return mockXHRInstance;
+    }
+  }
+  vi.stubGlobal('XMLHttpRequest', StubXHR);
+});
+
+describe('XHRLoader', () => {
+  describe('constructor', () => {
+    it('accepts a URL string and starts in UNINITIALIZED state', () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      expect(loader.getState()).toBe(LoaderState.UNINITIALIZED);
+    });
+  });
+
+  describe('load - HTTP success', () => {
+    it('resolves with an AudioBuffer on 200 status', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 200;
+        mockXHRInstance.statusText = 'OK';
+        mockXHRInstance.fireLoad();
+      });
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+      expect(loader.getState()).toBe(LoaderState.FINISHED);
+      expect(loader.getAudioBuffer()).toBe(fakeAudioBuffer);
+    });
+
+    it('opens the request with GET and the correct URL', async () => {
+      const ac = createMockAudioContext();
+      const url = 'https://cdn.example.com/track.wav';
+      const loader = new XHRLoader(url, ac);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(mockXHRInstance.open).toHaveBeenCalledWith('GET', url, true);
+      expect(mockXHRInstance.responseType).toBe('arraybuffer');
+    });
+
+    it('resolves on any 2xx status (e.g. 206)', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 206;
+        mockXHRInstance.statusText = 'Partial Content';
+        mockXHRInstance.fireLoad();
+      });
+
+      const result = await loader.load();
+
+      expect(result).toBe(fakeAudioBuffer);
+    });
+  });
+
+  describe('load - HTTP errors', () => {
+    it('rejects with HTTP error on 404 status', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/missing.mp3', ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 404;
+        mockXHRInstance.statusText = 'Not Found';
+        mockXHRInstance.fireLoad();
+      });
+
+      await expect(loader.load()).rejects.toThrow('HTTP 404: Not Found');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'HTTP 404: Not Found' })
+      );
+    });
+
+    it('rejects with HTTP error on 500 status', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 500;
+        mockXHRInstance.statusText = 'Internal Server Error';
+        mockXHRInstance.fireLoad();
+      });
+
+      await expect(loader.load()).rejects.toThrow('HTTP 500: Internal Server Error');
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('load - network errors', () => {
+    it('rejects on network error', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.fireError();
+      });
+
+      await expect(loader.load()).rejects.toThrow('Network error while loading audio file');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Network error while loading audio file',
+        })
+      );
+    });
+
+    it('rejects on abort', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.fireAbort();
+      });
+
+      await expect(loader.load()).rejects.toThrow('Audio file loading was aborted');
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('progress events', () => {
+    it('emits loadprogress with percentage', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const progressSpy = vi.fn();
+      loader.on('loadprogress', progressSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.fireProgress(500, 1000);
+        mockXHRInstance.fireProgress(1000, 1000);
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(progressSpy).toHaveBeenCalledTimes(2);
+      expect(progressSpy).toHaveBeenNthCalledWith(1, 50, 'https://example.com/audio.mp3');
+      expect(progressSpy).toHaveBeenNthCalledWith(2, 100, 'https://example.com/audio.mp3');
+    });
+
+    it('emits 0 percent when length is not computable', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const progressSpy = vi.fn();
+      loader.on('loadprogress', progressSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.fireProgressRaw(false, 500, 0);
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(progressSpy).toHaveBeenCalledWith(0, 'https://example.com/audio.mp3');
+    });
+  });
+
+  describe('state transitions', () => {
+    it('transitions through LOADING -> DECODING -> FINISHED on success', async () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const stateChanges: LoaderState[] = [];
+      loader.on('audiorequeststatechange', (state) => {
+        stateChanges.push(state);
+      });
+
+      mockXHRInstance.send.mockImplementation(() => {
+        // Progress event triggers LOADING state
+        mockXHRInstance.fireProgress(500, 1000);
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await loader.load();
+
+      expect(stateChanges).toEqual([
+        LoaderState.LOADING,
+        LoaderState.DECODING,
+        LoaderState.FINISHED,
+      ]);
+    });
+
+    it('transitions to DECODING -> ERROR when decoding fails', async () => {
+      const ac = createMockAudioContext({ shouldDecode: false });
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const stateChanges: LoaderState[] = [];
+      loader.on('audiorequeststatechange', (state) => {
+        stateChanges.push(state);
+      });
+      // Suppress the error event so it doesn't cause unhandled rejection noise
+      loader.on('error', () => {});
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await expect(loader.load()).rejects.toThrow('Unable to decode audio data');
+
+      expect(stateChanges).toEqual([LoaderState.DECODING, LoaderState.ERROR]);
+    });
+
+    it('starts in UNINITIALIZED and stays there before load is called', () => {
+      const ac = createMockAudioContext();
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      expect(loader.getState()).toBe(LoaderState.UNINITIALIZED);
+      expect(loader.getAudioBuffer()).toBeUndefined();
+    });
+  });
+
+  describe('decode failure', () => {
+    it('emits error event when decodeAudioData fails', async () => {
+      const ac = createMockAudioContext({ shouldDecode: false });
+      const loader = new XHRLoader('https://example.com/audio.mp3', ac);
+
+      const errorSpy = vi.fn();
+      loader.on('error', errorSpy);
+
+      mockXHRInstance.send.mockImplementation(() => {
+        mockXHRInstance.status = 200;
+        mockXHRInstance.fireLoad();
+      });
+
+      await expect(loader.load()).rejects.toThrow();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Unable to decode audio data' })
+      );
+      expect(loader.getState()).toBe(LoaderState.ERROR);
+    });
+  });
+});

--- a/packages/playout/src/SoundFontCache.ts
+++ b/packages/playout/src/SoundFontCache.ts
@@ -1,5 +1,5 @@
 import { SoundFont2, GeneratorType } from 'soundfont2';
-import type { Key, Generator, ZoneMap } from 'soundfont2';
+import type { Generator, ZoneMap } from 'soundfont2';
 
 /**
  * Result of looking up a MIDI note in the SoundFont.
@@ -48,6 +48,142 @@ export function getGeneratorValue(
   type: GeneratorType
 ): number | undefined {
   return generators[type]?.value;
+}
+
+/**
+ * Convert Int16Array sample data to Float32Array.
+ * SF2 samples are 16-bit signed integers; Web Audio needs Float32 [-1, 1].
+ */
+export function int16ToFloat32(samples: Int16Array): Float32Array {
+  const floats = new Float32Array(samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    floats[i] = samples[i] / 32768;
+  }
+  return floats;
+}
+
+/**
+ * Input parameters for playback rate calculation.
+ */
+export interface PlaybackRateParams {
+  /** Target MIDI note number (0-127) */
+  midiNote: number;
+  /** OverridingRootKey generator value, or undefined if not set */
+  overrideRootKey: number | undefined;
+  /** sample.header.originalPitch (255 means unpitched) */
+  originalPitch: number;
+  /** CoarseTune generator value in semitones (default 0) */
+  coarseTune: number;
+  /** FineTune generator value in cents (default 0) */
+  fineTune: number;
+  /** sample.header.pitchCorrection in cents (default 0) */
+  pitchCorrection: number;
+}
+
+/**
+ * Calculate playback rate for a MIDI note using the SF2 generator chain.
+ *
+ * SF2 root key resolution priority:
+ *   1. OverridingRootKey generator (per-zone, most specific)
+ *   2. sample.header.originalPitch (sample header)
+ *   3. MIDI note 60 (middle C fallback)
+ *
+ * Tuning adjustments:
+ *   - CoarseTune generator (semitones, additive)
+ *   - FineTune generator (cents, additive)
+ *   - sample.header.pitchCorrection (cents, additive)
+ */
+export function calculatePlaybackRate(params: PlaybackRateParams): number {
+  const { midiNote, overrideRootKey, originalPitch, coarseTune, fineTune, pitchCorrection } =
+    params;
+
+  // Resolve root key: OverridingRootKey → originalPitch → 60
+  const rootKey =
+    overrideRootKey !== undefined ? overrideRootKey : originalPitch !== 255 ? originalPitch : 60;
+
+  // Total offset in semitones: target note - root key + tuning
+  const totalSemitones = midiNote - rootKey + coarseTune + (fineTune + pitchCorrection) / 100;
+
+  return Math.pow(2, totalSemitones / 12);
+}
+
+/**
+ * Input parameters for loop and envelope extraction.
+ */
+export interface LoopAndEnvelopeParams {
+  /** SF2 generators zone map */
+  generators: ZoneMap<Generator>;
+  /** Sample header with loop points and sample rate */
+  header: {
+    startLoop: number;
+    endLoop: number;
+    sampleRate: number;
+  };
+}
+
+/**
+ * Extract loop points and volume envelope data from per-zone generators.
+ *
+ * Loop points are stored as absolute indices into the SF2 sample pool.
+ * We convert to AudioBuffer-relative seconds by subtracting header.start
+ * and dividing by sampleRate.
+ *
+ * Volume envelope times are in SF2 timecents; sustain is centibels attenuation.
+ */
+export function extractLoopAndEnvelope(
+  params: LoopAndEnvelopeParams
+): Omit<SoundFontSample, 'buffer' | 'playbackRate'> {
+  const { generators, header } = params;
+
+  // --- Loop points ---
+  const loopMode = getGeneratorValue(generators, GeneratorType.SampleModes) ?? 0;
+
+  // Compute actual loop positions (header + fine/coarse generator offsets)
+  const rawLoopStart =
+    header.startLoop +
+    (getGeneratorValue(generators, GeneratorType.StartLoopAddrsOffset) ?? 0) +
+    (getGeneratorValue(generators, GeneratorType.StartLoopAddrsCoarseOffset) ?? 0) * 32768;
+  const rawLoopEnd =
+    header.endLoop +
+    (getGeneratorValue(generators, GeneratorType.EndLoopAddrsOffset) ?? 0) +
+    (getGeneratorValue(generators, GeneratorType.EndLoopAddrsCoarseOffset) ?? 0) * 32768;
+
+  // The soundfont2 library already converts startLoop/endLoop to be
+  // relative to sample.data (subtracts header.start during parsing),
+  // so we only need to divide by sampleRate to get seconds.
+  const loopStart = rawLoopStart / header.sampleRate;
+  const loopEnd = rawLoopEnd / header.sampleRate;
+
+  // --- Volume envelope ---
+  const attackVolEnv = timecentsToSeconds(
+    getGeneratorValue(generators, GeneratorType.AttackVolEnv) ?? -12000
+  );
+  const holdVolEnv = timecentsToSeconds(
+    getGeneratorValue(generators, GeneratorType.HoldVolEnv) ?? -12000
+  );
+  const decayVolEnv = timecentsToSeconds(
+    getGeneratorValue(generators, GeneratorType.DecayVolEnv) ?? -12000
+  );
+  const releaseVolEnv = Math.min(
+    timecentsToSeconds(getGeneratorValue(generators, GeneratorType.ReleaseVolEnv) ?? -12000),
+    MAX_RELEASE_SECONDS
+  );
+
+  // SustainVolEnv is centibels attenuation: 0 = full volume, 1440 = silence
+  // Convert to linear gain: 10^(-cb / 200)
+  const sustainCb = getGeneratorValue(generators, GeneratorType.SustainVolEnv) ?? 0;
+  const sustainVolEnv = Math.pow(10, -sustainCb / 200);
+
+  return {
+    loopMode,
+    loopStart,
+    loopEnd,
+    attackVolEnv,
+    holdVolEnv,
+    decayVolEnv,
+    sustainVolEnv,
+    releaseVolEnv,
+  };
 }
 
 /**
@@ -141,122 +277,32 @@ export class SoundFontCache {
 
     // Calculate playback rate using SF2 generator chain for root key.
     // Priority: OverridingRootKey generator → sample.header.originalPitch → 60
-    const playbackRate = this.calculatePlaybackRate(midiNote, keyData);
+    const playbackRate = calculatePlaybackRate({
+      midiNote,
+      overrideRootKey: getGeneratorValue(keyData.generators, GeneratorType.OverridingRootKey),
+      originalPitch: sample.header.originalPitch,
+      coarseTune: getGeneratorValue(keyData.generators, GeneratorType.CoarseTune) ?? 0,
+      fineTune: getGeneratorValue(keyData.generators, GeneratorType.FineTune) ?? 0,
+      pitchCorrection: sample.header.pitchCorrection ?? 0,
+    });
 
     // Extract per-zone loop points and volume envelope from generators
-    const loopAndEnvelope = this.extractLoopAndEnvelope(keyData);
+    const loopAndEnvelope = extractLoopAndEnvelope({
+      generators: keyData.generators,
+      header: keyData.sample.header,
+    });
 
     return { buffer, playbackRate, ...loopAndEnvelope };
   }
 
   /**
-   * Extract loop points and volume envelope data from per-zone generators.
-   *
-   * Loop points are stored as absolute indices into the SF2 sample pool.
-   * We convert to AudioBuffer-relative seconds by subtracting header.start
-   * and dividing by sampleRate.
-   *
-   * Volume envelope times are in SF2 timecents; sustain is centibels attenuation.
-   */
-  private extractLoopAndEnvelope(keyData: Key): Omit<SoundFontSample, 'buffer' | 'playbackRate'> {
-    const { generators } = keyData;
-    const header = keyData.sample.header;
-
-    // --- Loop points ---
-    const loopMode = getGeneratorValue(generators, GeneratorType.SampleModes) ?? 0;
-
-    // Compute actual loop positions (header + fine/coarse generator offsets)
-    const rawLoopStart =
-      header.startLoop +
-      (getGeneratorValue(generators, GeneratorType.StartLoopAddrsOffset) ?? 0) +
-      (getGeneratorValue(generators, GeneratorType.StartLoopAddrsCoarseOffset) ?? 0) * 32768;
-    const rawLoopEnd =
-      header.endLoop +
-      (getGeneratorValue(generators, GeneratorType.EndLoopAddrsOffset) ?? 0) +
-      (getGeneratorValue(generators, GeneratorType.EndLoopAddrsCoarseOffset) ?? 0) * 32768;
-
-    // The soundfont2 library already converts startLoop/endLoop to be
-    // relative to sample.data (subtracts header.start during parsing),
-    // so we only need to divide by sampleRate to get seconds.
-    const loopStart = rawLoopStart / header.sampleRate;
-    const loopEnd = rawLoopEnd / header.sampleRate;
-
-    // --- Volume envelope ---
-    const attackVolEnv = timecentsToSeconds(
-      getGeneratorValue(generators, GeneratorType.AttackVolEnv) ?? -12000
-    );
-    const holdVolEnv = timecentsToSeconds(
-      getGeneratorValue(generators, GeneratorType.HoldVolEnv) ?? -12000
-    );
-    const decayVolEnv = timecentsToSeconds(
-      getGeneratorValue(generators, GeneratorType.DecayVolEnv) ?? -12000
-    );
-    const releaseVolEnv = Math.min(
-      timecentsToSeconds(getGeneratorValue(generators, GeneratorType.ReleaseVolEnv) ?? -12000),
-      MAX_RELEASE_SECONDS
-    );
-
-    // SustainVolEnv is centibels attenuation: 0 = full volume, 1440 = silence
-    // Convert to linear gain: 10^(-cb / 200)
-    const sustainCb = getGeneratorValue(generators, GeneratorType.SustainVolEnv) ?? 0;
-    const sustainVolEnv = Math.pow(10, -sustainCb / 200);
-
-    return {
-      loopMode,
-      loopStart,
-      loopEnd,
-      attackVolEnv,
-      holdVolEnv,
-      decayVolEnv,
-      sustainVolEnv,
-      releaseVolEnv,
-    };
-  }
-
-  /**
-   * Calculate playback rate for a MIDI note using the SF2 generator chain.
-   *
-   * SF2 root key resolution priority:
-   *   1. OverridingRootKey generator (per-zone, most specific)
-   *   2. sample.header.originalPitch (sample header)
-   *   3. MIDI note 60 (middle C fallback)
-   *
-   * Tuning adjustments:
-   *   - CoarseTune generator (semitones, additive)
-   *   - FineTune generator (cents, additive)
-   *   - sample.header.pitchCorrection (cents, additive)
-   */
-  private calculatePlaybackRate(midiNote: number, keyData: Key): number {
-    const sample = keyData.sample;
-    const generators = keyData.generators;
-
-    // Resolve root key: OverridingRootKey → originalPitch → 60
-    const overrideRootKey = getGeneratorValue(generators, GeneratorType.OverridingRootKey);
-    const originalPitch = sample.header.originalPitch;
-    const rootKey =
-      overrideRootKey !== undefined ? overrideRootKey : originalPitch !== 255 ? originalPitch : 60;
-
-    // Tuning adjustments in semitones
-    const coarseTune = getGeneratorValue(generators, GeneratorType.CoarseTune) ?? 0;
-    const fineTune = getGeneratorValue(generators, GeneratorType.FineTune) ?? 0;
-    const pitchCorrection = sample.header.pitchCorrection ?? 0;
-
-    // Total offset in semitones: target note - root key + tuning
-    const totalSemitones = midiNote - rootKey + coarseTune + (fineTune + pitchCorrection) / 100;
-
-    return Math.pow(2, totalSemitones / 12);
-  }
-
-  /**
    * Convert Int16Array sample data to an AudioBuffer.
-   * SF2 samples are 16-bit signed integers; Web Audio needs Float32 [-1, 1].
+   * Uses the extracted int16ToFloat32 for the conversion, then copies into an AudioBuffer.
    */
   private int16ToAudioBuffer(data: Int16Array, sampleRate: number): AudioBuffer {
-    const buffer = this.context.createBuffer(1, data.length, sampleRate);
-    const channel = buffer.getChannelData(0);
-    for (let i = 0; i < data.length; i++) {
-      channel[i] = data[i] / 32768;
-    }
+    const floats = int16ToFloat32(data);
+    const buffer = this.context.createBuffer(1, floats.length, sampleRate);
+    buffer.getChannelData(0).set(floats);
     return buffer;
   }
 

--- a/packages/playout/src/__tests__/SoundFontCache.test.ts
+++ b/packages/playout/src/__tests__/SoundFontCache.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { timecentsToSeconds, getGeneratorValue } from '../SoundFontCache';
+import {
+  timecentsToSeconds,
+  getGeneratorValue,
+  int16ToFloat32,
+  calculatePlaybackRate,
+  extractLoopAndEnvelope,
+} from '../SoundFontCache';
 import type { Generator, ZoneMap } from 'soundfont2';
 import { GeneratorType } from 'soundfont2';
 
@@ -79,23 +85,307 @@ describe('getGeneratorValue', () => {
   });
 });
 
-/**
- * NOTE: The following functions are private methods on SoundFontCache and
- * cannot be tested directly without extraction:
- *
- * - calculatePlaybackRate(midiNote, keyData) - pitch shifting math
- *   SHOULD be exported as a standalone pure function for testing.
- *   Formula: 2^((midiNote - rootKey + coarseTune + (fineTune + pitchCorrection) / 100) / 12)
- *
- * - int16ToAudioBuffer(data, sampleRate) - Int16 to Float32 conversion
- *   SHOULD be exported as a standalone pure function for testing.
- *   Formula: float = int16 / 32768
- *
- * - extractLoopAndEnvelope(keyData) - loop points + volume envelope extraction
- *   Uses timecentsToSeconds and getGeneratorValue (tested above).
- *   SHOULD be exported as a standalone pure function for testing.
- *
- * These are good candidates for extraction into standalone exported functions
- * since they are pure computations with no dependency on SoundFontCache instance
- * state (only this.context for int16ToAudioBuffer's createBuffer call).
- */
+describe('int16ToFloat32', () => {
+  it('converts 0 to 0', () => {
+    const input = new Int16Array([0]);
+    const result = int16ToFloat32(input);
+    expect(result[0]).toBe(0);
+  });
+
+  it('converts 32767 to approximately 1.0', () => {
+    const input = new Int16Array([32767]);
+    const result = int16ToFloat32(input);
+    expect(result[0]).toBeCloseTo(32767 / 32768, 10);
+  });
+
+  it('converts -32768 to -1.0', () => {
+    const input = new Int16Array([-32768]);
+    const result = int16ToFloat32(input);
+    expect(result[0]).toBe(-1);
+  });
+
+  it('returns an empty Float32Array for empty input', () => {
+    const input = new Int16Array([]);
+    const result = int16ToFloat32(input);
+    expect(result.length).toBe(0);
+    expect(result).toBeInstanceOf(Float32Array);
+  });
+
+  it('converts multiple samples correctly', () => {
+    const input = new Int16Array([0, 16384, -16384, 32767, -32768]);
+    const result = int16ToFloat32(input);
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBeCloseTo(0.5, 5);
+    expect(result[2]).toBeCloseTo(-0.5, 5);
+    expect(result[3]).toBeCloseTo(1.0, 3);
+    expect(result[4]).toBe(-1.0);
+  });
+
+  it('output values are in [-1, 1] range', () => {
+    const input = new Int16Array([32767, -32768, 0, 1, -1]);
+    const result = int16ToFloat32(input);
+    for (let i = 0; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThanOrEqual(-1);
+      expect(result[i]).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('calculatePlaybackRate', () => {
+  const baseParams = {
+    midiNote: 60,
+    overrideRootKey: undefined,
+    originalPitch: 60,
+    coarseTune: 0,
+    fineTune: 0,
+    pitchCorrection: 0,
+  };
+
+  it('returns 1.0 when midiNote equals root key (middle C)', () => {
+    const rate = calculatePlaybackRate(baseParams);
+    expect(rate).toBeCloseTo(1.0, 10);
+  });
+
+  it('doubles rate for one octave up (MIDI 72 from root 60)', () => {
+    const rate = calculatePlaybackRate({ ...baseParams, midiNote: 72 });
+    expect(rate).toBeCloseTo(2.0, 10);
+  });
+
+  it('halves rate for one octave down (MIDI 48 from root 60)', () => {
+    const rate = calculatePlaybackRate({ ...baseParams, midiNote: 48 });
+    expect(rate).toBeCloseTo(0.5, 10);
+  });
+
+  it('one semitone up gives 2^(1/12)', () => {
+    const rate = calculatePlaybackRate({ ...baseParams, midiNote: 61 });
+    expect(rate).toBeCloseTo(Math.pow(2, 1 / 12), 10);
+  });
+
+  it('uses OverridingRootKey when provided', () => {
+    // Root key is 48, playing MIDI 60 = one octave up = 2.0
+    const rate = calculatePlaybackRate({
+      ...baseParams,
+      overrideRootKey: 48,
+      originalPitch: 60,
+    });
+    expect(rate).toBeCloseTo(2.0, 10);
+  });
+
+  it('OverridingRootKey takes priority over originalPitch', () => {
+    // overrideRootKey=60, originalPitch=48. Should use 60, so rate=1.0
+    const rate = calculatePlaybackRate({
+      ...baseParams,
+      overrideRootKey: 60,
+      originalPitch: 48,
+    });
+    expect(rate).toBeCloseTo(1.0, 10);
+  });
+
+  it('falls back to 60 when originalPitch is 255 (unpitched)', () => {
+    const rate = calculatePlaybackRate({
+      ...baseParams,
+      overrideRootKey: undefined,
+      originalPitch: 255,
+    });
+    // midiNote=60, rootKey=60 → rate=1.0
+    expect(rate).toBeCloseTo(1.0, 10);
+  });
+
+  it('applies CoarseTune (semitones)', () => {
+    // midiNote=60, rootKey=60, coarseTune=12 → offset = 0 + 12 = 12 semitones → 2.0
+    const rate = calculatePlaybackRate({ ...baseParams, coarseTune: 12 });
+    expect(rate).toBeCloseTo(2.0, 10);
+  });
+
+  it('applies negative CoarseTune', () => {
+    // midiNote=60, rootKey=60, coarseTune=-12 → offset = -12 → 0.5
+    const rate = calculatePlaybackRate({ ...baseParams, coarseTune: -12 });
+    expect(rate).toBeCloseTo(0.5, 10);
+  });
+
+  it('applies FineTune (cents)', () => {
+    // fineTune=100 cents = 1 semitone
+    const rate = calculatePlaybackRate({ ...baseParams, fineTune: 100 });
+    expect(rate).toBeCloseTo(Math.pow(2, 1 / 12), 10);
+  });
+
+  it('applies pitchCorrection (cents)', () => {
+    // pitchCorrection=100 cents = 1 semitone
+    const rate = calculatePlaybackRate({ ...baseParams, pitchCorrection: 100 });
+    expect(rate).toBeCloseTo(Math.pow(2, 1 / 12), 10);
+  });
+
+  it('combines fineTune and pitchCorrection additively', () => {
+    // fineTune=50 + pitchCorrection=50 = 100 cents = 1 semitone
+    const rate = calculatePlaybackRate({ ...baseParams, fineTune: 50, pitchCorrection: 50 });
+    expect(rate).toBeCloseTo(Math.pow(2, 1 / 12), 10);
+  });
+
+  it('combines all tuning parameters', () => {
+    // coarseTune=11 semitones + fineTune=50 + pitchCorrection=50 = 12 semitones total
+    const rate = calculatePlaybackRate({
+      ...baseParams,
+      coarseTune: 11,
+      fineTune: 50,
+      pitchCorrection: 50,
+    });
+    expect(rate).toBeCloseTo(2.0, 10);
+  });
+
+  it('result is always positive', () => {
+    // Even extreme downshift
+    const rate = calculatePlaybackRate({ ...baseParams, midiNote: 0, originalPitch: 127 });
+    expect(rate).toBeGreaterThan(0);
+  });
+});
+
+describe('extractLoopAndEnvelope', () => {
+  const makeGenerators = (
+    entries: Array<{ type: GeneratorType; value: number }>
+  ): ZoneMap<Generator> => {
+    const map: ZoneMap<Generator> = {};
+    for (const { type, value } of entries) {
+      map[type] = { id: type, value } as Generator;
+    }
+    return map;
+  };
+
+  it('returns default values with no generators', () => {
+    const result = extractLoopAndEnvelope({
+      generators: {},
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    expect(result.loopMode).toBe(0);
+    expect(result.loopStart).toBe(0);
+    expect(result.loopEnd).toBe(0);
+    // Default envelope: -12000 timecents = 2^(-10) ~ 0.000977s
+    const defaultTime = Math.pow(2, -10);
+    expect(result.attackVolEnv).toBeCloseTo(defaultTime, 5);
+    expect(result.holdVolEnv).toBeCloseTo(defaultTime, 5);
+    expect(result.decayVolEnv).toBeCloseTo(defaultTime, 5);
+    expect(result.releaseVolEnv).toBeCloseTo(defaultTime, 5);
+    // Default sustain: 0 centibels = full volume = 1.0
+    expect(result.sustainVolEnv).toBeCloseTo(1.0, 10);
+  });
+
+  it('extracts loop mode from SampleModes generator', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.SampleModes, value: 1 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    expect(result.loopMode).toBe(1);
+  });
+
+  it('sustain loop mode (3)', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.SampleModes, value: 3 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    expect(result.loopMode).toBe(3);
+  });
+
+  it('computes loop start and end in seconds', () => {
+    const result = extractLoopAndEnvelope({
+      generators: {},
+      header: { startLoop: 44100, endLoop: 88200, sampleRate: 44100 },
+    });
+    expect(result.loopStart).toBeCloseTo(1.0, 10);
+    expect(result.loopEnd).toBeCloseTo(2.0, 10);
+  });
+
+  it('applies fine loop address offsets', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([
+        { type: GeneratorType.StartLoopAddrsOffset, value: 4410 },
+        { type: GeneratorType.EndLoopAddrsOffset, value: -4410 },
+      ]),
+      header: { startLoop: 44100, endLoop: 88200, sampleRate: 44100 },
+    });
+    // startLoop: (44100 + 4410) / 44100 = 1.1s
+    expect(result.loopStart).toBeCloseTo(1.1, 5);
+    // endLoop: (88200 - 4410) / 44100 = 1.9s
+    expect(result.loopEnd).toBeCloseTo(1.9, 5);
+  });
+
+  it('applies coarse loop address offsets (x32768)', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.StartLoopAddrsCoarseOffset, value: 1 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // startLoop: (0 + 1*32768) / 44100
+    expect(result.loopStart).toBeCloseTo(32768 / 44100, 5);
+  });
+
+  it('extracts attack volume envelope', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.AttackVolEnv, value: 0 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 0 timecents = 2^0 = 1 second
+    expect(result.attackVolEnv).toBeCloseTo(1.0, 10);
+  });
+
+  it('extracts hold volume envelope', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.HoldVolEnv, value: 1200 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 1200 timecents = 2 seconds
+    expect(result.holdVolEnv).toBeCloseTo(2.0, 10);
+  });
+
+  it('extracts decay volume envelope', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.DecayVolEnv, value: -1200 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // -1200 timecents = 0.5 seconds
+    expect(result.decayVolEnv).toBeCloseTo(0.5, 10);
+  });
+
+  it('caps release at MAX_RELEASE_SECONDS (5s)', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.ReleaseVolEnv, value: 12000 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 12000 timecents = 1024 seconds, but capped at 5
+    expect(result.releaseVolEnv).toBe(5);
+  });
+
+  it('does not cap release when under 5s', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.ReleaseVolEnv, value: 1200 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 1200 timecents = 2 seconds, not capped
+    expect(result.releaseVolEnv).toBeCloseTo(2.0, 10);
+  });
+
+  it('converts sustain centibels attenuation to linear gain', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.SustainVolEnv, value: 200 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 200 centibels → 10^(-200/200) = 10^(-1) = 0.1
+    expect(result.sustainVolEnv).toBeCloseTo(0.1, 10);
+  });
+
+  it('sustain 0 centibels = full volume (1.0)', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.SustainVolEnv, value: 0 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    expect(result.sustainVolEnv).toBeCloseTo(1.0, 10);
+  });
+
+  it('sustain 1440 centibels is near silence', () => {
+    const result = extractLoopAndEnvelope({
+      generators: makeGenerators([{ type: GeneratorType.SustainVolEnv, value: 1440 }]),
+      header: { startLoop: 0, endLoop: 0, sampleRate: 44100 },
+    });
+    // 10^(-1440/200) = 10^(-7.2) ≈ 6.3e-8
+    expect(result.sustainVolEnv).toBeLessThan(0.0001);
+    expect(result.sustainVolEnv).toBeGreaterThan(0);
+  });
+});

--- a/packages/playout/src/__tests__/audioContext.test.ts
+++ b/packages/playout/src/__tests__/audioContext.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Shared mock state that each test can configure
+const mockRawContext = {
+  state: 'suspended' as AudioContextState,
+};
+
+const mockResume = vi.fn().mockResolvedValue(undefined);
+const mockClose = vi.fn().mockResolvedValue(undefined);
+
+// Track how many Context instances are created
+let contextCreateCount = 0;
+
+vi.mock('tone', () => {
+  // Use a named function so it can be called with `new`
+  const MockContext = vi.fn(function (this: Record<string, unknown>) {
+    contextCreateCount++;
+    this.rawContext = mockRawContext;
+    this.resume = mockResume;
+    this.close = mockClose;
+    // Define state as a getter so it always reflects current mockRawContext.state
+    Object.defineProperty(this, 'state', {
+      get: () => mockRawContext.state,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+  return {
+    Context: MockContext,
+    setContext: vi.fn(),
+  };
+});
+
+// Must import AFTER vi.mock
+import {
+  getGlobalContext,
+  getGlobalAudioContext,
+  getGlobalAudioContextState,
+  resumeGlobalAudioContext,
+  closeGlobalAudioContext,
+} from '../audioContext';
+import { Context, setContext } from 'tone';
+
+describe('audioContext singleton', () => {
+  beforeEach(async () => {
+    // Reset singleton state between tests
+    // Set state to non-closed so closeGlobalAudioContext actually resets
+    mockRawContext.state = 'running';
+    await closeGlobalAudioContext();
+    vi.clearAllMocks();
+    contextCreateCount = 0;
+    // Reset mock state to default
+    mockRawContext.state = 'suspended';
+  });
+
+  afterEach(async () => {
+    mockRawContext.state = 'running';
+    await closeGlobalAudioContext();
+  });
+
+  describe('getGlobalContext', () => {
+    it('returns a Tone.js Context instance', () => {
+      const context = getGlobalContext();
+      expect(context).toBeDefined();
+      expect(context.rawContext).toBe(mockRawContext);
+      expect(Context).toHaveBeenCalledOnce();
+    });
+
+    it('calls setContext with the created context', () => {
+      const context = getGlobalContext();
+      expect(setContext).toHaveBeenCalledWith(context);
+    });
+
+    it('returns the same instance on multiple calls (singleton)', () => {
+      const first = getGlobalContext();
+      const second = getGlobalContext();
+      const third = getGlobalContext();
+      expect(first).toBe(second);
+      expect(second).toBe(third);
+      expect(contextCreateCount).toBe(1);
+    });
+  });
+
+  describe('getGlobalAudioContext', () => {
+    it('returns the rawContext from the Tone.js Context', () => {
+      const rawContext = getGlobalAudioContext();
+      expect(rawContext).toBe(mockRawContext);
+    });
+
+    it('returns the same rawContext on multiple calls', () => {
+      const first = getGlobalAudioContext();
+      const second = getGlobalAudioContext();
+      expect(first).toBe(second);
+    });
+
+    it('creates the context if not yet initialized', () => {
+      getGlobalAudioContext();
+      expect(Context).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('getGlobalAudioContextState', () => {
+    it('returns "suspended" when context has not been created', () => {
+      // No context created yet, globalToneContext is null
+      const state = getGlobalAudioContextState();
+      expect(state).toBe('suspended');
+    });
+
+    it('returns the rawContext state when context exists', () => {
+      getGlobalContext(); // Create the context
+      mockRawContext.state = 'running';
+      expect(getGlobalAudioContextState()).toBe('running');
+    });
+
+    it('reflects state changes', () => {
+      getGlobalContext();
+      mockRawContext.state = 'suspended';
+      expect(getGlobalAudioContextState()).toBe('suspended');
+
+      mockRawContext.state = 'running';
+      expect(getGlobalAudioContextState()).toBe('running');
+
+      mockRawContext.state = 'closed';
+      expect(getGlobalAudioContextState()).toBe('closed');
+    });
+  });
+
+  describe('resumeGlobalAudioContext', () => {
+    it('calls resume when context state is not running', async () => {
+      mockRawContext.state = 'suspended';
+      await resumeGlobalAudioContext();
+      expect(mockResume).toHaveBeenCalledOnce();
+    });
+
+    it('does not call resume when context is already running', async () => {
+      mockRawContext.state = 'running';
+      getGlobalContext(); // Ensure context exists
+      await resumeGlobalAudioContext();
+      expect(mockResume).not.toHaveBeenCalled();
+    });
+
+    it('creates the context if not yet initialized', async () => {
+      mockRawContext.state = 'suspended';
+      await resumeGlobalAudioContext();
+      expect(Context).toHaveBeenCalled();
+    });
+  });
+
+  describe('closeGlobalAudioContext', () => {
+    it('calls close on the context', async () => {
+      getGlobalContext(); // Create the context
+      mockRawContext.state = 'running';
+      await closeGlobalAudioContext();
+      expect(mockClose).toHaveBeenCalledOnce();
+    });
+
+    it('does not call close if context is already closed', async () => {
+      getGlobalContext();
+      mockRawContext.state = 'closed';
+      await closeGlobalAudioContext();
+      expect(mockClose).not.toHaveBeenCalled();
+    });
+
+    it('is safe to call when no context exists', async () => {
+      // No context created — should not throw
+      await expect(closeGlobalAudioContext()).resolves.toBeUndefined();
+    });
+
+    it('resets singleton so next call creates a fresh context', async () => {
+      getGlobalContext();
+      expect(contextCreateCount).toBe(1);
+
+      mockRawContext.state = 'running';
+      await closeGlobalAudioContext();
+
+      // Next call should create a new context
+      getGlobalContext();
+      expect(contextCreateCount).toBe(2);
+      expect(Context).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/playout/src/index.ts
+++ b/packages/playout/src/index.ts
@@ -4,8 +4,15 @@ export { MidiToneTrack } from './MidiToneTrack';
 export type { PlayableTrack, MidiClipInfo, MidiToneTrackOptions } from './MidiToneTrack';
 export { SoundFontToneTrack } from './SoundFontToneTrack';
 export type { SoundFontToneTrackOptions } from './SoundFontToneTrack';
-export { SoundFontCache } from './SoundFontCache';
-export type { SoundFontSample } from './SoundFontCache';
+export {
+  SoundFontCache,
+  timecentsToSeconds,
+  getGeneratorValue,
+  int16ToFloat32,
+  calculatePlaybackRate,
+  extractLoopAndEnvelope,
+} from './SoundFontCache';
+export type { SoundFontSample, PlaybackRateParams, LoopAndEnvelopeParams } from './SoundFontCache';
 export type { TonePlayoutOptions, EffectsFunction } from './TonePlayout';
 export type { ToneTrackOptions, TrackEffectsFunction } from './ToneTrack';
 


### PR DESCRIPTION
## Summary
Adds 243 new tests (bringing total to 893) and extracts testable pure logic from hooks and classes.

### New tests

| Package | Tests | What's covered |
|---------|-------|----------------|
| browser | 14 | `ClipCollisionModifier` — boundary trim bypass, move delegation, edge cases |
| browser | 11 | Extracted boundary trim math — left/right drag, min duration, offset clamping |
| loaders | 14 | `XHRLoader` — HTTP success/error, progress, state transitions |
| loaders | 17 | `BlobLoader` — mime validation, FileReader events, state transitions |
| playout | 16 | `audioContext` singleton — lazy init, resume, close, reset |
| playout | 28 | `SoundFontCache` extractions — `int16ToFloat32`, `calculatePlaybackRate`, `extractLoopAndEnvelope` |

### Extractions (refactors, no behavior change)

**browser `useClipDragHandlers`** — Boundary trim calculation extracted into `utils/boundaryTrim.ts` as a pure `calculateBoundaryTrim()` function. The hook now calls this instead of inline math.

**playout `SoundFontCache`** — Three private class methods extracted as standalone exported functions:
- `int16ToFloat32(samples)` — Int16 to Float32 conversion
- `calculatePlaybackRate(params)` — SF2 pitch math with root key + tuning
- `extractLoopAndEnvelope(params)` — Loop points + volume envelope from SF2 generators

Also adds missing `"test": "vitest run"` script to browser `package.json`.

## Test plan
- [x] 893 tests pass locally
- [x] Build passes
- [x] Lint passes
- [x] CI: Unit Tests (React 18)
- [x] CI: Unit Tests (React 19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)