### PR TITLE
perf: spectrogram worker pool, lazy FFT, and three-tier rendering

### DIFF
--- a/packages/browser/src/SpectrogramIntegrationContext.tsx
+++ b/packages/browser/src/SpectrogramIntegrationContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext } from 'react';
 import type {
-  SpectrogramData,
   SpectrogramConfig,
   ColorMapValue,
   RenderMode,
@@ -9,7 +8,6 @@ import type {
 import type { TrackMenuItem } from '@waveform-playlist/ui-components';
 
 export interface SpectrogramIntegration {
-  spectrogramDataMap: Map<string, SpectrogramData[]>;
   trackSpectrogramOverrides: Map<string, TrackSpectrogramOverrides>;
   spectrogramWorkerApi: SpectrogramWorkerApi | null;
   spectrogramConfig?: SpectrogramConfig;

--- a/packages/browser/src/components/PlaylistVisualization.tsx
+++ b/packages/browser/src/components/PlaylistVisualization.tsx
@@ -692,12 +692,6 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                         }}
                       >
                         {peaksData.data.map((channelPeaks: Peaks, channelIndex: number) => {
-                          const clipSpectrograms = spectrogram?.spectrogramDataMap.get(clip.clipId);
-                          const channelSpectrogram =
-                            clipSpectrograms?.[channelIndex] ?? clipSpectrograms?.[0];
-                          const helpers = perTrackSpectrogramHelpers.get(track.id);
-                          const trackCfg = helpers?.config;
-
                           return (
                             <ChannelWithProgress
                               key={`${clip.clipId}-${channelIndex}`}
@@ -716,12 +710,7 @@ export const PlaylistVisualization: React.FC<PlaylistVisualizationProps> = ({
                                   ? clip.offsetSamples / (clip.sampleRate || sampleRate)
                                   : 0
                               }
-                              spectrogramData={channelSpectrogram}
                               samplesPerPixel={samplesPerPixel}
-                              spectrogramColorLUT={helpers?.colorLUT}
-                              spectrogramFrequencyScaleFn={helpers?.frequencyScaleFn}
-                              spectrogramMinFrequency={trackCfg?.minFrequency}
-                              spectrogramMaxFrequency={trackCfg?.maxFrequency}
                               spectrogramWorkerApi={workerCanvasApi}
                               spectrogramClipId={clip.clipId}
                               spectrogramOnCanvasesReady={

--- a/packages/recording/src/__tests__/recordingProcessor.test.ts
+++ b/packages/recording/src/__tests__/recordingProcessor.test.ts
@@ -185,7 +185,9 @@ describe('RecordingProcessor', () => {
       // Stop to flush remaining 512 samples
       proc.port.onmessage({ data: { command: 'stop' } });
       expect(messages.length).toBe(expectedFlushes + 1);
-      expect(messages[expectedFlushes].channels[0].length).toBe(totalSamples - expectedFlushes * 768); // 512
+      expect(messages[expectedFlushes].channels[0].length).toBe(
+        totalSamples - expectedFlushes * 768
+      ); // 512
     });
   });
 

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -40,7 +40,7 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 
 **Problem:** During scrolling, stale FFT requests (~1.4s each) block the worker queue, delaying visible-range FFT for the new scroll position.
 
-**Fix:** Cooperative abort via `setTimeout(0)` yielding every 2000 FFT frames. Main thread sends `abort-generation` messages; worker checks `latestGeneration` between yields and returns `null` if stale. Provider catches `Error('aborted')` silently.
+**Fix:** Cooperative abort via `setTimeout(0)` yielding every 2000 FFT frames. Main thread sends `abort-generation` messages; worker checks `latestGeneration` between yields and returns `null` if stale. Provider catches `SpectrogramAbortError` (via `instanceof`, not string matching) silently.
 
 **Key fields:** `generation` on `ComputeFFTRequest`/`RenderChunksRequest`, `AbortGenerationMessage`, `latestGeneration` in worker.
 

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -23,3 +23,37 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 ## SpectrogramChannel Index vs ChannelIndex
 
 **`SpectrogramChannel`** has two index concerns: `index` (CSS positioning via Wrapper `top` offset) and `channelIndex` (canvas ID construction for worker registration, e.g. `clipId-ch{channelIndex}-chunk0`). In "both" mode, `SmartChannel` passes `index={props.index * 2}` for layout interleaving but `channelIndex={props.index}` for correct canvas identity. When `channelIndex` is omitted it defaults to `index`. Never use the visual `index` for canvas IDs — the worker and SpectrogramProvider registry expect sequential audio channel indices (0, 1).
+
+## Worker Pool Architecture
+
+**Decision:** `createSpectrogramWorkerPool` creates N workers (default 2) for parallel per-channel FFT.
+
+**How it works:** Each worker computes a single channel via `channelFilter` param. Pool routes canvases by channel parsed from canvas ID (`clipId-ch0-chunk5` → worker 0). `renderChunks({channelIndex: N})` remaps to `channelIndex: 0` at the target worker since each worker stores its channel at index 0. Audio data registered in ALL workers (needed for mono mode).
+
+**Mono mode:** Only worker 0 runs (no channelFilter), averages all channels as before.
+
+**Location:** `src/worker/createSpectrogramWorkerPool.ts`
+
+## Generation-Based Abort
+
+**Problem:** During scrolling, stale FFT requests (~1.4s each) block the worker queue, delaying visible-range FFT for the new scroll position.
+
+**Fix:** Cooperative abort via `setTimeout(0)` yielding every 2000 FFT frames. Main thread sends `abort-generation` messages; worker checks `latestGeneration` between yields and returns `null` if stale. Provider catches `Error('aborted')` silently.
+
+**Key fields:** `generation` on `ComputeFFTRequest`/`RenderChunksRequest`, `AbortGenerationMessage`, `latestGeneration` in worker.
+
+## Lazy Per-Batch FFT (OOM Prevention)
+
+**Decision:** Never compute a full-clip FFT. Compute FFT per rendering batch (visible range, then contiguous background groups).
+
+**Why:** Full-clip FFT on 1hr+ files allocates ~2.5GB (310K frames × 2048 bins × 4 bytes). Per-batch FFT bounds memory to the chunk range being rendered.
+
+**Implementation:** `computeFFTForChunks()` computes sample range from chunk positions, padded by windowSize. Worker LRU cache (16 entries) prevents recomputation on scroll-back.
+
+## Overscan Buffer (1.5x Viewport)
+
+**Critical:** `getVisibleChunkRange` in SpectrogramProvider MUST use the same 1.5× viewport-width buffer as `useVisibleChunkIndices` in ScrollViewport.tsx. Without this, canvases mounted in the buffer zone (by the virtualizer) remain black — they're classified as "remaining" and get aborted during scrolling before background batches render them.
+
+## Controls Outside Scroll Container
+
+**Gotcha:** `scrollContainerRef` coordinates do NOT include `controlWidth`. Controls render in a fixed `ControlsColumn` outside the scroll area. Never add `controlWidth` to chunk pixel positions in `getVisibleChunkRange` or viewport calculations.

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -26,7 +26,7 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 
 ## Worker Pool Architecture
 
-**Decision:** `createSpectrogramWorkerPool` creates N workers (default 2) for parallel per-channel FFT.
+**Decision:** `createSpectrogramWorkerPool` creates N workers (default `min(cores - 1, 4)`) for parallel per-channel FFT. Configurable via `<SpectrogramProvider workerPoolSize={N}>`.
 
 **How it works:** Each worker computes a single channel via `channelFilter` param. Pool routes canvases by channel parsed from canvas ID (`clipId-ch0-chunk5` → worker 0). `renderChunks({channelIndex: N})` remaps to `channelIndex: 0` at the target worker since each worker stores its channel at index 0. Audio data registered in ALL workers (needed for mono mode).
 

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -26,11 +26,13 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 
 ## Worker Pool Architecture
 
-**Decision:** `createSpectrogramWorkerPool` creates N workers (default `min(cores - 1, 4)`) for parallel per-channel FFT. Configurable via `<SpectrogramProvider workerPoolSize={N}>`.
+**Decision:** `createSpectrogramWorkerPool` creates N workers (default 2, one per stereo channel) for parallel per-channel FFT. Configurable via `<SpectrogramProvider workerPoolSize={N}>` for multi-channel audio.
 
 **How it works:** Each worker computes a single channel via `channelFilter` param. Pool routes canvases by channel parsed from canvas ID (`clipId-ch0-chunk5` → worker 0). `renderChunks({channelIndex: N})` remaps to `channelIndex: 0` at the target worker since each worker stores its channel at index 0. Audio data registered in ALL workers (needed for mono mode).
 
 **Mono mode:** Only worker 0 runs (no channelFilter), averages all channels as before.
+
+**Channel cap:** `computeFFT` fan-out is capped to `min(poolSize, channelDataArrays.length)`. A quad-core machine creates 3 workers, but stereo audio only has 2 channels — excess workers sit completely idle (canvas routing also maps by channel, not pool size).
 
 **Location:** `src/worker/createSpectrogramWorkerPool.ts`
 

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -32,7 +32,7 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 
 **Mono mode:** Only worker 0 runs (no channelFilter), averages all channels as before.
 
-**Channel cap:** `computeFFT` fan-out is capped to `min(poolSize, channelDataArrays.length)`. A quad-core machine creates 3 workers, but stereo audio only has 2 channels — excess workers sit completely idle (canvas routing also maps by channel, not pool size).
+**Channel cap:** `computeFFT` fan-out is capped to `min(poolSize, channelDataArrays.length)`. If `workerPoolSize` exceeds the channel count (e.g., 3 workers for stereo audio), excess workers sit completely idle (canvas routing also maps by channel, not pool size).
 
 **Location:** `src/worker/createSpectrogramWorkerPool.ts`
 

--- a/packages/spectrogram/CLAUDE.md
+++ b/packages/spectrogram/CLAUDE.md
@@ -54,6 +54,19 @@ const spectrogram = useContext(SpectrogramIntegrationContext);
 
 **Critical:** `getVisibleChunkRange` in SpectrogramProvider MUST use the same 1.5× viewport-width buffer as `useVisibleChunkIndices` in ScrollViewport.tsx. Without this, canvases mounted in the buffer zone (by the virtualizer) remain black — they're classified as "remaining" and get aborted during scrolling before background batches render them.
 
+## Three-Tier Rendering Pipeline
+
+**Decision:** Classify chunks into viewport/buffer/remaining instead of binary visible/remaining.
+
+**Why:** The virtualizer only mounts chunks within the 1.5× buffer. A binary split with a 1.5× buffer classifies ALL mounted chunks as "visible", making phase 1 FFT cover 5-6 chunks (~4.5s) instead of 2 viewport chunks (~1.5s).
+
+**Tiers:**
+- **Phase 1a (viewport):** Chunks intersecting exact scroll viewport — fast first paint (~1.5s cold, ~80ms cached)
+- **Phase 1b (buffer):** Chunks in 1.5× overscan but outside viewport — prevents black chunks on scroll
+- **Phase 2 (remaining):** Off-screen chunks via `requestIdleCallback` background batches
+
+**Contiguous grouping (critical):** Buffer indices may map to non-contiguous chunk numbers (e.g., indices `[0,3,4,5]` → chunks `[10,14,15,11]`). Always use `groupContiguousIndices()` before `computeFFTForChunks()` — without it, min-to-max spanning computes a huge FFT range (96K frames / 4.5s instead of 16K / 700ms per group).
+
 ## Controls Outside Scroll Container
 
 **Gotcha:** `scrollContainerRef` coordinates do NOT include `controlWidth`. Controls render in a fixed `ControlsColumn` outside the scroll area. Never add `controlWidth` to chunk pixel positions in `getVisibleChunkRange` or viewport calculations.

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -309,13 +309,21 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
     if (clipsNeedingFFT.length === 0 && clipsNeedingDisplayOnly.length === 0) return;
 
+    // Three-tier chunk classification:
+    // - viewportIndices: chunks intersecting the exact viewport (phase 1a — fast first paint)
+    // - bufferIndices: chunks in the 1.5× overscan buffer but outside viewport (phase 1b)
+    // - remainingIndices: chunks outside the buffer (phase 2 — background batches)
     const getVisibleChunkRange = (
       channelInfo: { canvasIds: string[]; canvasWidths: number[] },
       clipPixelOffset = 0
-    ): { visibleIndices: number[]; remainingIndices: number[] } => {
+    ): { viewportIndices: number[]; bufferIndices: number[]; remainingIndices: number[] } => {
       const container = scrollContainerRef.current;
       if (!container) {
-        return { visibleIndices: channelInfo.canvasWidths.map((_, i) => i), remainingIndices: [] };
+        return {
+          viewportIndices: channelInfo.canvasWidths.map((_, i) => i),
+          bufferIndices: [],
+          remainingIndices: [],
+        };
       }
 
       const scrollLeft = container.scrollLeft;
@@ -323,28 +331,27 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       // Match the 1.5× overscan buffer used by useVisibleChunkIndices
       // (ScrollViewport.tsx) so spectrogram FFT covers all mounted canvases.
       const buffer = viewportWidth * 1.5;
-      const rangeStart = Math.max(0, scrollLeft - buffer);
-      const rangeEnd = scrollLeft + viewportWidth + buffer;
+      const bufferStart = Math.max(0, scrollLeft - buffer);
+      const bufferEnd = scrollLeft + viewportWidth + buffer;
 
-      const visibleIndices: number[] = [];
+      const viewportIndices: number[] = [];
+      const bufferIndices: number[] = [];
       const remainingIndices: number[] = [];
 
       for (let i = 0; i < channelInfo.canvasWidths.length; i++) {
-        // Extract the actual chunk number from the canvas ID to compute the
-        // correct global pixel offset. With virtual scrolling, the registry
-        // may contain non-consecutive chunks (e.g., chunks 50-55).
-        // Controls are outside the scroll container, so no controlWidth offset needed.
         const chunkNumber = extractChunkNumber(channelInfo.canvasIds[i]);
         const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + clipPixelOffset;
         const chunkRight = chunkLeft + channelInfo.canvasWidths[i];
-        if (chunkRight > rangeStart && chunkLeft < rangeEnd) {
-          visibleIndices.push(i);
+        if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
+          viewportIndices.push(i);
+        } else if (chunkRight > bufferStart && chunkLeft < bufferEnd) {
+          bufferIndices.push(i);
         } else {
           remainingIndices.push(i);
         }
       }
 
-      return { visibleIndices, remainingIndices };
+      return { viewportIndices, bufferIndices, remainingIndices };
     };
 
     const renderChunkSubset = async (
@@ -597,46 +604,47 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               );
             }
 
-            // Phase 1: Compute FFT once and render visible chunks for ALL
-            // channels before background batches (multi-channel fairness).
+            // Three-phase rendering:
+            // Phase 1a: viewport-only chunks (fast first paint)
+            // Phase 1b: buffer-zone chunks (prevents black chunks on scroll)
+            // Phase 2: off-screen chunks (background batches)
             const phase1Start = performance.now();
             const channelRanges: Array<{
               ch: number;
               channelInfo: { canvasIds: string[]; canvasWidths: number[] };
-              visibleIndices: number[];
+              viewportIndices: number[];
+              bufferIndices: number[];
               remainingIndices: number[];
             }> = [];
 
-            // Collect visible/remaining ranges for all channels
             for (let ch = 0; ch < numChannels; ch++) {
               const channelInfo = clipCanvasInfo.get(ch);
               if (!channelInfo) continue;
               const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
               channelRanges.push({ ch, channelInfo, ...range });
               console.log(
-                `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
+                `[spectrogram] ch=${ch}: viewport=[${range.viewportIndices.join(',')}] buffer=[${range.bufferIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
               );
             }
 
-            // Compute FFT once for the visible range (covers all channels)
-            if (channelRanges.length > 0 && channelRanges[0].visibleIndices.length > 0) {
+            // Phase 1a: Compute FFT for viewport chunks only, render all channels
+            if (channelRanges.length > 0 && channelRanges[0].viewportIndices.length > 0) {
               const cacheKey = await computeFFTForChunks(
                 workerApi!,
                 channelRanges[0].channelInfo,
-                channelRanges[0].visibleIndices,
+                channelRanges[0].viewportIndices,
                 item,
                 generation
               );
 
               if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
-              // Render all channels from the single cached FFT
-              for (const { ch, channelInfo, visibleIndices } of channelRanges) {
+              for (const { ch, channelInfo, viewportIndices } of channelRanges) {
                 await renderChunkSubset(
                   workerApi!,
                   cacheKey,
                   channelInfo,
-                  visibleIndices,
+                  viewportIndices,
                   item,
                   ch,
                   generation
@@ -645,8 +653,53 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             }
 
             console.log(
-              `[spectrogram] phase1 complete: ${(performance.now() - phase1Start).toFixed(1)}ms`
+              `[spectrogram] phase1a (viewport) complete: ${(performance.now() - phase1Start).toFixed(1)}ms`
             );
+
+            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+            // Phase 1b: Compute FFT for buffer-zone chunks, render all channels.
+            // Buffer indices may be non-contiguous (e.g., chunks [10,14,15] from
+            // indices [0,3,4,5]), so group them to avoid spanning a huge FFT range.
+            if (channelRanges.length > 0 && channelRanges[0].bufferIndices.length > 0) {
+              const phase1bStart = performance.now();
+              const bufferGroups = groupContiguousIndices(
+                channelRanges[0].channelInfo,
+                channelRanges[0].bufferIndices
+              );
+
+              for (const group of bufferGroups) {
+                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+                const cacheKey = await computeFFTForChunks(
+                  workerApi!,
+                  channelRanges[0].channelInfo,
+                  group,
+                  item,
+                  generation
+                );
+
+                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+                for (const { ch, channelInfo } of channelRanges) {
+                  // Map this group's indices to the corresponding buffer indices for this channel
+                  const chBufferIndices = group;
+                  await renderChunkSubset(
+                    workerApi!,
+                    cacheKey,
+                    channelInfo,
+                    chBufferIndices,
+                    item,
+                    ch,
+                    generation
+                  );
+                }
+              }
+
+              console.log(
+                `[spectrogram] phase1b (buffer) complete: ${(performance.now() - phase1bStart).toFixed(1)}ms`
+              );
+            }
 
             renderedClipIdsRef.current.add(item.clipId);
 
@@ -671,55 +724,73 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         try {
           const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
 
-          // Two-phase rendering with per-batch FFT (same as FFT path above).
+          // Three-phase rendering with per-batch FFT (same as FFT path above).
           // Worker cache provides instant hits for previously computed ranges.
           const channelRanges: Array<{
             ch: number;
             channelInfo: { canvasIds: string[]; canvasWidths: number[] };
+            viewportIndices: number[];
+            bufferIndices: number[];
             remainingIndices: number[];
           }> = [];
           for (let ch = 0; ch < item.numChannels; ch++) {
             const channelInfo = clipCanvasInfo.get(ch);
             if (!channelInfo) continue;
-            const { visibleIndices, remainingIndices } = getVisibleChunkRange(
-              channelInfo,
-              clipPixelOffset
-            );
-            channelRanges.push({ ch, channelInfo, remainingIndices });
+            const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
+            channelRanges.push({ ch, channelInfo, ...range });
           }
 
-          // Compute FFT once, render all channels
-          if (channelRanges.length > 0) {
-            const firstVisible = channelRanges.find((r) => r.channelInfo.canvasIds.length > 0);
-            if (firstVisible) {
-              const visibleIndices = getVisibleChunkRange(
-                firstVisible.channelInfo,
-                clipPixelOffset
-              ).visibleIndices;
-              if (visibleIndices.length > 0) {
-                const cacheKey = await computeFFTForChunks(
+          // Phase 1a: viewport chunks
+          if (channelRanges.length > 0 && channelRanges[0].viewportIndices.length > 0) {
+            const cacheKey = await computeFFTForChunks(
+              workerApi!,
+              channelRanges[0].channelInfo,
+              channelRanges[0].viewportIndices,
+              item,
+              generation
+            );
+            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+            for (const { ch, channelInfo, viewportIndices } of channelRanges) {
+              await renderChunkSubset(
+                workerApi!,
+                cacheKey,
+                channelInfo,
+                viewportIndices,
+                item,
+                ch,
+                generation
+              );
+            }
+          }
+
+          if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+          // Phase 1b: buffer-zone chunks (grouped for contiguous FFT ranges)
+          if (channelRanges.length > 0 && channelRanges[0].bufferIndices.length > 0) {
+            const bufferGroups = groupContiguousIndices(
+              channelRanges[0].channelInfo,
+              channelRanges[0].bufferIndices
+            );
+            for (const group of bufferGroups) {
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+              const cacheKey = await computeFFTForChunks(
+                workerApi!,
+                channelRanges[0].channelInfo,
+                group,
+                item,
+                generation
+              );
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+              for (const { ch, channelInfo } of channelRanges) {
+                await renderChunkSubset(
                   workerApi!,
-                  firstVisible.channelInfo,
-                  visibleIndices,
+                  cacheKey,
+                  channelInfo,
+                  group,
                   item,
+                  ch,
                   generation
                 );
-                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-                for (const { ch, channelInfo } of channelRanges) {
-                  const chVisible = getVisibleChunkRange(
-                    channelInfo,
-                    clipPixelOffset
-                  ).visibleIndices;
-                  await renderChunkSubset(
-                    workerApi!,
-                    cacheKey,
-                    channelInfo,
-                    chVisible,
-                    item,
-                    ch,
-                    generation
-                  );
-                }
               }
             }
           }

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -8,7 +8,7 @@ import {
   type TrackSpectrogramOverrides,
 } from '@waveform-playlist/core';
 import { getColorMap, getFrequencyScale } from './computation';
-import { createSpectrogramWorker, type SpectrogramWorkerApi } from './worker';
+import { createSpectrogramWorkerPool, type SpectrogramWorkerApi } from './worker';
 import { SpectrogramMenuItems } from './components';
 import { SpectrogramSettingsModal } from './components';
 import {
@@ -78,11 +78,13 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     let workerApi = spectrogramWorkerRef.current;
     if (!workerApi) {
       try {
-        const rawWorker = new Worker(
-          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
-          { type: 'module' }
+        workerApi = createSpectrogramWorkerPool(
+          () =>
+            new Worker(
+              new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
+              { type: 'module' }
+            )
         );
-        workerApi = createSpectrogramWorker(rawWorker);
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
       } catch {
@@ -193,11 +195,13 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     let workerApi = spectrogramWorkerRef.current;
     if (!workerApi) {
       try {
-        const rawWorker = new Worker(
-          new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
-          { type: 'module' }
+        workerApi = createSpectrogramWorkerPool(
+          () =>
+            new Worker(
+              new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
+              { type: 'module' }
+            )
         );
-        workerApi = createSpectrogramWorker(rawWorker);
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
       } catch (err) {

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -185,6 +185,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
     const generation = ++spectrogramGenerationRef.current;
 
+    // Tell the worker to abort any in-flight FFT from previous generations
+    if (spectrogramWorkerRef.current) {
+      spectrogramWorkerRef.current.abortGeneration(generation);
+    }
+
     let workerApi = spectrogramWorkerRef.current;
     if (!workerApi) {
       try {
@@ -339,7 +344,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       channelInfo: { canvasIds: string[]; canvasWidths: number[] },
       indices: number[],
       item: { config: SpectrogramConfig; colorMap: ColorMapValue },
-      channelIndex: number
+      channelIndex: number,
+      gen: number
     ) => {
       if (indices.length === 0) return;
 
@@ -357,22 +363,25 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
       const colorLUT = getColorMap(item.colorMap);
 
-      await api.renderChunks({
-        cacheKey,
-        canvasIds,
-        canvasWidths,
-        globalPixelOffsets,
-        canvasHeight: waveHeight,
-        devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
-        samplesPerPixel,
-        colorLUT,
-        frequencyScale: item.config.frequencyScale ?? 'mel',
-        minFrequency: item.config.minFrequency ?? 0,
-        maxFrequency: item.config.maxFrequency ?? 0,
-        gainDb: item.config.gainDb ?? 20,
-        rangeDb: item.config.rangeDb ?? 80,
-        channelIndex,
-      });
+      await api.renderChunks(
+        {
+          cacheKey,
+          canvasIds,
+          canvasWidths,
+          globalPixelOffsets,
+          canvasHeight: waveHeight,
+          devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
+          samplesPerPixel,
+          colorLUT,
+          frequencyScale: item.config.frequencyScale ?? 'mel',
+          minFrequency: item.config.minFrequency ?? 0,
+          maxFrequency: item.config.maxFrequency ?? 0,
+          gainDb: item.config.gainDb ?? 20,
+          rangeDb: item.config.rangeDb ?? 80,
+          channelIndex,
+        },
+        gen
+      );
     };
 
     // Compute FFT for the sample range covered by a set of chunk indices.
@@ -391,7 +400,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         offsetSamples: number;
         durationSamples: number;
         monoFlag: boolean;
-      }
+      },
+      gen: number
     ): Promise<string> => {
       // Determine the sample range these chunks cover
       const chunkNumbers = indices.map((i) => extractChunkNumber(channelInfo.canvasIds[i]));
@@ -417,16 +427,19 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         rangeEndSample + windowSize
       );
 
-      const { cacheKey } = await api.computeFFT({
-        clipId: item.clipId,
-        channelDataArrays: item.channelDataArrays,
-        config: item.config,
-        sampleRate: item.sampleRate,
-        offsetSamples: item.offsetSamples,
-        durationSamples: item.durationSamples,
-        mono: item.monoFlag,
-        sampleRange: { start: paddedStart, end: paddedEnd },
-      });
+      const { cacheKey } = await api.computeFFT(
+        {
+          clipId: item.clipId,
+          channelDataArrays: item.channelDataArrays,
+          config: item.config,
+          sampleRate: item.sampleRate,
+          offsetSamples: item.offsetSamples,
+          durationSamples: item.durationSamples,
+          mono: item.monoFlag,
+          sampleRange: { start: paddedStart, end: paddedEnd },
+        },
+        gen
+      );
 
       return cacheKey;
     };
@@ -529,13 +542,14 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             workerApi!,
             firstChannelInfo,
             group,
-            item
+            item,
+            generation
           );
 
           // Render all channels from the cached FFT data
           for (const { ch, channelInfo: ci } of channelRangeEntries) {
             if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return true;
-            await renderChunkSubset(workerApi!, cacheKey, ci, group, item, ch);
+            await renderChunkSubset(workerApi!, cacheKey, ci, group, item, ch, generation);
           }
         }
         return false;
@@ -599,14 +613,23 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
                 workerApi!,
                 channelRanges[0].channelInfo,
                 channelRanges[0].visibleIndices,
-                item
+                item,
+                generation
               );
 
               if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
               // Render all channels from the single cached FFT
               for (const { ch, channelInfo, visibleIndices } of channelRanges) {
-                await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
+                await renderChunkSubset(
+                  workerApi!,
+                  cacheKey,
+                  channelInfo,
+                  visibleIndices,
+                  item,
+                  ch,
+                  generation
+                );
               }
             }
 
@@ -623,6 +646,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             if (await renderBackgroundBatches(channelRanges, item)) return;
           }
         } catch (err) {
+          if (err instanceof Error && err.message === 'aborted') return;
           console.warn('Spectrogram worker error for clip', item.clipId, err);
         }
       }
@@ -666,12 +690,24 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
                   workerApi!,
                   firstVisible.channelInfo,
                   visibleIndices,
-                  item
+                  item,
+                  generation
                 );
                 if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
                 for (const { ch, channelInfo } of channelRanges) {
-                  const chVisible = getVisibleChunkRange(channelInfo, clipPixelOffset).visibleIndices;
-                  await renderChunkSubset(workerApi!, cacheKey, channelInfo, chVisible, item, ch);
+                  const chVisible = getVisibleChunkRange(
+                    channelInfo,
+                    clipPixelOffset
+                  ).visibleIndices;
+                  await renderChunkSubset(
+                    workerApi!,
+                    cacheKey,
+                    channelInfo,
+                    chVisible,
+                    item,
+                    ch,
+                    generation
+                  );
                 }
               }
             }
@@ -682,6 +718,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
           // Phase 2: Render off-screen chunks in background batches.
           if (await renderBackgroundBatches(channelRanges, item)) return;
         } catch (err) {
+          if (err instanceof Error && err.message === 'aborted') return;
           console.warn('Spectrogram display re-render error for clip', item.clipId, err);
         }
       }

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -320,6 +320,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
       const scrollLeft = container.scrollLeft;
       const viewportWidth = container.clientWidth;
+      // Match the 1.5× overscan buffer used by useVisibleChunkIndices
+      // (ScrollViewport.tsx) so spectrogram FFT covers all mounted canvases.
+      const buffer = viewportWidth * 1.5;
+      const rangeStart = Math.max(0, scrollLeft - buffer);
+      const rangeEnd = scrollLeft + viewportWidth + buffer;
 
       const visibleIndices: number[] = [];
       const remainingIndices: number[] = [];
@@ -332,7 +337,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         const chunkNumber = extractChunkNumber(channelInfo.canvasIds[i]);
         const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + clipPixelOffset;
         const chunkRight = chunkLeft + channelInfo.canvasWidths[i];
-        if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
+        if (chunkRight > rangeStart && chunkLeft < rangeEnd) {
           visibleIndices.push(i);
         } else {
           remainingIndices.push(i);
@@ -583,9 +588,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             if (container) {
               const scrollLeft = container.scrollLeft;
               const viewportWidth = container.clientWidth;
+              const buffer = viewportWidth * 1.5;
               const clipEndPx = clipPixelOffset + Math.ceil(item.durationSamples / samplesPerPixel);
               console.log(
                 `[spectrogram] viewport: scrollLeft=${scrollLeft} width=${viewportWidth} ` +
+                  `buffered=[${Math.max(0, scrollLeft - buffer).toFixed(0)},${(scrollLeft + viewportWidth + buffer).toFixed(0)}] ` +
                   `clipPx=[${clipPixelOffset},${clipEndPx}]`
               );
             }

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -585,35 +585,10 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             const numChannels = item.monoFlag ? 1 : item.channelDataArrays.length;
             const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
 
-            // Debug: log registered canvas info per channel
-            for (const [ch, info] of clipCanvasInfo.entries()) {
-              const chunkNumbers = info.canvasIds.map((id: string) => {
-                const m = id.match(/chunk(\d+)$/);
-                return m ? parseInt(m[1], 10) : -1;
-              });
-              console.log(
-                `[spectrogram] clip=${item.clipId} ch=${ch} registered chunks=[${chunkNumbers.join(',')}] widths=[${info.canvasWidths.join(',')}]`
-              );
-            }
-
-            const container = scrollContainerRef.current;
-            if (container) {
-              const scrollLeft = container.scrollLeft;
-              const viewportWidth = container.clientWidth;
-              const buffer = viewportWidth * 1.5;
-              const clipEndPx = clipPixelOffset + Math.ceil(item.durationSamples / samplesPerPixel);
-              console.log(
-                `[spectrogram] viewport: scrollLeft=${scrollLeft} width=${viewportWidth} ` +
-                  `buffered=[${Math.max(0, scrollLeft - buffer).toFixed(0)},${(scrollLeft + viewportWidth + buffer).toFixed(0)}] ` +
-                  `clipPx=[${clipPixelOffset},${clipEndPx}]`
-              );
-            }
-
             // Three-phase rendering:
             // Phase 1a: viewport-only chunks (fast first paint)
             // Phase 1b: buffer-zone chunks (prevents black chunks on scroll)
             // Phase 2: off-screen chunks (background batches)
-            const phase1Start = performance.now();
             const channelRanges: Array<{
               ch: number;
               channelInfo: { canvasIds: string[]; canvasWidths: number[] };
@@ -627,9 +602,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               if (!channelInfo) continue;
               const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
               channelRanges.push({ ch, channelInfo, ...range });
-              console.log(
-                `[spectrogram] ch=${ch}: viewport=[${range.viewportIndices.join(',')}] buffer=[${range.bufferIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
-              );
             }
 
             // Phase 1a: Compute FFT for viewport chunks only, render all channels
@@ -657,17 +629,12 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               }
             }
 
-            console.log(
-              `[spectrogram] phase1a (viewport) complete: ${(performance.now() - phase1Start).toFixed(1)}ms`
-            );
-
             if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
             // Phase 1b: Compute FFT for buffer-zone chunks, render all channels.
             // Buffer indices may be non-contiguous (e.g., chunks [10,14,15] from
             // indices [0,3,4,5]), so group them to avoid spanning a huge FFT range.
             if (channelRanges.length > 0 && channelRanges[0].bufferIndices.length > 0) {
-              const phase1bStart = performance.now();
               const bufferGroups = groupContiguousIndices(
                 channelRanges[0].channelInfo,
                 channelRanges[0].bufferIndices
@@ -700,10 +667,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
                   );
                 }
               }
-
-              console.log(
-                `[spectrogram] phase1b (buffer) complete: ${(performance.now() - phase1bStart).toFixed(1)}ms`
-              );
             }
 
             renderedClipIdsRef.current.add(item.clipId);

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -217,7 +217,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
       } catch (err) {
-        console.error('[waveform-playlist] Spectrogram Web Worker required but unavailable:', err);
+        console.error(
+          `[waveform-playlist] Spectrogram Web Worker required but unavailable: ${err instanceof Error ? err.message : String(err)}`
+        );
         return;
       }
     }
@@ -661,13 +663,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
                 if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
                 for (const { ch, channelInfo } of channelRanges) {
-                  // Map this group's indices to the corresponding buffer indices for this channel
-                  const chBufferIndices = group;
                   await renderChunkSubset(
                     workerApi!,
                     cacheKey,
                     channelInfo,
-                    chBufferIndices,
+                    group,
                     item,
                     ch,
                     generation
@@ -786,7 +786,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     };
 
     computeAsync().catch((err) => {
-      console.error('[waveform-playlist] Spectrogram computation failed:', err);
+      console.error(
+        `[waveform-playlist] Spectrogram computation failed: ${err instanceof Error ? err.message : String(err)}`
+      );
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- workerPoolSize intentionally omitted, pool created once via spectrogramWorkerRef guard
   }, [
@@ -871,7 +873,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
   const value: SpectrogramIntegration = useMemo(
     () => ({
-      spectrogramDataMap: new Map(),
       trackSpectrogramOverrides,
       spectrogramWorkerApi: spectrogramWorkerReady ? spectrogramWorkerRef.current : null,
       spectrogramConfig,

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -59,7 +59,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
   const spectrogramGenerationRef = useRef(0);
   const prevCanvasVersionRef = useRef(0);
   const [spectrogramWorkerReady, setSpectrogramWorkerReady] = useState(false);
-  const clipCacheKeysRef = useRef<Map<string, string>>(new Map());
+  const renderedClipIdsRef = useRef<Set<string>>(new Set());
   const backgroundRenderAbortRef = useRef<{ aborted: boolean } | null>(null);
   const registeredAudioClipIdsRef = useRef<Set<string>>(new Set());
 
@@ -216,7 +216,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     const clipsNeedingDisplayOnly: Array<{
       clipId: string;
       trackIndex: number;
+      channelDataArrays: Float32Array[];
       config: SpectrogramConfig;
+      sampleRate: number;
+      offsetSamples: number;
+      durationSamples: number;
       clipStartSample: number;
       monoFlag: boolean;
       colorMap: ColorMapValue;
@@ -253,11 +257,19 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
         const monoFlag = mono || clip.audioBuffer.numberOfChannels === 1;
 
-        if (!trackFFTChanged && !hasRegisteredCanvases && clipCacheKeysRef.current.has(clip.id)) {
+        if (!trackFFTChanged && !hasRegisteredCanvases && renderedClipIdsRef.current.has(clip.id)) {
+          const channelDataArrays: Float32Array[] = [];
+          for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
+            channelDataArrays.push(clip.audioBuffer.getChannelData(ch));
+          }
           clipsNeedingDisplayOnly.push({
             clipId: clip.id,
             trackIndex: i,
+            channelDataArrays,
             config: cfg,
+            sampleRate: clip.audioBuffer.sampleRate,
+            offsetSamples: clip.offsetSamples,
+            durationSamples: clip.durationSamples,
             clipStartSample: clip.startSample,
             monoFlag,
             colorMap: cm,
@@ -363,11 +375,96 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       });
     };
 
+    // Compute FFT for the sample range covered by a set of chunk indices.
+    // Returns the cache key (data covers all channels).
+    // This avoids computing a single full-clip FFT (which OOMs on 1hr+ files)
+    // by computing per-batch ranges on demand.
+    const computeFFTForChunks = async (
+      api: SpectrogramWorkerApi,
+      channelInfo: { canvasIds: string[]; canvasWidths: number[] },
+      indices: number[],
+      item: {
+        clipId: string;
+        channelDataArrays: Float32Array[];
+        config: SpectrogramConfig;
+        sampleRate: number;
+        offsetSamples: number;
+        durationSamples: number;
+        monoFlag: boolean;
+      }
+    ): Promise<string> => {
+      // Determine the sample range these chunks cover
+      const chunkNumbers = indices.map((i) => extractChunkNumber(channelInfo.canvasIds[i]));
+      const minChunk = Math.min(...chunkNumbers);
+      const maxChunk = Math.max(...chunkNumbers);
+      const maxChunkIdx = indices[chunkNumbers.indexOf(maxChunk)];
+      const lastChunkWidth = channelInfo.canvasWidths[maxChunkIdx];
+
+      const startPx = minChunk * MAX_CANVAS_WIDTH;
+      const endPx = maxChunk * MAX_CANVAS_WIDTH + lastChunkWidth;
+
+      const windowSize = item.config.fftSize ?? 2048;
+      const rangeStartSample = item.offsetSamples + Math.floor(startPx * samplesPerPixel);
+      const rangeEndSample = Math.min(
+        item.offsetSamples + item.durationSamples,
+        item.offsetSamples + Math.ceil(endPx * samplesPerPixel)
+      );
+
+      // Pad by windowSize to avoid edge artifacts
+      const paddedStart = Math.max(item.offsetSamples, rangeStartSample - windowSize);
+      const paddedEnd = Math.min(
+        item.offsetSamples + item.durationSamples,
+        rangeEndSample + windowSize
+      );
+
+      const { cacheKey } = await api.computeFFT({
+        clipId: item.clipId,
+        channelDataArrays: item.channelDataArrays,
+        config: item.config,
+        sampleRate: item.sampleRate,
+        offsetSamples: item.offsetSamples,
+        durationSamples: item.durationSamples,
+        mono: item.monoFlag,
+        sampleRange: { start: paddedStart, end: paddedEnd },
+      });
+
+      return cacheKey;
+    };
+
+    // Split indices into contiguous groups based on chunk numbers.
+    // E.g., remaining=[0,1,4,5] → [[0,1],[4,5]] — prevents computing
+    // an FFT range spanning the gap between 1 and 4.
+    const groupContiguousIndices = (
+      channelInfo: { canvasIds: string[] },
+      indices: number[]
+    ): number[][] => {
+      if (indices.length === 0) return [];
+      const groups: number[][] = [];
+      let currentGroup = [indices[0]];
+      let prevChunk = extractChunkNumber(channelInfo.canvasIds[indices[0]]);
+      for (let i = 1; i < indices.length; i++) {
+        const chunk = extractChunkNumber(channelInfo.canvasIds[indices[i]]);
+        if (chunk === prevChunk + 1) {
+          currentGroup.push(indices[i]);
+        } else {
+          groups.push(currentGroup);
+          currentGroup = [indices[i]];
+        }
+        prevChunk = chunk;
+      }
+      groups.push(currentGroup);
+      return groups;
+    };
+
     const computeAsync = async () => {
       const abortToken = { aborted: false };
       backgroundRenderAbortRef.current = abortToken;
 
-      // Render off-screen chunks in idle-callback batches.
+      // Render off-screen chunks in idle-callback batches, computing FFT
+      // per contiguous group to avoid allocating one giant Float32Array for the
+      // full clip (which OOMs on 1hr+ files — e.g., 310K frames × 2048 bins = 2.5GB).
+      // Groups remaining indices into contiguous runs (e.g., [0,1,4,5] → [0,1]+[4,5])
+      // so each FFT only covers the sample range actually needed.
       // Returns true if aborted (caller should return early).
       const renderBackgroundBatches = async (
         channelRanges: Array<{
@@ -375,27 +472,70 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
           channelInfo: { canvasIds: string[]; canvasWidths: number[] };
           remainingIndices: number[];
         }>,
-        cacheKey: string,
-        item: { config: SpectrogramConfig; colorMap: ColorMapValue }
+        item: {
+          clipId: string;
+          channelDataArrays: Float32Array[];
+          config: SpectrogramConfig;
+          sampleRate: number;
+          offsetSamples: number;
+          durationSamples: number;
+          monoFlag: boolean;
+          colorMap: ColorMapValue;
+        }
       ): Promise<boolean> => {
-        const BATCH_SIZE = 4;
-        for (const { ch, channelInfo, remainingIndices } of channelRanges) {
-          for (let batchStart = 0; batchStart < remainingIndices.length; batchStart += BATCH_SIZE) {
-            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return true;
+        // Collect all contiguous groups across channels, then render
+        // each group for ALL channels before moving to the next group
+        // (multi-channel fairness — avoids ch1 starvation).
+        const allGroups: Array<{
+          group: number[];
+          channelRangeEntries: Array<{
+            ch: number;
+            channelInfo: { canvasIds: string[]; canvasWidths: number[] };
+          }>;
+        }> = [];
 
-            const batch = remainingIndices.slice(batchStart, batchStart + BATCH_SIZE);
-
-            await new Promise<void>((resolve) => {
-              if (typeof requestIdleCallback === 'function') {
-                requestIdleCallback(() => resolve());
-              } else {
-                setTimeout(resolve, 0);
-              }
+        // Build contiguous groups from the first channel's remaining indices
+        // (all channels have the same chunk layout).
+        if (channelRanges.length > 0) {
+          const { channelInfo, remainingIndices } = channelRanges[0];
+          const groups = groupContiguousIndices(channelInfo, remainingIndices);
+          for (const group of groups) {
+            allGroups.push({
+              group,
+              channelRangeEntries: channelRanges.map(({ ch, channelInfo: ci }) => ({
+                ch,
+                channelInfo: ci,
+              })),
             });
+          }
+        }
 
+        for (const { group, channelRangeEntries } of allGroups) {
+          if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return true;
+
+          await new Promise<void>((resolve) => {
+            if (typeof requestIdleCallback === 'function') {
+              requestIdleCallback(() => resolve());
+            } else {
+              setTimeout(resolve, 0);
+            }
+          });
+
+          if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return true;
+
+          // Compute FFT once for this contiguous group (covers all channels)
+          const { channelInfo: firstChannelInfo } = channelRangeEntries[0];
+          const cacheKey = await computeFFTForChunks(
+            workerApi!,
+            firstChannelInfo,
+            group,
+            item
+          );
+
+          // Render all channels from the cached FFT data
+          for (const { ch, channelInfo: ci } of channelRangeEntries) {
             if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return true;
-
-            await renderChunkSubset(workerApi!, cacheKey, channelInfo, batch, item, ch);
+            await renderChunkSubset(workerApi!, cacheKey, ci, group, item, ch);
           }
         }
         return false;
@@ -422,107 +562,18 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             }
 
             const container = scrollContainerRef.current;
-            const windowSize = item.config.fftSize ?? 2048;
-            let visibleRange: { start: number; end: number } | undefined;
-
             if (container) {
               const scrollLeft = container.scrollLeft;
               const viewportWidth = container.clientWidth;
-
-              // Controls are outside the scroll container, so scrollLeft is
-              // already in clip-local coordinate space — no controlWidth offset.
-              const vpStartPx = scrollLeft;
-              const vpEndPx = vpStartPx + viewportWidth;
-
-              const clipStartPx = clipPixelOffset;
-              const clipEndPx = clipStartPx + Math.ceil(item.durationSamples / samplesPerPixel);
-
-              const overlapStartPx = Math.max(vpStartPx, clipStartPx);
-              const overlapEndPx = Math.min(vpEndPx, clipEndPx);
-
-              if (overlapEndPx > overlapStartPx) {
-                const localStartPx = overlapStartPx - clipStartPx;
-                const localEndPx = overlapEndPx - clipStartPx;
-                const visStartSample =
-                  item.offsetSamples + Math.floor(localStartPx * samplesPerPixel);
-                const visEndSample = Math.min(
-                  item.offsetSamples + item.durationSamples,
-                  item.offsetSamples + Math.ceil(localEndPx * samplesPerPixel)
-                );
-                const paddedStart = Math.max(item.offsetSamples, visStartSample - windowSize);
-                const paddedEnd = Math.min(
-                  item.offsetSamples + item.durationSamples,
-                  visEndSample + windowSize
-                );
-
-                if (paddedEnd - paddedStart < item.durationSamples * 0.8) {
-                  visibleRange = { start: paddedStart, end: paddedEnd };
-                }
-              }
-
+              const clipEndPx = clipPixelOffset + Math.ceil(item.durationSamples / samplesPerPixel);
               console.log(
                 `[spectrogram] viewport: scrollLeft=${scrollLeft} width=${viewportWidth} ` +
-                  `vpPx=[${vpStartPx},${vpEndPx}] ` +
-                  `clipPx=[${clipStartPx},${clipEndPx}] ` +
-                  `visibleRange=${visibleRange ? `[${visibleRange.start},${visibleRange.end}]` : 'full'}`
+                  `clipPx=[${clipPixelOffset},${clipEndPx}]`
               );
             }
 
-            const fullClipAlreadyCached = clipCacheKeysRef.current.has(item.clipId);
-            let visibleAlreadyRendered = false;
-
-            if (visibleRange && !fullClipAlreadyCached) {
-              // Phase 0: Fast visible-range FFT — compute and render only the
-              // portion of the clip that's currently on screen.
-              const { cacheKey: visibleCacheKey } = await workerApi!.computeFFT({
-                clipId: item.clipId,
-                channelDataArrays: item.channelDataArrays,
-                config: item.config,
-                sampleRate: item.sampleRate,
-                offsetSamples: item.offsetSamples,
-                durationSamples: item.durationSamples,
-                mono: item.monoFlag,
-                sampleRange: visibleRange,
-              });
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-              for (let ch = 0; ch < numChannels; ch++) {
-                const channelInfo = clipCanvasInfo.get(ch);
-                if (!channelInfo) continue;
-
-                const { visibleIndices } = getVisibleChunkRange(channelInfo, clipPixelOffset);
-                await renderChunkSubset(
-                  workerApi!,
-                  visibleCacheKey,
-                  channelInfo,
-                  visibleIndices,
-                  item,
-                  ch
-                );
-              }
-
-              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-              visibleAlreadyRendered = true;
-            }
-
-            // Full-clip FFT (needed for off-screen chunks and scrolling).
-            const { cacheKey } = await workerApi!.computeFFT({
-              clipId: item.clipId,
-              channelDataArrays: item.channelDataArrays,
-              config: item.config,
-              sampleRate: item.sampleRate,
-              offsetSamples: item.offsetSamples,
-              durationSamples: item.durationSamples,
-              mono: item.monoFlag,
-            });
-
-            if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
-
-            clipCacheKeysRef.current.set(item.clipId, cacheKey);
-
-            // Phase 1: Render visible chunks for ALL channels first (unless
-            // already rendered from the visible-range FFT — the padded sample
-            // range produces identical pixels for visible chunks).
+            // Phase 1: Compute FFT once and render visible chunks for ALL
+            // channels before background batches (multi-channel fairness).
             const phase1Start = performance.now();
             const channelRanges: Array<{
               ch: number;
@@ -530,28 +581,32 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               visibleIndices: number[];
               remainingIndices: number[];
             }> = [];
+
+            // Collect visible/remaining ranges for all channels
             for (let ch = 0; ch < numChannels; ch++) {
               const channelInfo = clipCanvasInfo.get(ch);
               if (!channelInfo) continue;
               const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
               channelRanges.push({ ch, channelInfo, ...range });
+              console.log(
+                `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
+              );
+            }
 
-              if (!visibleAlreadyRendered) {
-                console.log(
-                  `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
-                );
-                await renderChunkSubset(
-                  workerApi!,
-                  cacheKey,
-                  channelInfo,
-                  range.visibleIndices,
-                  item,
-                  ch
-                );
-              } else {
-                console.log(
-                  `[spectrogram] phase1 ch=${ch}: skipped (already rendered), remaining=[${range.remainingIndices.join(',')}]`
-                );
+            // Compute FFT once for the visible range (covers all channels)
+            if (channelRanges.length > 0 && channelRanges[0].visibleIndices.length > 0) {
+              const cacheKey = await computeFFTForChunks(
+                workerApi!,
+                channelRanges[0].channelInfo,
+                channelRanges[0].visibleIndices,
+                item
+              );
+
+              if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+
+              // Render all channels from the single cached FFT
+              for (const { ch, channelInfo, visibleIndices } of channelRanges) {
+                await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
               }
             }
 
@@ -559,10 +614,13 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               `[spectrogram] phase1 complete: ${(performance.now() - phase1Start).toFixed(1)}ms`
             );
 
+            renderedClipIdsRef.current.add(item.clipId);
+
             if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
-            // Phase 2: Render off-screen chunks in background batches.
-            if (await renderBackgroundBatches(channelRanges, cacheKey, item)) return;
+            // Phase 2: Render off-screen chunks in background batches
+            // (each batch computes its own bounded FFT range).
+            if (await renderBackgroundBatches(channelRanges, item)) return;
           }
         } catch (err) {
           console.warn('Spectrogram worker error for clip', item.clipId, err);
@@ -572,16 +630,14 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       for (const item of clipsNeedingDisplayOnly) {
         if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
-        const cacheKey = clipCacheKeysRef.current.get(item.clipId);
-        if (!cacheKey) continue;
-
         const clipCanvasInfo = spectrogramCanvasRegistryRef.current.get(item.clipId);
         if (!clipCanvasInfo || clipCanvasInfo.size === 0) continue;
 
         try {
           const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
 
-          // Two-phase rendering: visible chunks first, then background (same as FFT path above).
+          // Two-phase rendering with per-batch FFT (same as FFT path above).
+          // Worker cache provides instant hits for previously computed ranges.
           const channelRanges: Array<{
             ch: number;
             channelInfo: { canvasIds: string[]; canvasWidths: number[] };
@@ -595,13 +651,36 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               clipPixelOffset
             );
             channelRanges.push({ ch, channelInfo, remainingIndices });
-            await renderChunkSubset(workerApi!, cacheKey, channelInfo, visibleIndices, item, ch);
+          }
+
+          // Compute FFT once, render all channels
+          if (channelRanges.length > 0) {
+            const firstVisible = channelRanges.find((r) => r.channelInfo.canvasIds.length > 0);
+            if (firstVisible) {
+              const visibleIndices = getVisibleChunkRange(
+                firstVisible.channelInfo,
+                clipPixelOffset
+              ).visibleIndices;
+              if (visibleIndices.length > 0) {
+                const cacheKey = await computeFFTForChunks(
+                  workerApi!,
+                  firstVisible.channelInfo,
+                  visibleIndices,
+                  item
+                );
+                if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+                for (const { ch, channelInfo } of channelRanges) {
+                  const chVisible = getVisibleChunkRange(channelInfo, clipPixelOffset).visibleIndices;
+                  await renderChunkSubset(workerApi!, cacheKey, channelInfo, chVisible, item, ch);
+                }
+              }
+            }
           }
 
           if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
           // Phase 2: Render off-screen chunks in background batches.
-          if (await renderBackgroundBatches(channelRanges, cacheKey, item)) return;
+          if (await renderBackgroundBatches(channelRanges, item)) return;
         } catch (err) {
           console.warn('Spectrogram display re-render error for clip', item.clipId, err);
         }

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -30,12 +30,15 @@ function extractChunkNumber(canvasId: string): number {
 export interface SpectrogramProviderProps {
   config?: SpectrogramConfig;
   colorMap?: ColorMapValue;
+  /** Number of Web Workers for parallel FFT computation. Defaults to min(cores - 1, 4). */
+  workerPoolSize?: number;
   children: ReactNode;
 }
 
 export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
   config: spectrogramConfig,
   colorMap: spectrogramColorMap,
+  workerPoolSize,
   children,
 }) => {
   const { tracks, waveHeight, samplesPerPixel, isReady, mono } = usePlaylistData();
@@ -83,7 +86,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             new Worker(
               new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
               { type: 'module' }
-            )
+            ),
+          workerPoolSize
         );
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
@@ -200,7 +204,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             new Worker(
               new URL('@waveform-playlist/spectrogram/worker/spectrogram.worker', import.meta.url),
               { type: 'module' }
-            )
+            ),
+          workerPoolSize
         );
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -30,7 +30,7 @@ function extractChunkNumber(canvasId: string): number {
 export interface SpectrogramProviderProps {
   config?: SpectrogramConfig;
   colorMap?: ColorMapValue;
-  /** Number of Web Workers for parallel FFT computation. Defaults to min(cores - 1, 4). */
+  /** Number of Web Workers for parallel FFT computation. Defaults to 2 (one per stereo channel). */
   workerPoolSize?: number;
   children: ReactNode;
 }
@@ -91,8 +91,10 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         );
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
-      } catch {
-        console.warn('Spectrogram Web Worker unavailable for pre-transfer');
+      } catch (err) {
+        console.warn(
+          `[waveform-playlist] Spectrogram Web Worker unavailable for pre-transfer: ${err instanceof Error ? err.message : String(err)}`
+        );
         return;
       }
     }
@@ -121,7 +123,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         registeredAudioClipIdsRef.current.delete(clipId);
       }
     }
-  }, [isReady, tracks]);
+    // workerPoolSize intentionally omitted — pool is created once via spectrogramWorkerRef guard
+  }, [isReady, tracks]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Main spectrogram computation effect
   useEffect(() => {
@@ -679,7 +682,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
           }
         } catch (err) {
           if (err instanceof Error && err.message === 'aborted') return;
-          console.warn('Spectrogram worker error for clip', item.clipId, err);
+          console.warn(
+            `[waveform-playlist] Spectrogram worker error for clip ${item.clipId}: ${err instanceof Error ? err.message : String(err)}`
+          );
         }
       }
 
@@ -769,7 +774,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
           if (await renderBackgroundBatches(channelRanges, item)) return;
         } catch (err) {
           if (err instanceof Error && err.message === 'aborted') return;
-          console.warn('Spectrogram display re-render error for clip', item.clipId, err);
+          console.warn(
+            `[waveform-playlist] Spectrogram display re-render error for clip ${item.clipId}: ${err instanceof Error ? err.message : String(err)}`
+          );
         }
       }
     };
@@ -777,6 +784,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     computeAsync().catch((err) => {
       console.error('[waveform-playlist] Spectrogram computation failed:', err);
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workerPoolSize intentionally omitted, pool created once via spectrogramWorkerRef guard
   }, [
     tracks,
     mono,

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -1,19 +1,13 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import {
   MAX_CANVAS_WIDTH,
-  type SpectrogramData,
   type SpectrogramConfig,
   type SpectrogramComputeConfig,
   type ColorMapValue,
   type RenderMode,
   type TrackSpectrogramOverrides,
 } from '@waveform-playlist/core';
-import {
-  computeSpectrogram,
-  computeSpectrogramMono,
-  getColorMap,
-  getFrequencyScale,
-} from './computation';
+import { getColorMap, getFrequencyScale } from './computation';
 import { createSpectrogramWorker, type SpectrogramWorkerApi } from './worker';
 import { SpectrogramMenuItems } from './components';
 import { SpectrogramSettingsModal } from './components';
@@ -44,13 +38,10 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
   colorMap: spectrogramColorMap,
   children,
 }) => {
-  const { tracks, waveHeight, samplesPerPixel, isReady, mono, controls } = usePlaylistData();
+  const { tracks, waveHeight, samplesPerPixel, isReady, mono } = usePlaylistData();
   const { scrollContainerRef } = usePlaylistControls();
 
   // State
-  const [spectrogramDataMap, setSpectrogramDataMap] = useState<Map<string, SpectrogramData[]>>(
-    new Map()
-  );
   const [trackSpectrogramOverrides, setTrackSpectrogramOverrides] = useState<
     Map<string, TrackSpectrogramOverrides>
   >(new Map());
@@ -188,28 +179,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       prevSpectrogramFFTKeyRef.current = currentFFTKeys;
     }
 
-    if (configChanged) {
-      setSpectrogramDataMap((prevMap) => {
-        const activeClipIds = new Set<string>();
-        for (const track of tracks) {
-          const mode =
-            trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
-          if (mode === 'spectrogram' || mode === 'both') {
-            for (const clip of track.clips) {
-              activeClipIds.add(clip.id);
-            }
-          }
-        }
-        const newMap = new Map(prevMap);
-        for (const clipId of newMap.keys()) {
-          if (!activeClipIds.has(clipId)) {
-            newMap.delete(clipId);
-          }
-        }
-        return newMap;
-      });
-    }
-
     if (backgroundRenderAbortRef.current) {
       backgroundRenderAbortRef.current.aborted = true;
     }
@@ -226,8 +195,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         workerApi = createSpectrogramWorker(rawWorker);
         spectrogramWorkerRef.current = workerApi;
         setSpectrogramWorkerReady(true);
-      } catch {
-        console.warn('Spectrogram Web Worker unavailable, falling back to synchronous computation');
+      } catch (err) {
+        console.error('[waveform-playlist] Spectrogram Web Worker required but unavailable:', err);
+        return;
       }
     }
 
@@ -318,46 +288,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
     if (clipsNeedingFFT.length === 0 && clipsNeedingDisplayOnly.length === 0) return;
 
-    if (!workerApi) {
-      try {
-        setSpectrogramDataMap((prevMap) => {
-          const newMap = new Map(prevMap);
-          for (const item of clipsNeedingFFT) {
-            const clip = tracks.flatMap((t) => t.clips).find((c) => c.id === item.clipId);
-            if (!clip?.audioBuffer) continue;
-            const channelSpectrograms: SpectrogramData[] = [];
-            if (item.monoFlag) {
-              channelSpectrograms.push(
-                computeSpectrogramMono(
-                  clip.audioBuffer,
-                  item.config,
-                  item.offsetSamples,
-                  item.durationSamples
-                )
-              );
-            } else {
-              for (let ch = 0; ch < clip.audioBuffer.numberOfChannels; ch++) {
-                channelSpectrograms.push(
-                  computeSpectrogram(
-                    clip.audioBuffer,
-                    item.config,
-                    item.offsetSamples,
-                    item.durationSamples,
-                    ch
-                  )
-                );
-              }
-            }
-            newMap.set(item.clipId, channelSpectrograms);
-          }
-          return newMap;
-        });
-      } catch (err) {
-        console.error('[waveform-playlist] Synchronous spectrogram computation failed:', err);
-      }
-      return;
-    }
-
     const getVisibleChunkRange = (
       channelInfo: { canvasIds: string[]; canvasWidths: number[] },
       clipPixelOffset = 0
@@ -369,7 +299,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
       const scrollLeft = container.scrollLeft;
       const viewportWidth = container.clientWidth;
-      const controlWidth = controls.show ? controls.width : 0;
 
       const visibleIndices: number[] = [];
       const remainingIndices: number[] = [];
@@ -378,8 +307,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         // Extract the actual chunk number from the canvas ID to compute the
         // correct global pixel offset. With virtual scrolling, the registry
         // may contain non-consecutive chunks (e.g., chunks 50-55).
+        // Controls are outside the scroll container, so no controlWidth offset needed.
         const chunkNumber = extractChunkNumber(channelInfo.canvasIds[i]);
-        const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + controlWidth + clipPixelOffset;
+        const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + clipPixelOffset;
         const chunkRight = chunkLeft + channelInfo.canvasWidths[i];
         if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
           visibleIndices.push(i);
@@ -480,6 +410,17 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             const numChannels = item.monoFlag ? 1 : item.channelDataArrays.length;
             const clipPixelOffset = Math.floor(item.clipStartSample / samplesPerPixel);
 
+            // Debug: log registered canvas info per channel
+            for (const [ch, info] of clipCanvasInfo.entries()) {
+              const chunkNumbers = info.canvasIds.map((id: string) => {
+                const m = id.match(/chunk(\d+)$/);
+                return m ? parseInt(m[1], 10) : -1;
+              });
+              console.log(
+                `[spectrogram] clip=${item.clipId} ch=${ch} registered chunks=[${chunkNumbers.join(',')}] widths=[${info.canvasWidths.join(',')}]`
+              );
+            }
+
             const container = scrollContainerRef.current;
             const windowSize = item.config.fftSize ?? 2048;
             let visibleRange: { start: number; end: number } | undefined;
@@ -487,9 +428,10 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             if (container) {
               const scrollLeft = container.scrollLeft;
               const viewportWidth = container.clientWidth;
-              const controlWidth = controls.show ? controls.width : 0;
 
-              const vpStartPx = Math.max(0, scrollLeft - controlWidth);
+              // Controls are outside the scroll container, so scrollLeft is
+              // already in clip-local coordinate space — no controlWidth offset.
+              const vpStartPx = scrollLeft;
               const vpEndPx = vpStartPx + viewportWidth;
 
               const clipStartPx = clipPixelOffset;
@@ -517,6 +459,13 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
                   visibleRange = { start: paddedStart, end: paddedEnd };
                 }
               }
+
+              console.log(
+                `[spectrogram] viewport: scrollLeft=${scrollLeft} width=${viewportWidth} ` +
+                  `vpPx=[${vpStartPx},${vpEndPx}] ` +
+                  `clipPx=[${clipStartPx},${clipEndPx}] ` +
+                  `visibleRange=${visibleRange ? `[${visibleRange.start},${visibleRange.end}]` : 'full'}`
+              );
             }
 
             const fullClipAlreadyCached = clipCacheKeysRef.current.has(item.clipId);
@@ -568,6 +517,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             // Phase 1: Render visible chunks for ALL channels first.
             // This prevents ch1 from being starved when ch0's background
             // batches cause generation aborts during scrolling.
+            const phase1Start = performance.now();
             const channelRanges: Array<{
               ch: number;
               channelInfo: { canvasIds: string[]; canvasWidths: number[] };
@@ -579,6 +529,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               if (!channelInfo) continue;
               const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
               channelRanges.push({ ch, channelInfo, ...range });
+              console.log(
+                `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
+              );
               await renderChunkSubset(
                 workerApi!,
                 cacheKey,
@@ -589,27 +542,14 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               );
             }
 
+            console.log(
+              `[spectrogram] phase1 complete: ${(performance.now() - phase1Start).toFixed(1)}ms`
+            );
+
             if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
 
             // Phase 2: Render off-screen chunks in background batches.
             if (await renderBackgroundBatches(channelRanges, cacheKey, item)) return;
-          } else {
-            const spectrograms = await workerApi!.compute({
-              channelDataArrays: item.channelDataArrays,
-              config: item.config,
-              sampleRate: item.sampleRate,
-              offsetSamples: item.offsetSamples,
-              durationSamples: item.durationSamples,
-              mono: item.monoFlag,
-            });
-
-            if (spectrogramGenerationRef.current !== generation) return;
-
-            setSpectrogramDataMap((prevMap) => {
-              const newMap = new Map(prevMap);
-              newMap.set(item.clipId, spectrograms);
-              return newMap;
-            });
           }
         } catch (err) {
           console.warn('Spectrogram worker error for clip', item.clipId, err);
@@ -667,7 +607,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     waveHeight,
     samplesPerPixel,
     spectrogramCanvasVersion,
-    controls,
     scrollContainerRef,
   ]);
 
@@ -741,7 +680,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
   const value: SpectrogramIntegration = useMemo(
     () => ({
-      spectrogramDataMap,
+      spectrogramDataMap: new Map(),
       trackSpectrogramOverrides,
       spectrogramWorkerApi: spectrogramWorkerReady ? spectrogramWorkerRef.current : null,
       spectrogramConfig,
@@ -758,7 +697,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       ) => (f: number, minF: number, maxF: number) => number,
     }),
     [
-      spectrogramDataMap,
       trackSpectrogramOverrides,
       spectrogramWorkerReady,
       spectrogramConfig,

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -469,7 +469,11 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             }
 
             const fullClipAlreadyCached = clipCacheKeysRef.current.has(item.clipId);
+            let visibleAlreadyRendered = false;
+
             if (visibleRange && !fullClipAlreadyCached) {
+              // Phase 0: Fast visible-range FFT — compute and render only the
+              // portion of the clip that's currently on screen.
               const { cacheKey: visibleCacheKey } = await workerApi!.computeFFT({
                 clipId: item.clipId,
                 channelDataArrays: item.channelDataArrays,
@@ -498,8 +502,10 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               }
 
               if (spectrogramGenerationRef.current !== generation || abortToken.aborted) return;
+              visibleAlreadyRendered = true;
             }
 
+            // Full-clip FFT (needed for off-screen chunks and scrolling).
             const { cacheKey } = await workerApi!.computeFFT({
               clipId: item.clipId,
               channelDataArrays: item.channelDataArrays,
@@ -514,9 +520,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
 
             clipCacheKeysRef.current.set(item.clipId, cacheKey);
 
-            // Phase 1: Render visible chunks for ALL channels first.
-            // This prevents ch1 from being starved when ch0's background
-            // batches cause generation aborts during scrolling.
+            // Phase 1: Render visible chunks for ALL channels first (unless
+            // already rendered from the visible-range FFT — the padded sample
+            // range produces identical pixels for visible chunks).
             const phase1Start = performance.now();
             const channelRanges: Array<{
               ch: number;
@@ -529,17 +535,24 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
               if (!channelInfo) continue;
               const range = getVisibleChunkRange(channelInfo, clipPixelOffset);
               channelRanges.push({ ch, channelInfo, ...range });
-              console.log(
-                `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
-              );
-              await renderChunkSubset(
-                workerApi!,
-                cacheKey,
-                channelInfo,
-                range.visibleIndices,
-                item,
-                ch
-              );
+
+              if (!visibleAlreadyRendered) {
+                console.log(
+                  `[spectrogram] phase1 ch=${ch}: visible=[${range.visibleIndices.join(',')}] remaining=[${range.remainingIndices.join(',')}]`
+                );
+                await renderChunkSubset(
+                  workerApi!,
+                  cacheKey,
+                  channelInfo,
+                  range.visibleIndices,
+                  item,
+                  ch
+                );
+              } else {
+                console.log(
+                  `[spectrogram] phase1 ch=${ch}: skipped (already rendered), remaining=[${range.remainingIndices.join(',')}]`
+                );
+              }
             }
 
             console.log(

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -8,7 +8,11 @@ import {
   type TrackSpectrogramOverrides,
 } from '@waveform-playlist/core';
 import { getColorMap, getFrequencyScale } from './computation';
-import { createSpectrogramWorkerPool, type SpectrogramWorkerApi } from './worker';
+import {
+  createSpectrogramWorkerPool,
+  SpectrogramAbortError,
+  type SpectrogramWorkerApi,
+} from './worker';
 import { SpectrogramMenuItems } from './components';
 import { SpectrogramSettingsModal } from './components';
 import {
@@ -681,7 +685,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
             if (await renderBackgroundBatches(channelRanges, item)) return;
           }
         } catch (err) {
-          if (err instanceof Error && err.message === 'aborted') return;
+          if (err instanceof SpectrogramAbortError) return;
           console.warn(
             `[waveform-playlist] Spectrogram worker error for clip ${item.clipId}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -773,7 +777,7 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
           // Phase 2: Render off-screen chunks in background batches.
           if (await renderBackgroundBatches(channelRanges, item)) return;
         } catch (err) {
-          if (err instanceof Error && err.message === 'aborted') return;
+          if (err instanceof SpectrogramAbortError) return;
           console.warn(
             `[waveform-playlist] Spectrogram display re-render error for clip ${item.clipId}: ${err instanceof Error ? err.message : String(err)}`
           );

--- a/packages/spectrogram/src/index.ts
+++ b/packages/spectrogram/src/index.ts
@@ -15,7 +15,7 @@ export type { SpectrogramSettingsModalProps } from './components';
 export type { TrackMenuItem } from './components';
 
 // Worker
-export { createSpectrogramWorker } from './worker';
+export { createSpectrogramWorker, SpectrogramAbortError } from './worker';
 export { createSpectrogramWorkerPool } from './worker';
 export type { SpectrogramWorkerApi } from './worker';
 

--- a/packages/spectrogram/src/index.ts
+++ b/packages/spectrogram/src/index.ts
@@ -16,6 +16,7 @@ export type { TrackMenuItem } from './components';
 
 // Worker
 export { createSpectrogramWorker } from './worker';
+export { createSpectrogramWorkerPool } from './worker';
 export type { SpectrogramWorkerApi } from './worker';
 
 // Provider

--- a/packages/spectrogram/src/index.ts
+++ b/packages/spectrogram/src/index.ts
@@ -16,7 +16,7 @@ export type { TrackMenuItem } from './components';
 
 // Worker
 export { createSpectrogramWorker } from './worker';
-export type { SpectrogramWorkerApi, SpectrogramWorkerRenderParams } from './worker';
+export type { SpectrogramWorkerApi } from './worker';
 
 // Provider
 export { SpectrogramProvider } from './SpectrogramProvider';

--- a/packages/spectrogram/src/worker/createSpectrogramWorker.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorker.ts
@@ -31,6 +31,7 @@ export interface SpectrogramWorkerRenderChunksParams {
 type ComputeResponse =
   | { id: string; type: 'cache-key'; cacheKey: string }
   | { id: string; type: 'done' }
+  | { id: string; type: 'aborted' }
   | { id: string; type: 'error'; error: string };
 
 /** Union of all values that worker resolve callbacks receive. */
@@ -52,8 +53,12 @@ function addPending<T>(
 }
 
 export interface SpectrogramWorkerApi {
-  computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }>;
-  renderChunks(params: SpectrogramWorkerRenderChunksParams): Promise<void>;
+  computeFFT(
+    params: SpectrogramWorkerFFTParams,
+    generation?: number
+  ): Promise<{ cacheKey: string }>;
+  renderChunks(params: SpectrogramWorkerRenderChunksParams, generation?: number): Promise<void>;
+  abortGeneration(generation: number): void;
   registerCanvas(canvasId: string, canvas: OffscreenCanvas): void;
   unregisterCanvas(canvasId: string): void;
   registerAudioData(clipId: string, channelDataArrays: Float32Array[], sampleRate: number): void;
@@ -91,6 +96,9 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
         case 'error':
           entry.reject(new Error(msg.error));
           break;
+        case 'aborted':
+          entry.reject(new Error('aborted'));
+          break;
         case 'cache-key':
           entry.resolve({ cacheKey: msg.cacheKey });
           break;
@@ -112,7 +120,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
   };
 
   return {
-    computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }> {
+    computeFFT(params: SpectrogramWorkerFFTParams, generation = 0): Promise<{ cacheKey: string }> {
       if (terminated) return Promise.reject(new Error('Worker terminated'));
       const id = String(++idCounter);
 
@@ -130,6 +138,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
           {
             type: 'compute-fft',
             id,
+            generation,
             clipId: params.clipId,
             channelDataArrays: transferableArrays,
             config: params.config,
@@ -144,7 +153,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
       });
     },
 
-    renderChunks(params: SpectrogramWorkerRenderChunksParams): Promise<void> {
+    renderChunks(params: SpectrogramWorkerRenderChunksParams, generation = 0): Promise<void> {
       if (terminated) return Promise.reject(new Error('Worker terminated'));
       const id = String(++idCounter);
 
@@ -154,6 +163,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
         worker.postMessage({
           type: 'render-chunks',
           id,
+          generation,
           cacheKey: params.cacheKey,
           canvasIds: params.canvasIds,
           canvasWidths: params.canvasWidths,
@@ -170,6 +180,11 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
           channelIndex: params.channelIndex,
         });
       });
+    },
+
+    abortGeneration(generation: number): void {
+      if (terminated) return;
+      worker.postMessage({ type: 'abort-generation', generation });
     },
 
     registerCanvas(canvasId: string, canvas: OffscreenCanvas): void {

--- a/packages/spectrogram/src/worker/createSpectrogramWorker.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorker.ts
@@ -1,5 +1,16 @@
 import type { SpectrogramConfig } from '@waveform-playlist/core';
 
+/**
+ * Error thrown when a spectrogram computation is aborted due to a generation change.
+ * Use `instanceof SpectrogramAbortError` instead of string matching on error messages.
+ */
+export class SpectrogramAbortError extends Error {
+  constructor() {
+    super('aborted');
+    this.name = 'SpectrogramAbortError';
+  }
+}
+
 export interface SpectrogramWorkerFFTParams {
   clipId: string;
   channelDataArrays: Float32Array[];
@@ -99,7 +110,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
           entry.reject(new Error(msg.error));
           break;
         case 'aborted':
-          entry.reject(new Error('aborted'));
+          entry.reject(new SpectrogramAbortError());
           break;
         case 'cache-key':
           entry.resolve({ cacheKey: msg.cacheKey });

--- a/packages/spectrogram/src/worker/createSpectrogramWorker.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorker.ts
@@ -9,6 +9,8 @@ export interface SpectrogramWorkerFFTParams {
   durationSamples: number;
   mono: boolean;
   sampleRange?: { start: number; end: number };
+  /** If set, compute only this channel index (used by worker pool). */
+  channelFilter?: number;
 }
 
 export interface SpectrogramWorkerRenderChunksParams {
@@ -147,6 +149,7 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
             durationSamples: params.durationSamples,
             mono: params.mono,
             ...(params.sampleRange ? { sampleRange: params.sampleRange } : {}),
+            ...(params.channelFilter !== undefined ? { channelFilter: params.channelFilter } : {}),
           },
           transferables
         );

--- a/packages/spectrogram/src/worker/createSpectrogramWorker.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorker.ts
@@ -1,27 +1,4 @@
-import type { SpectrogramConfig, SpectrogramData } from '@waveform-playlist/core';
-
-export interface SpectrogramWorkerComputeParams {
-  channelDataArrays: Float32Array[];
-  config: SpectrogramConfig;
-  sampleRate: number;
-  offsetSamples: number;
-  durationSamples: number;
-  mono: boolean;
-}
-
-export interface SpectrogramWorkerRenderParams extends SpectrogramWorkerComputeParams {
-  render: {
-    canvasIds: string[][];
-    canvasWidths: number[];
-    canvasHeight: number;
-    devicePixelRatio: number;
-    samplesPerPixel: number;
-    colorLUT: Uint8Array;
-    frequencyScale: string;
-    minFrequency: number;
-    maxFrequency: number;
-  };
-}
+import type { SpectrogramConfig } from '@waveform-playlist/core';
 
 export interface SpectrogramWorkerFFTParams {
   clipId: string;
@@ -52,13 +29,12 @@ export interface SpectrogramWorkerRenderChunksParams {
 }
 
 type ComputeResponse =
-  | { id: string; type: 'spectrograms'; spectrograms: SpectrogramData[] }
   | { id: string; type: 'cache-key'; cacheKey: string }
   | { id: string; type: 'done' }
   | { id: string; type: 'error'; error: string };
 
 /** Union of all values that worker resolve callbacks receive. */
-type PendingResolveValue = SpectrogramData[] | { cacheKey: string } | void;
+type PendingResolveValue = { cacheKey: string } | void;
 
 interface PendingEntry {
   resolve: (value: PendingResolveValue) => void;
@@ -76,14 +52,12 @@ function addPending<T>(
 }
 
 export interface SpectrogramWorkerApi {
-  compute(params: SpectrogramWorkerComputeParams): Promise<SpectrogramData[]>;
   computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }>;
   renderChunks(params: SpectrogramWorkerRenderChunksParams): Promise<void>;
   registerCanvas(canvasId: string, canvas: OffscreenCanvas): void;
   unregisterCanvas(canvasId: string): void;
   registerAudioData(clipId: string, channelDataArrays: Float32Array[], sampleRate: number): void;
   unregisterAudioData(clipId: string): void;
-  computeAndRender(params: SpectrogramWorkerRenderParams): Promise<void>;
   terminate(): void;
 }
 
@@ -123,9 +97,6 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
         case 'done':
           entry.resolve(undefined);
           break;
-        case 'spectrograms':
-          entry.resolve(msg.spectrograms);
-          break;
       }
     } else if (msg.id) {
       console.warn(`[spectrogram] Received response for unknown message ID: ${msg.id}`);
@@ -141,32 +112,6 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
   };
 
   return {
-    compute(params: SpectrogramWorkerComputeParams): Promise<SpectrogramData[]> {
-      if (terminated) return Promise.reject(new Error('Worker terminated'));
-      const id = String(++idCounter);
-
-      return new Promise<SpectrogramData[]>((resolve, reject) => {
-        addPending(pending, id, resolve, reject);
-
-        // Slice channel data so we can transfer without detaching the original AudioBuffer views
-        const transferableArrays = params.channelDataArrays.map((arr) => arr.slice());
-        const transferables = transferableArrays.map((arr) => arr.buffer);
-
-        worker.postMessage(
-          {
-            id,
-            channelDataArrays: transferableArrays,
-            config: params.config,
-            sampleRate: params.sampleRate,
-            offsetSamples: params.offsetSamples,
-            durationSamples: params.durationSamples,
-            mono: params.mono,
-          },
-          transferables
-        );
-      });
-    },
-
     computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }> {
       if (terminated) return Promise.reject(new Error('Worker terminated'));
       const id = String(++idCounter);
@@ -248,33 +193,6 @@ export function createSpectrogramWorker(worker: Worker): SpectrogramWorkerApi {
     unregisterAudioData(clipId: string): void {
       worker.postMessage({ type: 'unregister-audio-data', clipId });
       registeredClipIds.delete(clipId);
-    },
-
-    computeAndRender(params: SpectrogramWorkerRenderParams): Promise<void> {
-      if (terminated) return Promise.reject(new Error('Worker terminated'));
-      const id = String(++idCounter);
-
-      return new Promise<void>((resolve, reject) => {
-        addPending(pending, id, resolve, reject);
-
-        const transferableArrays = params.channelDataArrays.map((arr) => arr.slice());
-        const transferables: Transferable[] = transferableArrays.map((arr) => arr.buffer);
-
-        worker.postMessage(
-          {
-            type: 'compute-render',
-            id,
-            channelDataArrays: transferableArrays,
-            config: params.config,
-            sampleRate: params.sampleRate,
-            offsetSamples: params.offsetSamples,
-            durationSamples: params.durationSamples,
-            mono: params.mono,
-            render: params.render,
-          },
-          transferables
-        );
-      });
     },
 
     terminate() {

--- a/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -26,16 +26,13 @@ function parseChannelFromCanvasId(canvasId: string): number {
  * fans out with channelFilter so each worker computes only its channel.
  */
 /**
- * Default pool size: min of 2 and available logical cores (minus 1 for the main thread).
- * Falls back to 2 if navigator.hardwareConcurrency is unavailable.
+ * Default pool size: 2 workers (one per channel for stereo).
+ * Most web audio is mono or stereo, so 2 is sufficient.
+ * Configurable via `<SpectrogramProvider workerPoolSize={N}>` for
+ * multi-channel audio (e.g., 5.1 surround).
  */
 function defaultPoolSize(): number {
-  const cores =
-    typeof navigator !== 'undefined' && navigator.hardwareConcurrency
-      ? navigator.hardwareConcurrency
-      : 4;
-  // Reserve 1 core for main thread, cap at a reasonable maximum
-  return Math.max(1, Math.min(cores - 1, 4));
+  return 2;
 }
 
 export function createSpectrogramWorkerPool(

--- a/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -25,9 +25,22 @@ function parseChannelFromCanvasId(canvasId: string): number {
  * mode). Canvases are routed to the worker for their channel. computeFFT
  * fans out with channelFilter so each worker computes only its channel.
  */
+/**
+ * Default pool size: min of 2 and available logical cores (minus 1 for the main thread).
+ * Falls back to 2 if navigator.hardwareConcurrency is unavailable.
+ */
+function defaultPoolSize(): number {
+  const cores =
+    typeof navigator !== 'undefined' && navigator.hardwareConcurrency
+      ? navigator.hardwareConcurrency
+      : 4;
+  // Reserve 1 core for main thread, cap at a reasonable maximum
+  return Math.max(1, Math.min(cores - 1, 4));
+}
+
 export function createSpectrogramWorkerPool(
   createWorker: () => Worker,
-  poolSize = 2
+  poolSize = defaultPoolSize()
 ): SpectrogramWorkerApi {
   const workers: SpectrogramWorkerApi[] = [];
   for (let i = 0; i < poolSize; i++) {

--- a/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -58,8 +58,12 @@ export function createSpectrogramWorkerPool(
         return workers[0].computeFFT(params, generation);
       }
 
-      // Multi-channel: fan out with channelFilter, each worker computes its channel
-      const promises = workers.map((w, i) =>
+      // Multi-channel: fan out with channelFilter, one worker per channel.
+      // Pool may have more workers than channels (e.g., 3 workers for stereo) —
+      // only use workers up to the channel count.
+      const channelCount = params.channelDataArrays.length;
+      const activeWorkers = workers.slice(0, channelCount);
+      const promises = activeWorkers.map((w, i) =>
         w.computeFFT({ ...params, channelFilter: i }, generation)
       );
       // Wait for all workers, return any cacheKey (all are identical)

--- a/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -1,0 +1,97 @@
+import {
+  createSpectrogramWorker,
+  type SpectrogramWorkerApi,
+  type SpectrogramWorkerFFTParams,
+  type SpectrogramWorkerRenderChunksParams,
+} from './createSpectrogramWorker';
+
+/**
+ * Parse the channel index from a canvas ID like "clipId-ch0-chunk5" → 0.
+ */
+function parseChannelFromCanvasId(canvasId: string): number {
+  const match = canvasId.match(/-ch(\d+)-/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+/**
+ * Creates a pool of spectrogram workers that parallelize FFT computation
+ * across channels. Each worker handles a subset of channels, so stereo
+ * audio computes ch0 and ch1 FFTs in parallel (~1.5s instead of ~2.9s).
+ *
+ * The pool exposes the same `SpectrogramWorkerApi` interface, so it's
+ * a drop-in replacement for a single worker in SpectrogramProvider.
+ *
+ * Audio data is registered in ALL workers (each needs full data for mono
+ * mode). Canvases are routed to the worker for their channel. computeFFT
+ * fans out with channelFilter so each worker computes only its channel.
+ */
+export function createSpectrogramWorkerPool(
+  createWorker: () => Worker,
+  poolSize = 2
+): SpectrogramWorkerApi {
+  const workers: SpectrogramWorkerApi[] = [];
+  for (let i = 0; i < poolSize; i++) {
+    workers.push(createSpectrogramWorker(createWorker()));
+  }
+
+  function getWorkerForChannel(channelIndex: number): SpectrogramWorkerApi {
+    return workers[channelIndex % workers.length];
+  }
+
+  return {
+    computeFFT(params: SpectrogramWorkerFFTParams, generation = 0): Promise<{ cacheKey: string }> {
+      // Mono: single worker computes the mono mix (needs all channel data)
+      if (params.mono) {
+        return workers[0].computeFFT(params, generation);
+      }
+
+      // Multi-channel: fan out with channelFilter, each worker computes its channel
+      const promises = workers.map((w, i) =>
+        w.computeFFT({ ...params, channelFilter: i }, generation)
+      );
+      // Wait for all workers, return any cacheKey (all are identical)
+      return Promise.all(promises).then((results) => results[0]);
+    },
+
+    renderChunks(params: SpectrogramWorkerRenderChunksParams, generation = 0): Promise<void> {
+      const worker = getWorkerForChannel(params.channelIndex);
+      // Remap channelIndex to 0 — each worker stores its channel at index 0
+      return worker.renderChunks({ ...params, channelIndex: 0 }, generation);
+    },
+
+    abortGeneration(generation: number): void {
+      for (const w of workers) {
+        w.abortGeneration(generation);
+      }
+    },
+
+    registerCanvas(canvasId: string, canvas: OffscreenCanvas): void {
+      const ch = parseChannelFromCanvasId(canvasId);
+      getWorkerForChannel(ch).registerCanvas(canvasId, canvas);
+    },
+
+    unregisterCanvas(canvasId: string): void {
+      const ch = parseChannelFromCanvasId(canvasId);
+      getWorkerForChannel(ch).unregisterCanvas(canvasId);
+    },
+
+    registerAudioData(clipId: string, channelDataArrays: Float32Array[], sampleRate: number): void {
+      // All workers get full audio data (needed for mono computation)
+      for (const w of workers) {
+        w.registerAudioData(clipId, channelDataArrays, sampleRate);
+      }
+    },
+
+    unregisterAudioData(clipId: string): void {
+      for (const w of workers) {
+        w.unregisterAudioData(clipId);
+      }
+    },
+
+    terminate(): void {
+      for (const w of workers) {
+        w.terminate();
+      }
+    },
+  };
+}

--- a/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -40,8 +40,15 @@ export function createSpectrogramWorkerPool(
   poolSize = defaultPoolSize()
 ): SpectrogramWorkerApi {
   const workers: SpectrogramWorkerApi[] = [];
-  for (let i = 0; i < poolSize; i++) {
-    workers.push(createSpectrogramWorker(createWorker()));
+  try {
+    for (let i = 0; i < poolSize; i++) {
+      workers.push(createSpectrogramWorker(createWorker()));
+    }
+  } catch (err) {
+    for (const w of workers) {
+      w.terminate();
+    }
+    throw err;
   }
 
   function getWorkerForChannel(channelIndex: number): SpectrogramWorkerApi {

--- a/packages/spectrogram/src/worker/index.ts
+++ b/packages/spectrogram/src/worker/index.ts
@@ -1,4 +1,5 @@
 export { createSpectrogramWorker } from './createSpectrogramWorker';
+export { createSpectrogramWorkerPool } from './createSpectrogramWorkerPool';
 export type {
   SpectrogramWorkerFFTParams,
   SpectrogramWorkerRenderChunksParams,

--- a/packages/spectrogram/src/worker/index.ts
+++ b/packages/spectrogram/src/worker/index.ts
@@ -1,7 +1,5 @@
 export { createSpectrogramWorker } from './createSpectrogramWorker';
 export type {
-  SpectrogramWorkerComputeParams,
-  SpectrogramWorkerRenderParams,
   SpectrogramWorkerFFTParams,
   SpectrogramWorkerRenderChunksParams,
   SpectrogramWorkerApi,

--- a/packages/spectrogram/src/worker/index.ts
+++ b/packages/spectrogram/src/worker/index.ts
@@ -1,4 +1,4 @@
-export { createSpectrogramWorker } from './createSpectrogramWorker';
+export { createSpectrogramWorker, SpectrogramAbortError } from './createSpectrogramWorker';
 export { createSpectrogramWorkerPool } from './createSpectrogramWorkerPool';
 export type {
   SpectrogramWorkerFFTParams,

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -53,17 +53,6 @@ function generateCacheKey(params: {
 
 // --- Message types ---
 
-interface ComputeRequest {
-  type?: 'compute';
-  id: string;
-  channelDataArrays: Float32Array[];
-  config: SpectrogramConfig;
-  sampleRate: number;
-  offsetSamples: number;
-  durationSamples: number;
-  mono: boolean;
-}
-
 interface RegisterCanvasMessage {
   type: 'register-canvas';
   canvasId: string;
@@ -73,28 +62,6 @@ interface RegisterCanvasMessage {
 interface UnregisterCanvasMessage {
   type: 'unregister-canvas';
   canvasId: string;
-}
-
-interface ComputeRenderRequest {
-  type: 'compute-render';
-  id: string;
-  channelDataArrays: Float32Array[];
-  config: SpectrogramConfig;
-  sampleRate: number;
-  offsetSamples: number;
-  durationSamples: number;
-  mono: boolean;
-  render: {
-    canvasIds: string[][]; // [channel][chunk] → canvasId
-    canvasWidths: number[]; // per-chunk CSS widths
-    canvasHeight: number;
-    devicePixelRatio: number;
-    samplesPerPixel: number;
-    colorLUT: Uint8Array;
-    frequencyScale: string;
-    minFrequency: number;
-    maxFrequency: number;
-  };
 }
 
 interface RegisterAudioDataMessage {
@@ -142,17 +109,14 @@ interface RenderChunksRequest {
 }
 
 type WorkerMessage =
-  | ComputeRequest
   | RegisterCanvasMessage
   | UnregisterCanvasMessage
-  | ComputeRenderRequest
   | ComputeFFTRequest
   | RenderChunksRequest
   | RegisterAudioDataMessage
   | UnregisterAudioDataMessage;
 
 type ComputeResponse =
-  | { id: string; type: 'spectrograms'; spectrograms: SpectrogramData[] }
   | { id: string; type: 'cache-key'; cacheKey: string }
   | { id: string; type: 'done' }
   | { id: string; type: 'error'; error: string };
@@ -491,6 +455,8 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
       });
 
       if (!fftCache.has(cacheKey)) {
+        const t0 = performance.now();
+
         // Evict stale cache entries for this clip (different FFT params)
         const clipPrefix = `${clipId}:`;
         for (const key of fftCache.keys()) {
@@ -524,6 +490,16 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
           }
         }
         fftCache.set(cacheKey, { spectrograms, sampleOffset: effectiveOffset });
+
+        console.log(
+          `[spectrogram-worker] compute-fft: ${(performance.now() - t0).toFixed(1)}ms, ` +
+            `${spectrograms.length} channel(s), ` +
+            `${spectrograms[0].frameCount} frames, ` +
+            `range=${sampleRange ? `${sampleRange.start}-${sampleRange.end}` : 'full'}, ` +
+            `duration=${effectiveDuration} samples`
+        );
+      } else {
+        console.log(`[spectrogram-worker] compute-fft: cache hit for ${clipId}`);
       }
 
       const response: ComputeResponse = { id, type: 'cache-key', cacheKey };
@@ -563,6 +539,8 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
         return;
       }
 
+      const t0 = performance.now();
+
       const scaleFn = getFrequencyScale((frequencyScale ?? 'mel') as FrequencyScaleName);
       const isNonLinear = frequencyScale !== 'linear';
 
@@ -584,112 +562,21 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
         cacheEntry.sampleOffset
       );
 
-      const response: ComputeResponse = { id, type: 'done' };
-      (self as unknown as Worker).postMessage(response);
-    } catch (err) {
-      const response: ComputeResponse = { id, type: 'error', error: String(err) };
-      (self as unknown as Worker).postMessage(response);
-    }
-    return;
-  }
-
-  // Compute + render to registered canvases (uses cache internally)
-  if (msg.type === 'compute-render') {
-    const { id } = msg;
-    try {
-      const {
-        channelDataArrays,
-        config,
-        sampleRate,
-        offsetSamples,
-        durationSamples,
-        mono,
-        render,
-      } = msg;
-
-      // Compute spectrograms
-      const spectrograms: SpectrogramData[] = [];
-      if (mono || channelDataArrays.length === 1) {
-        spectrograms.push(
-          computeMonoFromChannels(
-            channelDataArrays,
-            config,
-            sampleRate,
-            offsetSamples,
-            durationSamples
-          )
-        );
-      } else {
-        for (const channelData of channelDataArrays) {
-          spectrograms.push(
-            computeFromChannelData(channelData, config, sampleRate, offsetSamples, durationSamples)
-          );
-        }
-      }
-
-      // Render each channel's spectrogram to its canvas chunks
-      const scaleFn = getFrequencyScale((render.frequencyScale ?? 'mel') as FrequencyScaleName);
-      const isNonLinear = render.frequencyScale !== 'linear';
-
-      for (let ch = 0; ch < spectrograms.length; ch++) {
-        const channelCanvasIds = render.canvasIds[ch];
-        if (!channelCanvasIds || channelCanvasIds.length === 0) continue;
-
-        renderSpectrogramToCanvas(
-          spectrograms[ch],
-          channelCanvasIds,
-          render.canvasWidths,
-          render.canvasHeight,
-          render.devicePixelRatio,
-          render.samplesPerPixel,
-          render.colorLUT,
-          scaleFn,
-          render.minFrequency,
-          render.maxFrequency,
-          isNonLinear
-        );
-      }
-
-      const response: ComputeResponse = { id, type: 'done' };
-      (self as unknown as Worker).postMessage(response);
-    } catch (err) {
-      const response: ComputeResponse = { id, type: 'error', error: String(err) };
-      (self as unknown as Worker).postMessage(response);
-    }
-    return;
-  }
-
-  // Legacy compute-only (backward compat — no type field or type === 'compute')
-  const { id, channelDataArrays, config, sampleRate, offsetSamples, durationSamples, mono } =
-    msg as ComputeRequest;
-  try {
-    const spectrograms: SpectrogramData[] = [];
-
-    if (mono || channelDataArrays.length === 1) {
-      spectrograms.push(
-        computeMonoFromChannels(
-          channelDataArrays,
-          config,
-          sampleRate,
-          offsetSamples,
-          durationSamples
-        )
+      console.log(
+        `[spectrogram-worker] render-chunks: ${(performance.now() - t0).toFixed(1)}ms, ` +
+          `ch=${channelIndex}, ${canvasIds.length} chunk(s), ` +
+          `offsets=[${globalPixelOffsets.join(',')}], widths=[${canvasWidths.join(',')}]`
       );
-    } else {
-      for (const channelData of channelDataArrays) {
-        spectrograms.push(
-          computeFromChannelData(channelData, config, sampleRate, offsetSamples, durationSamples)
-        );
-      }
+
+      const response: ComputeResponse = { id, type: 'done' };
+      (self as unknown as Worker).postMessage(response);
+    } catch (err) {
+      const response: ComputeResponse = { id, type: 'error', error: String(err) };
+      (self as unknown as Worker).postMessage(response);
     }
-
-    // Transfer the data Float32Arrays back (zero-copy)
-    const transferables = spectrograms.map((s) => s.data.buffer);
-
-    const response: ComputeResponse = { id, type: 'spectrograms', spectrograms };
-    (self as unknown as Worker).postMessage(response, transferables);
-  } catch (err) {
-    const response: ComputeResponse = { id, type: 'error', error: String(err) };
-    (self as unknown as Worker).postMessage(response);
+    return;
   }
+
+  // Unknown message type
+  console.warn(`[spectrogram-worker] Unknown message type: ${(msg as { type?: string }).type}`);
 };

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -105,6 +105,8 @@ interface ComputeFFTRequest {
   durationSamples: number;
   mono: boolean;
   sampleRange?: { start: number; end: number };
+  /** If set, compute only this channel index (not all channels). */
+  channelFilter?: number;
 }
 
 interface RenderChunksRequest {
@@ -428,6 +430,7 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
     durationSamples,
     mono,
     sampleRange,
+    channelFilter,
   } = msg;
 
   // Use pre-registered audio data if available, otherwise use message payload
@@ -468,6 +471,35 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
     if (mono || channelDataArrays.length === 1) {
       const result = await computeMonoFromChannels(
         channelDataArrays,
+        config,
+        sampleRate,
+        effectiveOffset,
+        effectiveDuration,
+        generation
+      );
+      if (result === null) {
+        console.log(
+          `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
+        );
+        const response: ComputeResponse = { id, type: 'aborted' };
+        (self as unknown as Worker).postMessage(response);
+        return;
+      }
+      spectrograms.push(result);
+    } else if (channelFilter !== undefined) {
+      // Pool mode: compute only the requested channel
+      const channelData = channelDataArrays[channelFilter];
+      if (!channelData) {
+        const response: ComputeResponse = {
+          id,
+          type: 'error',
+          error: `channelFilter ${channelFilter} out of range (${channelDataArrays.length} channels)`,
+        };
+        (self as unknown as Worker).postMessage(response);
+        return;
+      }
+      const result = await computeFromChannelData(
+        channelData,
         config,
         sampleRate,
         effectiveOffset,

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -1,12 +1,11 @@
 /**
  * Web Worker for off-main-thread spectrogram computation and rendering.
  *
- * Supports five modes:
- * 1. `compute` — FFT only, returns SpectrogramData to main thread (backward compat)
- * 2. `register-canvas` / `unregister-canvas` — manage OffscreenCanvas ownership
- * 3. `compute-render` — FFT + direct pixel rendering to registered OffscreenCanvases
- * 4. `compute-fft` — FFT with caching, returns cache key (no rendering)
- * 5. `render-chunks` — render specific chunks from cached FFT data
+ * Supports:
+ * 1. `register-canvas` / `unregister-canvas` — manage OffscreenCanvas ownership
+ * 2. `compute-fft` — FFT with caching, returns cache key (no rendering)
+ * 3. `render-chunks` — render specific chunks from cached FFT data
+ * 4. `abort-generation` — cancel stale FFT computations cooperatively
  */
 
 import type {
@@ -89,9 +88,15 @@ interface UnregisterAudioDataMessage {
   clipId: string;
 }
 
+interface AbortGenerationMessage {
+  type: 'abort-generation';
+  generation: number;
+}
+
 interface ComputeFFTRequest {
   type: 'compute-fft';
   id: string;
+  generation: number;
   clipId: string;
   channelDataArrays: Float32Array[];
   config: SpectrogramConfig;
@@ -105,6 +110,7 @@ interface ComputeFFTRequest {
 interface RenderChunksRequest {
   type: 'render-chunks';
   id: string;
+  generation: number;
   cacheKey: string;
   canvasIds: string[]; // flat list of canvas IDs to render
   canvasWidths: number[]; // per-chunk CSS widths
@@ -127,22 +133,40 @@ type WorkerMessage =
   | ComputeFFTRequest
   | RenderChunksRequest
   | RegisterAudioDataMessage
-  | UnregisterAudioDataMessage;
+  | UnregisterAudioDataMessage
+  | AbortGenerationMessage;
 
 type ComputeResponse =
   | { id: string; type: 'cache-key'; cacheKey: string }
   | { id: string; type: 'done' }
+  | { id: string; type: 'aborted' }
   | { id: string; type: 'error'; error: string };
 
-// --- FFT computation (unchanged) ---
+// --- Generation tracking ---
+// The main thread sends abort-generation messages when a new computation
+// generation starts. The worker tracks the latest generation and aborts
+// stale FFT computations by yielding periodically to process messages.
+let latestGeneration = 0;
+const FRAMES_PER_YIELD = 2000;
 
-function computeFromChannelData(
+function isGenerationStale(generation: number): boolean {
+  return generation < latestGeneration;
+}
+
+function yieldToMessageQueue(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// --- FFT computation (async with abort support) ---
+
+async function computeFromChannelData(
   channelData: Float32Array,
   config: SpectrogramConfig,
   sampleRate: number,
   offsetSamples: number,
-  durationSamples: number
-): SpectrogramData {
+  durationSamples: number,
+  generation: number
+): Promise<SpectrogramData | null> {
   const windowSize = config.fftSize ?? 2048;
   const zeroPaddingFactor = config.zeroPaddingFactor ?? 2;
   const actualFftSize = windowSize * zeroPaddingFactor;
@@ -162,6 +186,12 @@ function computeFromChannelData(
   const dbBuf = new Float32Array(frequencyBinCount);
 
   for (let frame = 0; frame < frameCount; frame++) {
+    // Yield periodically to process abort messages
+    if (frame > 0 && frame % FRAMES_PER_YIELD === 0) {
+      await yieldToMessageQueue();
+      if (isGenerationStale(generation)) return null;
+    }
+
     const start = offsetSamples + frame * hopSize;
 
     for (let i = 0; i < windowSize; i++) {
@@ -189,15 +219,23 @@ function computeFromChannelData(
   };
 }
 
-function computeMonoFromChannels(
+async function computeMonoFromChannels(
   channels: Float32Array[],
   config: SpectrogramConfig,
   sampleRate: number,
   offsetSamples: number,
-  durationSamples: number
-): SpectrogramData {
+  durationSamples: number,
+  generation: number
+): Promise<SpectrogramData | null> {
   if (channels.length === 1) {
-    return computeFromChannelData(channels[0], config, sampleRate, offsetSamples, durationSamples);
+    return computeFromChannelData(
+      channels[0],
+      config,
+      sampleRate,
+      offsetSamples,
+      durationSamples,
+      generation
+    );
   }
 
   const windowSize = config.fftSize ?? 2048;
@@ -219,6 +257,12 @@ function computeMonoFromChannels(
   const dbBuf = new Float32Array(frequencyBinCount);
 
   for (let frame = 0; frame < frameCount; frame++) {
+    // Yield periodically to process abort messages
+    if (frame > 0 && frame % FRAMES_PER_YIELD === 0) {
+      await yieldToMessageQueue();
+      if (isGenerationStale(generation)) return null;
+    }
+
     const start = offsetSamples + frame * hopSize;
 
     for (let i = 0; i < windowSize; i++) {
@@ -371,6 +415,112 @@ function renderSpectrogramToCanvas(
   }
 }
 
+// --- Async compute-fft handler ---
+
+async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
+  const {
+    id,
+    generation,
+    clipId,
+    config,
+    sampleRate: msgSampleRate,
+    offsetSamples,
+    durationSamples,
+    mono,
+    sampleRange,
+  } = msg;
+
+  // Use pre-registered audio data if available, otherwise use message payload
+  const registered = audioDataRegistry.get(clipId);
+  const channelDataArrays =
+    registered && msg.channelDataArrays.length === 0
+      ? registered.channelDataArrays
+      : msg.channelDataArrays;
+  const sampleRate =
+    registered && msg.channelDataArrays.length === 0 ? registered.sampleRate : msgSampleRate;
+
+  const fftSize = config.fftSize ?? 2048;
+  const zeroPaddingFactor = config.zeroPaddingFactor ?? 2;
+  const hopSize = config.hopSize ?? Math.floor(fftSize / 4);
+  const windowFunction = config.windowFunction ?? 'hann';
+
+  // Use sampleRange if provided (visible-range-first optimization)
+  const effectiveOffset = sampleRange ? sampleRange.start : offsetSamples;
+  const effectiveDuration = sampleRange ? sampleRange.end - sampleRange.start : durationSamples;
+
+  const cacheKey = generateCacheKey({
+    clipId,
+    channelIndex: 0,
+    offsetSamples: effectiveOffset,
+    durationSamples: effectiveDuration,
+    sampleRate,
+    compute: { fftSize, zeroPaddingFactor, hopSize, windowFunction, alpha: config.alpha },
+    mono,
+  });
+
+  if (!fftCache.has(cacheKey)) {
+    const t0 = performance.now();
+
+    // Evict oldest cache entries if at capacity
+    evictOldestCacheEntries(cacheKey);
+
+    const spectrograms: SpectrogramData[] = [];
+    if (mono || channelDataArrays.length === 1) {
+      const result = await computeMonoFromChannels(
+        channelDataArrays,
+        config,
+        sampleRate,
+        effectiveOffset,
+        effectiveDuration,
+        generation
+      );
+      if (result === null) {
+        console.log(
+          `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
+        );
+        const response: ComputeResponse = { id, type: 'aborted' };
+        (self as unknown as Worker).postMessage(response);
+        return;
+      }
+      spectrograms.push(result);
+    } else {
+      for (const channelData of channelDataArrays) {
+        const result = await computeFromChannelData(
+          channelData,
+          config,
+          sampleRate,
+          effectiveOffset,
+          effectiveDuration,
+          generation
+        );
+        if (result === null) {
+          console.log(
+            `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
+          );
+          const response: ComputeResponse = { id, type: 'aborted' };
+          (self as unknown as Worker).postMessage(response);
+          return;
+        }
+        spectrograms.push(result);
+      }
+    }
+    fftCache.set(cacheKey, { spectrograms, sampleOffset: effectiveOffset });
+
+    console.log(
+      `[spectrogram-worker] compute-fft: ${(performance.now() - t0).toFixed(1)}ms, ` +
+        `${spectrograms.length} channel(s), ` +
+        `${spectrograms[0].frameCount} frames, ` +
+        `range=${sampleRange ? `${sampleRange.start}-${sampleRange.end}` : 'full'}, ` +
+        `duration=${effectiveDuration} samples`
+    );
+  } else {
+    console.log(`[spectrogram-worker] compute-fft: cache hit for ${clipId}`);
+  }
+
+  const response: ComputeResponse = { id, type: 'cache-key', cacheKey };
+  (self as unknown as Worker).postMessage(response);
+}
+
 // --- Message handler ---
 
 self.onmessage = (e: MessageEvent<WorkerMessage>) => {
@@ -425,103 +575,42 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
     return;
   }
 
+  // Abort stale generation — updates latestGeneration so in-flight async
+  // FFT computations will detect staleness and bail out at their next yield point.
+  if (msg.type === 'abort-generation') {
+    latestGeneration = Math.max(latestGeneration, msg.generation);
+    return;
+  }
+
   // Compute FFT only (with caching), return cache key
   if (msg.type === 'compute-fft') {
-    const { id } = msg;
-    try {
-      const {
-        clipId,
-        config,
-        sampleRate: msgSampleRate,
-        offsetSamples,
-        durationSamples,
-        mono,
-        sampleRange,
-      } = msg;
+    const { id, generation } = msg;
 
-      // Use pre-registered audio data if available, otherwise use message payload
-      const registered = audioDataRegistry.get(clipId);
-      const channelDataArrays =
-        registered && msg.channelDataArrays.length === 0
-          ? registered.channelDataArrays
-          : msg.channelDataArrays;
-      const sampleRate =
-        registered && msg.channelDataArrays.length === 0 ? registered.sampleRate : msgSampleRate;
-
-      const fftSize = config.fftSize ?? 2048;
-      const zeroPaddingFactor = config.zeroPaddingFactor ?? 2;
-      const hopSize = config.hopSize ?? Math.floor(fftSize / 4);
-      const windowFunction = config.windowFunction ?? 'hann';
-
-      // Use sampleRange if provided (visible-range-first optimization)
-      const effectiveOffset = sampleRange ? sampleRange.start : offsetSamples;
-      const effectiveDuration = sampleRange ? sampleRange.end - sampleRange.start : durationSamples;
-
-      const cacheKey = generateCacheKey({
-        clipId,
-        channelIndex: 0,
-        offsetSamples: effectiveOffset,
-        durationSamples: effectiveDuration,
-        sampleRate,
-        compute: { fftSize, zeroPaddingFactor, hopSize, windowFunction, alpha: config.alpha },
-        mono,
-      });
-
-      if (!fftCache.has(cacheKey)) {
-        const t0 = performance.now();
-
-        // Evict oldest cache entries if at capacity
-        evictOldestCacheEntries(cacheKey);
-
-        const spectrograms: SpectrogramData[] = [];
-        if (mono || channelDataArrays.length === 1) {
-          spectrograms.push(
-            computeMonoFromChannels(
-              channelDataArrays,
-              config,
-              sampleRate,
-              effectiveOffset,
-              effectiveDuration
-            )
-          );
-        } else {
-          for (const channelData of channelDataArrays) {
-            spectrograms.push(
-              computeFromChannelData(
-                channelData,
-                config,
-                sampleRate,
-                effectiveOffset,
-                effectiveDuration
-              )
-            );
-          }
-        }
-        fftCache.set(cacheKey, { spectrograms, sampleOffset: effectiveOffset });
-
-        console.log(
-          `[spectrogram-worker] compute-fft: ${(performance.now() - t0).toFixed(1)}ms, ` +
-            `${spectrograms.length} channel(s), ` +
-            `${spectrograms[0].frameCount} frames, ` +
-            `range=${sampleRange ? `${sampleRange.start}-${sampleRange.end}` : 'full'}, ` +
-            `duration=${effectiveDuration} samples`
-        );
-      } else {
-        console.log(`[spectrogram-worker] compute-fft: cache hit for ${clipId}`);
-      }
-
-      const response: ComputeResponse = { id, type: 'cache-key', cacheKey };
+    // Check staleness immediately before starting any work
+    if (isGenerationStale(generation)) {
+      const response: ComputeResponse = { id, type: 'aborted' };
       (self as unknown as Worker).postMessage(response);
-    } catch (err) {
+      return;
+    }
+
+    handleComputeFFT(msg).catch((err) => {
       const response: ComputeResponse = { id, type: 'error', error: String(err) };
       (self as unknown as Worker).postMessage(response);
-    }
+    });
     return;
   }
 
   // Render specific chunks from cached FFT data
   if (msg.type === 'render-chunks') {
-    const { id } = msg;
+    const { id, generation } = msg;
+
+    // Skip rendering if this request belongs to a stale generation
+    if (isGenerationStale(generation)) {
+      const response: ComputeResponse = { id, type: 'aborted' };
+      (self as unknown as Worker).postMessage(response);
+      return;
+    }
+
     try {
       const {
         cacheKey,

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -39,7 +39,7 @@ interface FFTCacheEntry {
 const MAX_CACHE_ENTRIES = 16;
 const fftCache = new Map<string, FFTCacheEntry>();
 
-function evictOldestCacheEntries(keepKey?: string) {
+function evictLRUCacheEntries(keepKey?: string) {
   while (fftCache.size >= MAX_CACHE_ENTRIES) {
     for (const key of fftCache.keys()) {
       if (key !== keepKey) {
@@ -47,6 +47,15 @@ function evictOldestCacheEntries(keepKey?: string) {
         break;
       }
     }
+  }
+}
+
+/** Bump a cache entry to most-recently-used by re-inserting it. */
+function touchCacheEntry(key: string) {
+  const entry = fftCache.get(key);
+  if (entry) {
+    fftCache.delete(key);
+    fftCache.set(key, entry);
   }
 }
 
@@ -465,7 +474,7 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
     const t0 = performance.now();
 
     // Evict oldest cache entries if at capacity
-    evictOldestCacheEntries(cacheKey);
+    evictLRUCacheEntries(cacheKey);
 
     const spectrograms: SpectrogramData[] = [];
     if (mono || channelDataArrays.length === 1) {
@@ -546,6 +555,8 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
         `duration=${effectiveDuration} samples`
     );
   } else {
+    // Bump to most-recently-used so scroll-back patterns keep hot entries alive
+    touchCacheEntry(cacheKey);
     console.log(`[spectrogram-worker] compute-fft: cache hit for ${clipId}`);
   }
 

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -32,11 +32,24 @@ const audioDataRegistry = new Map<
 // Caches raw dB spectrogram data keyed by FFT computation params.
 // Display-only params (gain, range, colormap) don't affect the cache key.
 // sampleOffset: the sample position where this FFT data starts (for range-limited FFT)
+// Bounded to MAX_CACHE_ENTRIES to prevent OOM on long files with many ranges.
 interface FFTCacheEntry {
   spectrograms: SpectrogramData[];
   sampleOffset: number;
 }
+const MAX_CACHE_ENTRIES = 16;
 const fftCache = new Map<string, FFTCacheEntry>();
+
+function evictOldestCacheEntries(keepKey?: string) {
+  while (fftCache.size >= MAX_CACHE_ENTRIES) {
+    for (const key of fftCache.keys()) {
+      if (key !== keepKey) {
+        fftCache.delete(key);
+        break;
+      }
+    }
+  }
+}
 
 function generateCacheKey(params: {
   clipId: string;
@@ -457,13 +470,8 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
       if (!fftCache.has(cacheKey)) {
         const t0 = performance.now();
 
-        // Evict stale cache entries for this clip (different FFT params)
-        const clipPrefix = `${clipId}:`;
-        for (const key of fftCache.keys()) {
-          if (key.startsWith(clipPrefix) && key !== cacheKey) {
-            fftCache.delete(key);
-          }
-        }
+        // Evict oldest cache entries if at capacity
+        evictOldestCacheEntries(cacheKey);
 
         const spectrograms: SpectrogramData[] = [];
         if (mono || channelDataArrays.length === 1) {

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -421,7 +421,7 @@ function renderSpectrogramToCanvas(
       const tmpCtx = tmpCanvas.getContext('2d');
       if (!tmpCtx) {
         console.warn(
-          `[spectrogram-worker] getContext('2d') failed for DPR scaling of "${canvasIds[i]}"`
+          `[spectrogram-worker] getContext('2d') failed for DPR scaling of "${canvasIds[chunkIdx]}"`
         );
         continue;
       }

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -471,8 +471,6 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
   });
 
   if (!fftCache.has(cacheKey)) {
-    const t0 = performance.now();
-
     // Evict oldest cache entries if at capacity
     evictLRUCacheEntries(cacheKey);
 
@@ -487,9 +485,6 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
         generation
       );
       if (result === null) {
-        console.log(
-          `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
-        );
         const response: ComputeResponse = { id, type: 'aborted' };
         (self as unknown as Worker).postMessage(response);
         return;
@@ -516,9 +511,6 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
         generation
       );
       if (result === null) {
-        console.log(
-          `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
-        );
         const response: ComputeResponse = { id, type: 'aborted' };
         (self as unknown as Worker).postMessage(response);
         return;
@@ -535,9 +527,6 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
           generation
         );
         if (result === null) {
-          console.log(
-            `[spectrogram-worker] compute-fft: aborted (gen ${generation} < ${latestGeneration})`
-          );
           const response: ComputeResponse = { id, type: 'aborted' };
           (self as unknown as Worker).postMessage(response);
           return;
@@ -546,18 +535,9 @@ async function handleComputeFFT(msg: ComputeFFTRequest): Promise<void> {
       }
     }
     fftCache.set(cacheKey, { spectrograms, sampleOffset: effectiveOffset });
-
-    console.log(
-      `[spectrogram-worker] compute-fft: ${(performance.now() - t0).toFixed(1)}ms, ` +
-        `${spectrograms.length} channel(s), ` +
-        `${spectrograms[0].frameCount} frames, ` +
-        `range=${sampleRange ? `${sampleRange.start}-${sampleRange.end}` : 'full'}, ` +
-        `duration=${effectiveDuration} samples`
-    );
   } else {
     // Bump to most-recently-used so scroll-back patterns keep hot entries alive
     touchCacheEntry(cacheKey);
-    console.log(`[spectrogram-worker] compute-fft: cache hit for ${clipId}`);
   }
 
   const response: ComputeResponse = { id, type: 'cache-key', cacheKey };
@@ -679,8 +659,6 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
         return;
       }
 
-      const t0 = performance.now();
-
       const scaleFn = getFrequencyScale((frequencyScale ?? 'mel') as FrequencyScaleName);
       const isNonLinear = frequencyScale !== 'linear';
 
@@ -700,12 +678,6 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
         gainDb,
         rangeDb,
         cacheEntry.sampleOffset
-      );
-
-      console.log(
-        `[spectrogram-worker] render-chunks: ${(performance.now() - t0).toFixed(1)}ms, ` +
-          `ch=${channelIndex}, ${canvasIds.length} chunk(s), ` +
-          `offsets=[${globalPixelOffsets.join(',')}], widths=[${canvasWidths.join(',')}]`
       );
 
       const response: ComputeResponse = { id, type: 'done' };

--- a/packages/spectrogram/src/worker/spectrogram.worker.ts
+++ b/packages/spectrogram/src/worker/spectrogram.worker.ts
@@ -3,9 +3,10 @@
  *
  * Supports:
  * 1. `register-canvas` / `unregister-canvas` — manage OffscreenCanvas ownership
- * 2. `compute-fft` — FFT with caching, returns cache key (no rendering)
- * 3. `render-chunks` — render specific chunks from cached FFT data
- * 4. `abort-generation` — cancel stale FFT computations cooperatively
+ * 2. `register-audio-data` / `unregister-audio-data` — pre-transfer clip audio data to avoid re-transfer on each FFT request
+ * 3. `compute-fft` — FFT with LRU caching, returns cache key (no rendering)
+ * 4. `render-chunks` — render specific chunks from cached FFT data
+ * 5. `abort-generation` — cancel stale FFT computations cooperatively
  */
 
 import type {
@@ -41,12 +42,15 @@ const fftCache = new Map<string, FFTCacheEntry>();
 
 function evictLRUCacheEntries(keepKey?: string) {
   while (fftCache.size >= MAX_CACHE_ENTRIES) {
+    let deleted = false;
     for (const key of fftCache.keys()) {
       if (key !== keepKey) {
         fftCache.delete(key);
+        deleted = true;
         break;
       }
     }
+    if (!deleted) break; // Safety: prevent infinite loop if keepKey is the only entry
   }
 }
 
@@ -415,7 +419,12 @@ function renderSpectrogramToCanvas(
       // Render at CSS size to a temporary OffscreenCanvas, then scale up
       const tmpCanvas = new OffscreenCanvas(canvasWidth, canvasHeight);
       const tmpCtx = tmpCanvas.getContext('2d');
-      if (!tmpCtx) continue;
+      if (!tmpCtx) {
+        console.warn(
+          `[spectrogram-worker] getContext('2d') failed for DPR scaling of "${canvasIds[i]}"`
+        );
+        continue;
+      }
       tmpCtx.putImageData(imgData, 0, 0);
 
       ctx.imageSmoothingEnabled = false;
@@ -617,7 +626,8 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
     }
 
     handleComputeFFT(msg).catch((err) => {
-      const response: ComputeResponse = { id, type: 'error', error: String(err) };
+      const errorMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
+      const response: ComputeResponse = { id, type: 'error', error: errorMsg };
       (self as unknown as Worker).postMessage(response);
     });
     return;
@@ -653,8 +663,21 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
       } = msg;
 
       const cacheEntry = fftCache.get(cacheKey);
-      if (!cacheEntry || channelIndex >= cacheEntry.spectrograms.length) {
-        const response: ComputeResponse = { id, type: 'error', error: 'cache-miss' };
+      if (!cacheEntry) {
+        const response: ComputeResponse = {
+          id,
+          type: 'error',
+          error: `cache-miss: key "${cacheKey}" not found (cache has ${fftCache.size} entries)`,
+        };
+        (self as unknown as Worker).postMessage(response);
+        return;
+      }
+      if (channelIndex >= cacheEntry.spectrograms.length) {
+        const response: ComputeResponse = {
+          id,
+          type: 'error',
+          error: `cache-miss: channelIndex ${channelIndex} out of range (${cacheEntry.spectrograms.length} channels cached)`,
+        };
         (self as unknown as Worker).postMessage(response);
         return;
       }

--- a/packages/ui-components/CLAUDE.md
+++ b/packages/ui-components/CLAUDE.md
@@ -117,6 +117,8 @@
 
 **Backwards compatibility:** `useScrollViewport()` returns `null` without provider. All components default to rendering everything when viewport is `null`.
 
+**Overscan buffer contract:** The 1.5× container-width buffer in `ScrollViewportProvider` is a contract — `SpectrogramProvider.getVisibleChunkRange()` depends on matching this exact buffer size. If changed, update both.
+
 ## @dnd-kit Feedback Plugin Per-Entity Config
 
 **Pattern:** `useDraggable({ feedback: 'none' })` disables the Feedback plugin for that draggable — no fixed positioning, no CSS translate, no placeholder, no drop animation. Used on boundary trim handles where React state provides visual feedback.

--- a/packages/ui-components/src/components/SmartChannel.tsx
+++ b/packages/ui-components/src/components/SmartChannel.tsx
@@ -3,7 +3,7 @@ import { useDevicePixelRatio, usePlaylistInfo, useTheme } from '../contexts';
 import { Channel } from './Channel';
 import { PianoRollChannel } from './PianoRollChannel';
 import { SpectrogramChannel, type SpectrogramWorkerCanvasApi } from './SpectrogramChannel';
-import type { SpectrogramData, RenderMode, MidiNoteData } from '@waveform-playlist/core';
+import type { RenderMode, MidiNoteData } from '@waveform-playlist/core';
 
 export interface SmartChannelProps {
   className?: string;
@@ -16,18 +16,8 @@ export interface SmartChannelProps {
   transparentBackground?: boolean;
   /** Render mode: waveform, spectrogram, or both */
   renderMode?: RenderMode;
-  /** Spectrogram data for this channel */
-  spectrogramData?: SpectrogramData;
-  /** 256-entry RGB LUT from getColorMap() */
-  spectrogramColorLUT?: Uint8Array;
   /** Samples per pixel at current zoom level */
   samplesPerPixel?: number;
-  /** Frequency scale function */
-  spectrogramFrequencyScaleFn?: (f: number, minF: number, maxF: number) => number;
-  /** Min frequency in Hz */
-  spectrogramMinFrequency?: number;
-  /** Max frequency in Hz */
-  spectrogramMaxFrequency?: number;
   /** Worker API for OffscreenCanvas transfer */
   spectrogramWorkerApi?: SpectrogramWorkerCanvasApi;
   /** Clip ID for worker canvas registration */
@@ -46,12 +36,7 @@ export const SmartChannel: FunctionComponent<SmartChannelProps> = ({
   isSelected,
   transparentBackground,
   renderMode = 'waveform',
-  spectrogramData,
-  spectrogramColorLUT,
   samplesPerPixel: sppProp,
-  spectrogramFrequencyScaleFn,
-  spectrogramMinFrequency,
-  spectrogramMaxFrequency,
   spectrogramWorkerApi,
   spectrogramClipId,
   spectrogramOnCanvasesReady,
@@ -80,22 +65,17 @@ export const SmartChannel: FunctionComponent<SmartChannelProps> = ({
   // Get draw mode from theme (defaults to 'inverted' for backwards compatibility)
   const drawMode = theme?.waveformDrawMode || 'inverted';
 
-  // Worker mode: spectrogram data is optional (worker renders directly)
-  const hasSpectrogram = spectrogramData || spectrogramWorkerApi;
+  // Spectrogram requires worker API and clip ID
+  const hasSpectrogram = spectrogramWorkerApi && spectrogramClipId;
 
   if (renderMode === 'spectrogram' && hasSpectrogram) {
     return (
       <SpectrogramChannel
         index={props.index}
-        data={spectrogramData}
         length={props.length}
         waveHeight={waveHeight}
         devicePixelRatio={devicePixelRatio}
         samplesPerPixel={samplesPerPixel}
-        colorLUT={spectrogramColorLUT}
-        frequencyScaleFn={spectrogramFrequencyScaleFn}
-        minFrequency={spectrogramMinFrequency}
-        maxFrequency={spectrogramMaxFrequency}
         workerApi={spectrogramWorkerApi}
         clipId={spectrogramClipId}
         onCanvasesReady={spectrogramOnCanvasesReady}
@@ -112,15 +92,10 @@ export const SmartChannel: FunctionComponent<SmartChannelProps> = ({
         <SpectrogramChannel
           index={props.index * 2}
           channelIndex={props.index}
-          data={spectrogramData}
           length={props.length}
           waveHeight={halfHeight}
           devicePixelRatio={devicePixelRatio}
           samplesPerPixel={samplesPerPixel}
-          colorLUT={spectrogramColorLUT}
-          frequencyScaleFn={spectrogramFrequencyScaleFn}
-          minFrequency={spectrogramMinFrequency}
-          maxFrequency={spectrogramMaxFrequency}
           workerApi={spectrogramWorkerApi}
           clipId={spectrogramClipId}
           onCanvasesReady={spectrogramOnCanvasesReady}

--- a/packages/ui-components/src/components/SpectrogramChannel.tsx
+++ b/packages/ui-components/src/components/SpectrogramChannel.tsx
@@ -75,7 +75,7 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
   length,
   waveHeight,
   devicePixelRatio = 1,
-  samplesPerPixel,
+  samplesPerPixel: _samplesPerPixel,
   workerApi,
   clipId,
   onCanvasesReady,

--- a/packages/ui-components/src/components/SpectrogramChannel.tsx
+++ b/packages/ui-components/src/components/SpectrogramChannel.tsx
@@ -1,12 +1,9 @@
-import React, { FunctionComponent, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { FunctionComponent, useRef, useEffect } from 'react';
 import styled from 'styled-components';
-import type { SpectrogramData } from '@waveform-playlist/core';
 import { useVisibleChunkIndices } from '../contexts/ScrollViewport';
 import { useClipViewportOrigin } from '../contexts/ClipViewportOrigin';
 import { useChunkedCanvasRefs } from '../hooks/useChunkedCanvasRefs';
 import { MAX_CANVAS_WIDTH } from '@waveform-playlist/core';
-const LINEAR_FREQUENCY_SCALE = (f: number, minF: number, maxF: number) =>
-  (f - minF) / (maxF - minF);
 
 interface WrapperProps {
   readonly $index: number;
@@ -46,18 +43,6 @@ const SpectrogramCanvas = styled.canvas.attrs<CanvasProps>((props) => ({
   image-rendering: crisp-edges;
 `;
 
-// Inline getColorMap to avoid cross-package import at component level
-// This avoids needing browser package as dependency of ui-components
-function defaultGetColorMap(): Uint8Array {
-  // Grayscale fallback — 256-entry LUT (used when no colorLUT prop provided)
-  const lut = new Uint8Array(256 * 3);
-  for (let i = 0; i < 256; i++) {
-    lut[i * 3] = lut[i * 3 + 1] = lut[i * 3 + 2] = i;
-  }
-  return lut;
-}
-const DEFAULT_COLOR_LUT = defaultGetColorMap();
-
 export interface SpectrogramWorkerCanvasApi {
   registerCanvas(canvasId: string, canvas: OffscreenCanvas): void;
   unregisterCanvas(canvasId: string): void;
@@ -68,8 +53,6 @@ export interface SpectrogramChannelProps {
   index: number;
   /** Audio channel index for canvas ID construction. Defaults to `index` when omitted. */
   channelIndex?: number;
-  /** Computed spectrogram data (not needed when workerApi is provided) */
-  data?: SpectrogramData;
   /** Width in CSS pixels */
   length: number;
   /** Height in CSS pixels */
@@ -78,18 +61,10 @@ export interface SpectrogramChannelProps {
   devicePixelRatio?: number;
   /** Samples per pixel at current zoom level */
   samplesPerPixel: number;
-  /** 256-entry RGB LUT (768 bytes) from getColorMap() */
-  colorLUT?: Uint8Array;
-  /** Frequency scale function: (freqHz, minF, maxF) => [0,1] */
-  frequencyScaleFn?: (f: number, minF: number, maxF: number) => number;
-  /** Min frequency in Hz */
-  minFrequency?: number;
-  /** Max frequency in Hz (defaults to sampleRate/2) */
-  maxFrequency?: number;
-  /** Worker API for transferring canvas ownership. When provided, rendering is done in the worker. */
-  workerApi?: SpectrogramWorkerCanvasApi;
+  /** Worker API for transferring canvas ownership. Rendering is done in the worker. */
+  workerApi: SpectrogramWorkerCanvasApi;
   /** Clip ID used to construct unique canvas IDs for worker registration */
-  clipId?: string;
+  clipId: string;
   /** Callback when canvases are registered with the worker, providing canvas IDs and widths */
   onCanvasesReady?: (canvasIds: string[], canvasWidths: number[]) => void;
 }
@@ -97,15 +72,10 @@ export interface SpectrogramChannelProps {
 export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
   index,
   channelIndex: channelIndexProp,
-  data,
   length,
   waveHeight,
   devicePixelRatio = 1,
   samplesPerPixel,
-  colorLUT,
-  frequencyScaleFn,
-  minFrequency = 0,
-  maxFrequency,
   workerApi,
   clipId,
   onCanvasesReady,
@@ -117,16 +87,8 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
   const workerApiRef = useRef(workerApi);
   const onCanvasesReadyRef = useRef(onCanvasesReady);
 
-  // Track whether we're in worker mode (canvas transferred)
-  const isWorkerMode = !!(workerApi && clipId);
   const clipOriginX = useClipViewportOrigin();
-
   const visibleChunkIndices = useVisibleChunkIndices(length, MAX_CANVAS_WIDTH, clipOriginX);
-
-  const lut = colorLUT ?? DEFAULT_COLOR_LUT;
-  const maxF = maxFrequency ?? (data ? data.sampleRate / 2 : 22050);
-  const scaleFn = frequencyScaleFn ?? LINEAR_FREQUENCY_SCALE;
-  const hasCustomFrequencyScale = Boolean(frequencyScaleFn);
 
   // Keep refs in sync with latest props
   useEffect(() => {
@@ -137,12 +99,11 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
     onCanvasesReadyRef.current = onCanvasesReady;
   }, [onCanvasesReady]);
 
-  // Worker mode: clean up stale canvases, then transfer new ones.
+  // Clean up stale canvases, then transfer new ones to worker.
   // Cleanup and registration are combined in a single effect so that
   // `onCanvasesReady` always receives a clean list without stale IDs.
   // Uses visibleChunkIndices so it only re-runs when chunks mount/unmount.
   useEffect(() => {
-    if (!isWorkerMode) return;
     const currentWorkerApi = workerApiRef.current;
     if (!currentWorkerApi || !clipId) return;
 
@@ -216,7 +177,7 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
       });
       onCanvasesReadyRef.current?.(allIds, allWidths);
     }
-  }, [canvasMapRef, isWorkerMode, clipId, channelIndex, length, visibleChunkIndices]);
+  }, [canvasMapRef, clipId, channelIndex, length, visibleChunkIndices]);
 
   // Unregister all canvases from worker on component unmount
   useEffect(() => {
@@ -233,132 +194,6 @@ export const SpectrogramChannel: FunctionComponent<SpectrogramChannelProps> = ({
       registeredIdsRef.current = [];
     };
   }, []);
-
-  // Main-thread rendering (skipped in worker mode).
-  // useLayoutEffect so canvas drawing completes before the browser paints —
-  // prevents flicker from clearRect being visible for one frame.
-  useLayoutEffect(() => {
-    if (isWorkerMode || !data) return;
-
-    const {
-      frequencyBinCount,
-      frameCount,
-      hopSize,
-      sampleRate,
-      gainDb,
-      rangeDb: rawRangeDb,
-    } = data;
-    const rangeDb = rawRangeDb === 0 ? 1 : rawRangeDb;
-
-    // Pre-compute Y mapping: for each pixel row, which frequency bin(s) to sample
-    const binToFreq = (bin: number) => (bin / frequencyBinCount) * (sampleRate / 2);
-
-    for (const [canvasIdx, canvas] of canvasMapRef.current.entries()) {
-      const globalPixelOffset = canvasIdx * MAX_CANVAS_WIDTH;
-
-      const ctx = canvas.getContext('2d');
-      if (!ctx) continue;
-
-      const canvasWidth = canvas.width / devicePixelRatio;
-      const canvasHeight = waveHeight;
-
-      ctx.resetTransform();
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.imageSmoothingEnabled = false;
-      ctx.scale(devicePixelRatio, devicePixelRatio);
-
-      // Create ImageData at CSS pixel size, then putImageData at scaled resolution
-      const imgData = ctx.createImageData(canvasWidth, canvasHeight);
-      const pixels = imgData.data;
-
-      for (let x = 0; x < canvasWidth; x++) {
-        const globalX = globalPixelOffset + x;
-
-        // Map pixel X → spectrogram frame
-        const samplePos = globalX * samplesPerPixel;
-        const frame = Math.floor(samplePos / hopSize);
-
-        if (frame < 0 || frame >= frameCount) continue;
-
-        const frameOffset = frame * frequencyBinCount;
-
-        for (let y = 0; y < canvasHeight; y++) {
-          // Y=0 is top of canvas, but low frequencies should be at bottom
-          const normalizedY = 1 - y / canvasHeight; // 0=bottom, 1=top
-
-          // Map normalizedY through frequency scale to find which frequency this pixel represents
-          // We need the inverse: given a normalized position, find the frequency
-          // Use binary search over frequency bins
-          let bin = Math.floor(normalizedY * frequencyBinCount);
-
-          // If we have a non-linear scale, find the correct bin
-          if (hasCustomFrequencyScale) {
-            // Binary search: find the bin whose scaled position is closest to normalizedY
-            let lo = 0;
-            let hi = frequencyBinCount - 1;
-            while (lo < hi) {
-              const mid = (lo + hi) >> 1;
-              const freq = binToFreq(mid);
-              const scaled = scaleFn(freq, minFrequency, maxF);
-              if (scaled < normalizedY) {
-                lo = mid + 1;
-              } else {
-                hi = mid;
-              }
-            }
-            bin = lo;
-          }
-
-          if (bin < 0 || bin >= frequencyBinCount) continue;
-
-          // Get dB value and normalize to [0, 1]
-          const db = data.data[frameOffset + bin];
-          const normalized = Math.max(0, Math.min(1, (db + rangeDb + gainDb) / rangeDb));
-
-          // Map to color via LUT (0-255 index)
-          const colorIdx = Math.floor(normalized * 255);
-          const pixelIdx = (y * canvasWidth + x) * 4;
-          pixels[pixelIdx] = lut[colorIdx * 3];
-          pixels[pixelIdx + 1] = lut[colorIdx * 3 + 1];
-          pixels[pixelIdx + 2] = lut[colorIdx * 3 + 2];
-          pixels[pixelIdx + 3] = 255;
-        }
-      }
-
-      // Put at device pixel ratio scale
-      ctx.resetTransform();
-      ctx.putImageData(imgData, 0, 0);
-
-      // Scale up to fill canvas
-      if (devicePixelRatio !== 1) {
-        // Draw the image data at 1:1, then scale
-        const tmpCanvas = document.createElement('canvas');
-        tmpCanvas.width = canvasWidth;
-        tmpCanvas.height = canvasHeight;
-        const tmpCtx = tmpCanvas.getContext('2d');
-        if (!tmpCtx) continue;
-        tmpCtx.putImageData(imgData, 0, 0);
-
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.imageSmoothingEnabled = false;
-        ctx.drawImage(tmpCanvas, 0, 0, canvas.width, canvas.height);
-      }
-    }
-  }, [
-    canvasMapRef,
-    isWorkerMode,
-    data,
-    length,
-    waveHeight,
-    devicePixelRatio,
-    samplesPerPixel,
-    lut,
-    minFrequency,
-    maxF,
-    scaleFn,
-    hasCustomFrequencyScale,
-    visibleChunkIndices,
-  ]);
 
   // Build visible canvas chunk elements
   const canvases = visibleChunkIndices.map((i) => {

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -931,6 +931,8 @@ import { SpectrogramProvider } from '@waveform-playlist/spectrogram';
 interface SpectrogramProviderProps {
   config?: SpectrogramConfig;
   colorMap?: ColorMapValue;
+  /** Number of Web Workers for parallel FFT computation. Default: 2 (one per stereo channel). */
+  workerPoolSize?: number;
   children: ReactNode;
 }
 ```
@@ -979,21 +981,22 @@ interface TrackSpectrogramOverrides {
 
 // From @waveform-playlist/spectrogram
 interface SpectrogramWorkerApi {
-  compute(params: SpectrogramWorkerComputeParams): Promise<SpectrogramData[]>;
-  computeFFT(params: SpectrogramWorkerFFTParams): Promise<{ cacheKey: string }>;
-  renderChunks(params: SpectrogramWorkerRenderChunksParams): Promise<void>;
+  computeFFT(params: SpectrogramWorkerFFTParams, generation?: number): Promise<{ cacheKey: string }>;
+  renderChunks(params: SpectrogramWorkerRenderChunksParams, generation?: number): Promise<void>;
+  abortGeneration(generation: number): void;
   registerCanvas(canvasId: string, canvas: OffscreenCanvas): void;
   unregisterCanvas(canvasId: string): void;
   registerAudioData(clipId: string, channelDataArrays: Float32Array[], sampleRate: number): void;
   unregisterAudioData(clipId: string): void;
-  computeAndRender(params: SpectrogramWorkerRenderParams): Promise<void>;
   terminate(): void;
 }
 
+class SpectrogramAbortError extends Error {}  // instanceof check for aborted FFT computations
+
 // Key exports
-export { SpectrogramProvider } from '@waveform-playlist/spectrogram';
+export { SpectrogramProvider, SpectrogramAbortError } from '@waveform-playlist/spectrogram';
 export { computeSpectrogram, computeSpectrogramMono, getColorMap, getFrequencyScale } from '@waveform-playlist/spectrogram';
-export { createSpectrogramWorker } from '@waveform-playlist/spectrogram';
+export { createSpectrogramWorker, createSpectrogramWorkerPool } from '@waveform-playlist/spectrogram';
 export { SpectrogramMenuItems, SpectrogramSettingsModal } from '@waveform-playlist/spectrogram';
 
 // Integration context (from @waveform-playlist/browser)

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -28,7 +28,7 @@ waveform-playlist is a React component library for building browser-based audio 
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
 - `@waveform-playlist/media-element-playout` — HTMLAudioElement playback with pitch-preserving speed control
 - `@waveform-playlist/midi` — MIDI file loading and parsing: .mid file fetch/parse via @tonejs/midi, `useMidiTracks` hook converts to ClipTrack[] with midiNotes for piano roll visualization and SoundFont/PolySynth playback
-- `@waveform-playlist/spectrogram` — Optional spectrogram package: FFT computation, worker-based rendering, color maps, frequency scales. Integrates via `SpectrogramProvider` wrapper
+- `@waveform-playlist/spectrogram` — Optional spectrogram package: FFT computation, worker pool-based rendering (parallel per-channel FFT), color maps, frequency scales, generation-based abort (`SpectrogramAbortError`). Integrates via `SpectrogramProvider` wrapper (configurable `workerPoolSize`, default 2)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- **Worker pool** — Parallel per-channel FFT via `createSpectrogramWorkerPool` (default 2 workers for stereo, configurable via `workerPoolSize` prop). Fan-out capped to actual channel count.
- **Lazy per-batch FFT** — Never compute full-clip FFT. Compute per visible range, then background batches. Prevents OOM on 1hr+ files (~2.5GB savings).
- **Generation-based abort** — Cooperative abort via `setTimeout(0)` yielding. Stale FFT requests cancelled on scroll, so visible-range FFT isn't blocked by queued work.
- **Three-tier rendering** — Chunks classified as viewport (phase 1a), buffer (phase 1b), remaining (phase 2). Viewport-only FFT gives ~1.5s cold first paint vs ~4.5s with binary split.
- **LRU cache** — Map delete-and-re-insert pattern for true LRU eviction (16 entries). Scroll-back hits cache instead of recomputing.
- **Contiguous grouping** — Buffer indices grouped before FFT to avoid spanning huge sample ranges across non-adjacent chunks.

## Test plan

- [x] Load stereo audio file, verify spectrogram renders without errors
- [x] Scroll through long file, verify no `channelFilter out of range` errors
- [x] Scroll back and forth, verify cache hits (no recomputation)
- [x] Verify no memory issues on long files
- [x] Verify no debug `console.log` in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)