### PR TITLE
fix: Int16 overflow in peaksGenerator and time format padding

### DIFF
--- a/packages/recording/src/__tests__/peaksGenerator.test.ts
+++ b/packages/recording/src/__tests__/peaksGenerator.test.ts
@@ -67,11 +67,10 @@ describe('generatePeaks', () => {
     const result = generatePeaks(samples, 4, 16);
 
     const maxValue = 2 ** 15; // 32768
-    // min: Math.floor(-1 * 32768) = -32768
+    // min: Math.floor(-1 * 32768) = -32768 (valid Int16 min)
     expect(result[0]).toBe(-maxValue);
-    // max: Math.floor(1 * 32768) = 32768, but Int16Array wraps to -32768
-    // This is a known overflow behavior for full-scale positive signals
-    expect(result[1]).toBe(new Int16Array([maxValue])[0]);
+    // max: clamped to 32767 (Int16 max) instead of overflowing
+    expect(result[1]).toBe(maxValue - 1);
   });
 
   it('produces correct interleaved format: [min0, max0, min1, max1, ...]', () => {

--- a/packages/recording/src/utils/peaksGenerator.ts
+++ b/packages/recording/src/utils/peaksGenerator.ts
@@ -34,8 +34,9 @@ export function generatePeaks(
     }
 
     // Store as min/max pairs scaled to bit depth
-    peakArray[i * 2] = Math.floor(min * maxValue);
-    peakArray[i * 2 + 1] = Math.floor(max * maxValue);
+    // Clamp to valid range: Int16 is [-32768, 32767], Int8 is [-128, 127]
+    peakArray[i * 2] = Math.max(-maxValue, Math.floor(min * maxValue));
+    peakArray[i * 2 + 1] = Math.min(maxValue - 1, Math.floor(max * maxValue));
   }
 
   return peakArray;
@@ -77,8 +78,8 @@ export function appendPeaks(
     // Update last peak
     const updated = new (bits === 8 ? Int8Array : Int16Array)(existingPeaks.length);
     updated.set(existingPeaks);
-    updated[existingPeaks.length - 2] = Math.floor(min * maxValue);
-    updated[existingPeaks.length - 1] = Math.floor(max * maxValue);
+    updated[existingPeaks.length - 2] = Math.max(-maxValue, Math.floor(min * maxValue));
+    updated[existingPeaks.length - 1] = Math.min(maxValue - 1, Math.floor(max * maxValue));
 
     offset = endIndex;
 

--- a/packages/ui-components/src/__tests__/timeFormat.test.ts
+++ b/packages/ui-components/src/__tests__/timeFormat.test.ts
@@ -41,24 +41,23 @@ describe('formatTime', () => {
 
   describe('hh:mm:ss format', () => {
     it('formats zero', () => {
-      // decimals=0, padStart(3, '0') => 3-char seconds field
-      expect(formatTime(0, 'hh:mm:ss')).toBe('00:00:000');
+      expect(formatTime(0, 'hh:mm:ss')).toBe('00:00:00');
     });
 
     it('formats seconds only', () => {
-      expect(formatTime(5, 'hh:mm:ss')).toBe('00:00:005');
+      expect(formatTime(5, 'hh:mm:ss')).toBe('00:00:05');
     });
 
     it('formats minutes and seconds', () => {
-      expect(formatTime(65, 'hh:mm:ss')).toBe('00:01:005');
+      expect(formatTime(65, 'hh:mm:ss')).toBe('00:01:05');
     });
 
     it('formats hours, minutes, and seconds', () => {
-      expect(formatTime(3661, 'hh:mm:ss')).toBe('01:01:001');
+      expect(formatTime(3661, 'hh:mm:ss')).toBe('01:01:01');
     });
 
     it('rounds fractional seconds', () => {
-      expect(formatTime(1.7, 'hh:mm:ss')).toBe('00:00:002');
+      expect(formatTime(1.7, 'hh:mm:ss')).toBe('00:00:02');
     });
   });
 
@@ -102,11 +101,11 @@ describe('formatTime', () => {
 
   describe('wraps hours at 24', () => {
     it('wraps 86400 seconds (24h) to 00', () => {
-      expect(formatTime(86400, 'hh:mm:ss')).toBe('00:00:000');
+      expect(formatTime(86400, 'hh:mm:ss')).toBe('00:00:00');
     });
 
     it('wraps 90061 seconds (25h 1m 1s) to 01:01:01', () => {
-      expect(formatTime(90061, 'hh:mm:ss')).toBe('01:01:001');
+      expect(formatTime(90061, 'hh:mm:ss')).toBe('01:01:01');
     });
   });
 });
@@ -210,7 +209,7 @@ describe('round-trip: formatTime(parseTime(str)) === str', () => {
   });
 
   it('round-trips hh:mm:ss format', () => {
-    const str = '01:02:003';
+    const str = '01:02:03';
     expect(formatTime(parseTime(str, 'hh:mm:ss'), 'hh:mm:ss')).toBe(str);
   });
 

--- a/packages/ui-components/src/utils/timeFormat.ts
+++ b/packages/ui-components/src/utils/timeFormat.ts
@@ -23,7 +23,7 @@ function clockFormat(seconds: number, decimals: number): string {
     ':' +
     String(minutes).padStart(2, '0') +
     ':' +
-    secs.padStart(decimals + 3, '0')
+    secs.padStart(decimals > 0 ? decimals + 3 : 2, '0')
   );
 }
 


### PR DESCRIPTION
## Summary

- **Int16 overflow in `peaksGenerator`**: `Math.floor(1.0 * 32768)` produces 32768, which wraps to -32768 in Int16Array. Now clamps to valid range `[-32768, 32767]` for 16-bit and `[-128, 127]` for 8-bit.
- **Time format padding in `hh:mm:ss`**: `padStart(decimals + 3, '0')` with 0 decimals padded seconds to 3 digits (e.g., `00:00:005` instead of `00:00:05`). Now uses 2-char padding when no decimal places.

## Test plan

- [x] peaksGenerator tests pass (24 tests) — full-scale signal test now expects 32767 instead of wrapped -32768
- [x] timeFormat tests pass (53 tests) — `hh:mm:ss` format tests updated for correct 2-digit seconds
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)