### PR TITLE
feat: add configurable preservesPitch prop to MediaElementPlaylistProvider

### DIFF
--- a/packages/browser/src/MediaElementPlaylistContext.tsx
+++ b/packages/browser/src/MediaElementPlaylistContext.tsx
@@ -98,6 +98,9 @@ export interface MediaElementPlaylistProviderProps {
   timescale?: boolean;
   /** Initial playback rate (0.5 to 2.0) */
   playbackRate?: number;
+  /** Whether to preserve pitch when changing playback rate (default: true).
+   *  Set to false when using an external pitch processor like SoundTouch. */
+  preservesPitch?: boolean;
   /** Enable automatic scroll to keep playhead centered */
   automaticScroll?: boolean;
   /** Theme configuration */
@@ -154,6 +157,7 @@ export const MediaElementPlaylistProvider: React.FC<MediaElementPlaylistProvider
   waveHeight = 100,
   timescale = false,
   playbackRate: initialPlaybackRate = 1,
+  preservesPitch = true,
   automaticScroll = false,
   theme: userTheme,
   controls = { show: false, width: 0 },
@@ -246,6 +250,7 @@ export const MediaElementPlaylistProvider: React.FC<MediaElementPlaylistProvider
   useEffect(() => {
     const playout = new MediaElementPlayout({
       playbackRate: initialPlaybackRate,
+      preservesPitch,
     });
 
     playout.addTrack({
@@ -290,6 +295,7 @@ export const MediaElementPlaylistProvider: React.FC<MediaElementPlaylistProvider
     track.fadeOut,
     audioContext,
     initialPlaybackRate,
+    preservesPitch,
     onReady,
     stopAnimationFrameLoop,
     setActiveAnnotationId,

--- a/packages/media-element-playout/src/MediaElementPlayout.ts
+++ b/packages/media-element-playout/src/MediaElementPlayout.ts
@@ -5,6 +5,9 @@ export interface MediaElementPlayoutOptions {
   masterVolume?: number;
   /** Initial playback rate (0.5 to 2.0) */
   playbackRate?: number;
+  /** Whether to preserve pitch when changing playback rate (default: true).
+   *  Set to false when using an external pitch processor like SoundTouch. */
+  preservesPitch?: boolean;
 }
 
 /**
@@ -28,12 +31,14 @@ export class MediaElementPlayout {
   private track: MediaElementTrack | null = null;
   private _masterVolume: number;
   private _playbackRate: number;
+  private _preservesPitch: boolean;
   private _isPlaying: boolean = false;
   private onPlaybackCompleteCallback?: () => void;
 
   constructor(options: MediaElementPlayoutOptions = {}) {
     this._masterVolume = options.masterVolume ?? 1;
     this._playbackRate = options.playbackRate ?? 1;
+    this._preservesPitch = options.preservesPitch ?? true;
   }
 
   /**
@@ -63,6 +68,7 @@ export class MediaElementPlayout {
       ...options,
       volume: this._masterVolume * (options.volume ?? 1),
       playbackRate: this._playbackRate,
+      preservesPitch: this._preservesPitch,
     });
 
     // Set up stop callback

--- a/packages/media-element-playout/src/MediaElementTrack.ts
+++ b/packages/media-element-playout/src/MediaElementTrack.ts
@@ -24,8 +24,10 @@ export interface MediaElementTrackOptions {
   name?: string;
   /** Initial volume (0.0 to 1.0) */
   volume?: number;
-  /** Initial playback rate (0.5 to 2.0, pitch preserved) */
+  /** Initial playback rate (0.5 to 2.0) */
   playbackRate?: number;
+  /** Whether to preserve pitch when changing playback rate (default: true) */
+  preservesPitch?: boolean;
   /**
    * AudioContext for Web Audio routing.
    * When provided, audio is routed through Web Audio nodes for fades and effects:
@@ -98,15 +100,18 @@ export class MediaElementTrack {
     this.audioElement.preload = 'auto';
     this.audioElement.playbackRate = this._playbackRate;
 
-    // Preserve pitch when changing playback rate (default in modern browsers)
+    // Set pitch preservation (default: true).
+    // When false, the browser won't apply its own pitch correction — useful
+    // when an external processor like SoundTouch handles pitch compensation.
     // Vendor-prefixed properties are non-standard; cast once for type safety.
+    const shouldPreservePitch = options.preservesPitch ?? true;
     const audio = this.audioElement as unknown as VendorPrefixedPitch;
     if ('preservesPitch' in this.audioElement) {
-      audio.preservesPitch = true;
+      audio.preservesPitch = shouldPreservePitch;
     } else if ('mozPreservesPitch' in this.audioElement) {
-      audio.mozPreservesPitch = true;
+      audio.mozPreservesPitch = shouldPreservePitch;
     } else if ('webkitPreservesPitch' in this.audioElement) {
-      audio.webkitPreservesPitch = true;
+      audio.webkitPreservesPitch = shouldPreservePitch;
     }
 
     // Set up Web Audio routing if AudioContext provided

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -75,7 +75,8 @@ interface MediaElementPlaylistProviderProps {
   samplesPerPixel?: number;              // Default: 1024
   waveHeight?: number;                   // Default: 100
   timescale?: boolean;                   // Default: false
-  playbackRate?: number;                 // Default: 1 (range: 0.5–2.0, pitch-preserving)
+  playbackRate?: number;                 // Default: 1 (range: 0.5–2.0)
+  preservesPitch?: boolean;              // Default: true (set false for external pitch processor)
   automaticScroll?: boolean;             // Default: false
   theme?: Partial<WaveformPlaylistTheme>;
   controls?: { show: boolean; width: number }; // Default: { show: false, width: 0 }

--- a/website/docs/api/providers/media-element-playlist-provider.md
+++ b/website/docs/api/providers/media-element-playlist-provider.md
@@ -121,7 +121,14 @@ When provided, audio routes through a Web Audio graph enabling fades and effects
 **Type:** `number`
 **Default:** `1`
 
-Initial playback rate. Range: 0.5 to 2.0. Pitch is preserved automatically by the HTMLAudioElement.
+Initial playback rate. Range: 0.5 to 2.0.
+
+#### `preservesPitch`
+
+**Type:** `boolean`
+**Default:** `true`
+
+Whether to preserve pitch when changing playback rate. When `true`, the browser's built-in time-stretching keeps pitch constant while speed changes. Set to `false` when using an external pitch processor (e.g., SoundTouch AudioWorklet) that handles pitch compensation itself.
 
 #### `automaticScroll`
 
@@ -277,6 +284,7 @@ interface MediaElementPlaylistProviderProps {
 
   // Playback
   playbackRate?: number;
+  preservesPitch?: boolean;
   automaticScroll?: boolean;
 
   // Theming

--- a/website/src/components/examples/MediaElementExample.tsx
+++ b/website/src/components/examples/MediaElementExample.tsx
@@ -292,6 +292,7 @@ export function MediaElementExample() {
   const [trackConfigs, setTrackConfigs] = useState<Array<{ source: string; waveformData: any; name: string } | null>>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [preservesPitch, setPreservesPitch] = useState(true);
 
   // Load BBC peaks files and build track configs
   useEffect(() => {
@@ -348,10 +349,28 @@ export function MediaElementExample() {
             samplesPerPixel={512}
             waveHeight={120}
             theme={theme}
+            preservesPitch={preservesPitch}
             barWidth={2}
             barGap={0}
           >
             <PlaybackControls />
+            <Controls style={{ marginTop: '-0.5rem' }}>
+              <ControlGroup>
+                <Label>Preserve Pitch:</Label>
+                <SpeedButton
+                  $active={preservesPitch}
+                  onClick={() => setPreservesPitch(true)}
+                >
+                  On
+                </SpeedButton>
+                <SpeedButton
+                  $active={!preservesPitch}
+                  onClick={() => setPreservesPitch(false)}
+                >
+                  Off
+                </SpeedButton>
+              </ControlGroup>
+            </Controls>
             <MediaElementWaveform />
           </MediaElementPlaylistProvider>
         </Section>


### PR DESCRIPTION
## Summary

- Makes `HTMLAudioElement.preservesPitch` configurable instead of hardcoded to `true`
- New `preservesPitch` boolean prop on `MediaElementPlaylistProvider` (default: `true`, backwards compatible)
- Set to `false` when using an external pitch processor that handles pitch correction

## Changes

- `MediaElementTrackOptions.preservesPitch` — new optional prop
- `MediaElementPlayoutOptions.preservesPitch` — passes through to track
- `MediaElementPlaylistProviderProps.preservesPitch` — consumer-facing prop

## Test plan
- [ ] Existing MediaElement example still works (default `true`)
- [ ] `pnpm build` passes
- [ ] `pnpm lint` passes