### PR TITLE
fix: prevent duplicate audio on play/pause/play

### DIFF
--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -240,6 +240,12 @@ const sourceEnd = Math.min(waveformData.length, Math.ceil(targetEnd * ratio));
 
 **Test helper:** `WaveformData.create()` requires JSON with `{ version: 2, channels: 1, sample_rate, samples_per_pixel, bits, length, data }` — omitting `version`/`channels` causes a TypeScript error.
 
+## jsdom Keyboard Event Testing Quirks
+
+- `new KeyboardEvent()` has `target: null` in jsdom — use `Object.defineProperty(event, 'target', { value: document.body })` when calling handlers directly (not via `dispatchEvent`)
+- jsdom doesn't implement `isContentEditable` — returns `undefined`. Polyfill with `Object.defineProperty(el, 'isContentEditable', { value: true })` in tests
+- `handleKeyboardEvent` is exported as a pure function from `useKeyboardShortcuts.ts` for direct unit testing without React rendering infrastructure
+
 ## Click-to-Seek During Auto-Scroll
 
 `handleMouseUp` must NOT recompute click time from `getBoundingClientRect()` during playback — auto-scroll shifts the overlay between mouseDown and mouseUp, producing wrong positions. Instead, `mouseDownTimeRef` captures the time at mouseDown, and mouseUp reuses it when `isPlaying`. Applied in both `PlaylistVisualization` and `MediaElementPlaylist`.

--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -243,7 +243,7 @@ const sourceEnd = Math.min(waveformData.length, Math.ceil(targetEnd * ratio));
 ## jsdom Keyboard Event Testing Quirks
 
 - `new KeyboardEvent()` has `target: null` in jsdom — use `Object.defineProperty(event, 'target', { value: document.body })` when calling handlers directly (not via `dispatchEvent`)
-- jsdom doesn't implement `isContentEditable` — returns `undefined`. Polyfill with `Object.defineProperty(el, 'isContentEditable', { value: true })` in tests
+- jsdom doesn't implement `isContentEditable` (returns `undefined` as of jsdom 28). Polyfill with `Object.defineProperty(el, 'isContentEditable', { value: true })` in tests
 - `handleKeyboardEvent` is exported as a pure function from `useKeyboardShortcuts.ts` for direct unit testing without React rendering infrastructure
 
 ## Click-to-Seek During Auto-Scroll

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -48,6 +48,7 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^5.1.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.3.3",
     "vite": "^7.2.4",
     "vite-plugin-dts": "^4.5.0",
@@ -75,7 +76,11 @@
     "tone": "^15.0.0"
   },
   "peerDependenciesMeta": {
-    "@waveform-playlist/annotations": { "optional": true },
-    "@waveform-playlist/recording": { "optional": true }
+    "@waveform-playlist/annotations": {
+      "optional": true
+    },
+    "@waveform-playlist/recording": {
+      "optional": true
+    }
   }
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -48,7 +48,6 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^5.1.1",
-    "jsdom": "^28.1.0",
     "typescript": "^5.3.3",
     "vite": "^7.2.4",
     "vite-plugin-dts": "^4.5.0",

--- a/packages/browser/src/__tests__/useKeyboardShortcuts.test.ts
+++ b/packages/browser/src/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleKeyboardEvent, type KeyboardShortcut } from '../hooks/useKeyboardShortcuts';
+
+function makeKeyboardEvent(
+  key: string,
+  overrides: Partial<KeyboardEventInit & { repeat: boolean }> = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    ...overrides,
+  });
+  // jsdom doesn't set event.target for events created directly (not dispatched).
+  // Default to document.body so the target-tag check doesn't crash on null.
+  Object.defineProperty(event, 'target', { value: document.body });
+  return event;
+}
+
+describe('handleKeyboardEvent', () => {
+  let action: ReturnType<typeof vi.fn>;
+  let shortcuts: KeyboardShortcut[];
+
+  beforeEach(() => {
+    action = vi.fn();
+    shortcuts = [
+      {
+        key: ' ',
+        action,
+        description: 'Play/Pause',
+        preventDefault: true,
+      },
+    ];
+  });
+
+  it('calls action on matching keydown', () => {
+    const event = makeKeyboardEvent(' ');
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call action when disabled', () => {
+    const event = makeKeyboardEvent(' ');
+    handleKeyboardEvent(event, shortcuts, false);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not call action on key repeat', () => {
+    const event = makeKeyboardEvent(' ', { repeat: true });
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('calls action on first keydown but not on subsequent repeats', () => {
+    const first = makeKeyboardEvent(' ', { repeat: false });
+    const repeat1 = makeKeyboardEvent(' ', { repeat: true });
+    const repeat2 = makeKeyboardEvent(' ', { repeat: true });
+
+    handleKeyboardEvent(first, shortcuts, true);
+    handleKeyboardEvent(repeat1, shortcuts, true);
+    handleKeyboardEvent(repeat2, shortcuts, true);
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call action for non-matching key', () => {
+    const event = makeKeyboardEvent('a');
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('matches keys case-insensitively', () => {
+    const sAction = vi.fn();
+    const sShortcuts: KeyboardShortcut[] = [{ key: 's', action: sAction, description: 'Split' }];
+    const event = makeKeyboardEvent('S');
+    handleKeyboardEvent(event, sShortcuts, true);
+    expect(sAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call action when target is an input element', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'target', { value: input });
+
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('does not call action when target is a textarea element', () => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'target', { value: textarea });
+
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+
+    document.body.removeChild(textarea);
+  });
+
+  it('does not call action when target is contentEditable', () => {
+    const div = document.createElement('div');
+    div.contentEditable = 'true';
+    // jsdom doesn't implement isContentEditable, so we polyfill it for the test.
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    document.body.appendChild(div);
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+    });
+    Object.defineProperty(event, 'target', { value: div });
+
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+
+    document.body.removeChild(div);
+  });
+
+  it('calls preventDefault when shortcut.preventDefault is true', () => {
+    const event = makeKeyboardEvent(' ');
+    const spy = vi.spyOn(event, 'preventDefault');
+
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not call preventDefault when shortcut.preventDefault is false', () => {
+    const noPreventShortcuts: KeyboardShortcut[] = [
+      { key: ' ', action, description: 'test', preventDefault: false },
+    ];
+    const event = makeKeyboardEvent(' ');
+    const spy = vi.spyOn(event, 'preventDefault');
+
+    handleKeyboardEvent(event, noPreventShortcuts, true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  describe('modifier key matching', () => {
+    it('matches ctrlKey when specified', () => {
+      const ctrlShortcuts: KeyboardShortcut[] = [
+        { key: 'z', action, ctrlKey: true, description: 'Undo' },
+      ];
+      const withCtrl = makeKeyboardEvent('z', { ctrlKey: true });
+      const withoutCtrl = makeKeyboardEvent('z', { ctrlKey: false });
+
+      handleKeyboardEvent(withCtrl, ctrlShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+
+      handleKeyboardEvent(withoutCtrl, ctrlShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1); // Still 1 — not called again
+    });
+
+    it('matches shiftKey when specified', () => {
+      const shiftShortcuts: KeyboardShortcut[] = [
+        { key: 's', action, shiftKey: true, description: 'Split at selection' },
+      ];
+      const withShift = makeKeyboardEvent('S', { shiftKey: true });
+      const withoutShift = makeKeyboardEvent('s', { shiftKey: false });
+
+      handleKeyboardEvent(withShift, shiftShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+
+      handleKeyboardEvent(withoutShift, shiftShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores modifier keys when not specified in shortcut', () => {
+      // shortcut has no ctrlKey specified — should match regardless
+      const event = makeKeyboardEvent(' ', { ctrlKey: true });
+      handleKeyboardEvent(event, shortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multiple shortcuts', () => {
+    it('calls the correct action for each key', () => {
+      const playAction = vi.fn();
+      const stopAction = vi.fn();
+      const multiShortcuts: KeyboardShortcut[] = [
+        { key: ' ', action: playAction, description: 'Play' },
+        { key: 'Escape', action: stopAction, description: 'Stop' },
+      ];
+
+      handleKeyboardEvent(makeKeyboardEvent(' '), multiShortcuts, true);
+      expect(playAction).toHaveBeenCalledTimes(1);
+      expect(stopAction).not.toHaveBeenCalled();
+
+      handleKeyboardEvent(makeKeyboardEvent('Escape'), multiShortcuts, true);
+      expect(playAction).toHaveBeenCalledTimes(1);
+      expect(stopAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('rapid play/pause simulation (bug reproduction)', () => {
+    it('only triggers once despite rapid key events with repeats', () => {
+      // Simulates holding Space: one real keydown followed by repeats
+      const events = [
+        makeKeyboardEvent(' ', { repeat: false }), // Real press
+        makeKeyboardEvent(' ', { repeat: true }), // Hold repeat
+        makeKeyboardEvent(' ', { repeat: true }), // Hold repeat
+        makeKeyboardEvent(' ', { repeat: true }), // Hold repeat
+        makeKeyboardEvent(' ', { repeat: true }), // Hold repeat
+      ];
+
+      for (const event of events) {
+        handleKeyboardEvent(event, shortcuts, true);
+      }
+
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/browser/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/browser/src/hooks/useKeyboardShortcuts.ts
@@ -28,18 +28,14 @@ export function handleKeyboardEvent(
   if (!enabled) return;
 
   // Ignore key repeat events — holding a key fires keydown repeatedly.
-  // Without this guard, holding Space rapidly toggles play/pause, and
-  // during the async engine.init() on first play, repeat events see
-  // isPlaying=false and fire multiple concurrent play() calls.
+  // Without this guard, holding Space rapidly toggles play/pause.
   if (event.repeat) return;
 
-  // Check if we're in an input/textarea element
   const target = event.target as HTMLElement;
   if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
     return;
   }
 
-  // Find matching shortcut
   const matchingShortcut = shortcuts.find((shortcut) => {
     const keyMatch =
       event.key.toLowerCase() === shortcut.key.toLowerCase() || event.key === shortcut.key;
@@ -67,21 +63,18 @@ export function handleKeyboardEvent(
  *
  * @example
  * ```tsx
- * const { splitClipAtPlayhead } = useClipSplitting({ ... });
- *
  * useKeyboardShortcuts({
  *   shortcuts: [
+ *     {
+ *       key: ' ',
+ *       action: togglePlayPause,
+ *       description: 'Play/Pause',
+ *       preventDefault: true,
+ *     },
  *     {
  *       key: 's',
  *       action: splitClipAtPlayhead,
  *       description: 'Split clip at playhead',
- *       preventDefault: true,
- *     },
- *     {
- *       key: 'S',
- *       shiftKey: true,
- *       action: () => splitAtSelection(),
- *       description: 'Split at selection boundaries',
  *       preventDefault: true,
  *     },
  *   ],

--- a/packages/browser/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/browser/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,50 @@ export interface UseKeyboardShortcutsOptions {
 }
 
 /**
+ * Handle a keyboard event against a list of shortcuts.
+ * Extracted from the hook for testability — pure function, no React dependency.
+ */
+export function handleKeyboardEvent(
+  event: KeyboardEvent,
+  shortcuts: KeyboardShortcut[],
+  enabled: boolean
+): void {
+  if (!enabled) return;
+
+  // Ignore key repeat events — holding a key fires keydown repeatedly.
+  // Without this guard, holding Space rapidly toggles play/pause, and
+  // during the async engine.init() on first play, repeat events see
+  // isPlaying=false and fire multiple concurrent play() calls.
+  if (event.repeat) return;
+
+  // Check if we're in an input/textarea element
+  const target = event.target as HTMLElement;
+  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+    return;
+  }
+
+  // Find matching shortcut
+  const matchingShortcut = shortcuts.find((shortcut) => {
+    const keyMatch =
+      event.key.toLowerCase() === shortcut.key.toLowerCase() || event.key === shortcut.key;
+
+    const ctrlMatch = shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey;
+    const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
+    const metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
+    const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
+
+    return keyMatch && ctrlMatch && shiftMatch && metaMatch && altMatch;
+  });
+
+  if (matchingShortcut) {
+    if (matchingShortcut.preventDefault !== false) {
+      event.preventDefault();
+    }
+    matchingShortcut.action();
+  }
+}
+
+/**
  * Hook for managing keyboard shortcuts
  *
  * @param options - Configuration options
@@ -48,36 +92,7 @@ export const useKeyboardShortcuts = (options: UseKeyboardShortcutsOptions): void
   const { shortcuts, enabled = true } = options;
 
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (!enabled) return;
-
-      // Check if we're in an input/textarea element
-      const target = event.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        // Don't trigger shortcuts when typing in input fields
-        return;
-      }
-
-      // Find matching shortcut
-      const matchingShortcut = shortcuts.find((shortcut) => {
-        const keyMatch =
-          event.key.toLowerCase() === shortcut.key.toLowerCase() || event.key === shortcut.key;
-
-        const ctrlMatch = shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey;
-        const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
-        const metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
-        const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
-
-        return keyMatch && ctrlMatch && shiftMatch && metaMatch && altMatch;
-      });
-
-      if (matchingShortcut) {
-        if (matchingShortcut.preventDefault !== false) {
-          event.preventDefault();
-        }
-        matchingShortcut.action();
-      }
-    },
+    (event: KeyboardEvent) => handleKeyboardEvent(event, shortcuts, enabled),
     [shortcuts, enabled]
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/browser:
     dependencies:
@@ -145,9 +145,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.1.1(vite@7.2.4)
-      jsdom:
-        specifier: ^28.1.0
-        version: 28.1.0
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -171,7 +168,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/engine:
     devDependencies:
@@ -186,7 +183,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/loaders:
     dependencies:
@@ -205,7 +202,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/media-element-playout:
     dependencies:
@@ -277,7 +274,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/recording:
     dependencies:
@@ -314,7 +311,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/spectrogram:
     dependencies:
@@ -348,7 +345,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/ui-components:
     dependencies:
@@ -446,7 +443,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   website:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/browser:
     dependencies:
@@ -145,6 +145,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.1.1(vite@7.2.4)
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -168,7 +171,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/engine:
     devDependencies:
@@ -183,7 +186,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/loaders:
     dependencies:
@@ -202,7 +205,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/media-element-playout:
     dependencies:
@@ -274,7 +277,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/recording:
     dependencies:
@@ -311,7 +314,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/spectrogram:
     dependencies:
@@ -345,7 +348,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   packages/ui-components:
     dependencies:
@@ -443,7 +446,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@25.0.1)
 
   website:
     dependencies:

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -46,6 +46,10 @@ Each example page should have OG/Twitter meta tags with a social image. Pattern:
 
 - A320U.sf2 SoundFont — served from `static/media/soundfont/`. CC-BY 3.0 license. Loaded by MIDI example at `/waveform-playlist/media/soundfont/A320U.sf2`.
 
+## Example Component Guidelines
+
+- **Multi-track examples must use `deferEngineRebuild={loading}`** — Without it, the engine rebuilds on every track decode (up to N times for N tracks), creating race conditions with `pendingResumeRef` that cause duplicate audio on play/pause/play cycles.
+
 ## Guide Documentation Drift
 
 Context hooks tables in guide docs (e.g., `media-element-playout.md`) easily drift from source interfaces. Always cross-check guide "Returns" columns against the actual `*ContextValue` interfaces in the provider source file. Use "Key returns" column header (not "Returns") if listing a subset.

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -48,7 +48,7 @@ Each example page should have OG/Twitter meta tags with a social image. Pattern:
 
 ## Example Component Guidelines
 
-- **Multi-track examples must use `deferEngineRebuild={loading}`** — Without it, the engine rebuilds on every track decode (up to N times for N tracks), creating race conditions with `pendingResumeRef` that cause duplicate audio on play/pause/play cycles.
+- **Multi-track examples must use `deferEngineRebuild={loading}`** — Without it, the engine rebuilds on every track decode (up to N times for N tracks), creating race conditions that cause duplicate audio on play/pause/play cycles.
 
 ## Guide Documentation Drift
 

--- a/website/src/components/examples/FlexibleApiExample.tsx
+++ b/website/src/components/examples/FlexibleApiExample.tsx
@@ -557,6 +557,7 @@ export function FlexibleApiExample() {
         <WaveformPlaylistProvider
           tracks={tracks}
           onTracksChange={setTracks}
+          deferEngineRebuild={loading}
           samplesPerPixel={512}
           mono
           waveHeight={40}


### PR DESCRIPTION
## Summary

- Add `event.repeat` guard in `useKeyboardShortcuts` to prevent held-key repeats from firing multiple concurrent `play()` calls during async `engine.init()`
- Add `deferEngineRebuild={loading}` to `FlexibleApiExample` to prevent engine rebuilds on every track decode (up to 11 times)
- Extract `handleKeyboardEvent` as a pure function for direct unit testing
- Add 16 unit tests covering shortcut matching, modifier keys, input element exclusion, and a direct bug reproduction scenario

## Test plan

- [x] 16 new unit tests pass (`npx vitest run` in browser package — 178 total)
- [x] `pnpm lint` passes
- [ ] Manual test: open Flexible API example, press Space to play, Space to pause, Space to play again — no duplicate audio layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)