### PR TITLE
feat(dawcore): multi-channel waveform rendering

### DIFF
--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -36,7 +36,7 @@
 - **Derived width, not stored state** — `_totalWidth` is a getter derived from `_duration`, `effectiveSampleRate`, and `samplesPerPixel`. Not a `@state()` property — avoids Lit update loops from setting state in `updated()`.
 - **Error events** — `daw-track-error` dispatched on load failure (with `{ trackId, error }`). `daw-error` dispatched on playback failure (with `{ operation, error }`). Failed fetch promises are removed from cache to allow retry.
 - **Engine promise retry** — `_enginePromise` is cleared on rejection so `_ensureEngine()` can retry instead of caching a permanent failure.
-- **Multi-channel peak aggregation** — `_generatePeaks()` aggregates across all channels (min-of-mins, max-of-maxes). When `mono` is true, only channel 0 is used.
+- **Web worker peak generation** — `PeakPipeline` (in `workers/peakPipeline.ts`) generates `WaveformData` via inline Blob worker at base scale (256), caches per `AudioBuffer` (WeakMap), extracts `PeakData` at current zoom via `resample()`. Near-instant zoom changes. Per-channel peaks when `mono=false`; weighted-average mono merge when `mono=true`.
 
 ## CSS Theming
 
@@ -73,7 +73,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **`loadFiles()` returns result** — Returns `{ loaded: string[], failed: Array<{ file, error }> }` so callers can detect partial failures. Individual file errors are caught and reported via `daw-files-load-error` events.
 - **sampleRate comes from decoded audio** — Always use `audioBuffer.sampleRate` for clip creation. The global AudioContext decodes at the hardware rate (may be 44100 or 48000). Set `this.sampleRate` from the first decoded buffer so the ruler, peaks, and engine all agree.
 - **Use `getGlobalAudioContext()` for decode** — Import from `@waveform-playlist/playout`. Same context Tone.js uses. `decodeAudioData` works while suspended (pre-gesture). Never create a separate AudioContext for decoding.
-- **Pointer interactions extracted** — `interactions/pointer-handler.ts` handles pointerdown/move/up, caches timeline ref and rect, distinguishes click vs drag. The host implements `PointerHandlerHost` interface. `daw-editor.ts` is ~770 lines (under 800 max); consider extracting `loadFiles` if it grows further.
+- **Pointer interactions extracted** — `interactions/pointer-handler.ts` handles pointerdown/move/up, caches timeline ref and rect, distinguishes click vs drag. The host implements `PointerHandlerHost` interface.
+- **Peak pipeline extracted** — `workers/peakPipeline.ts` manages worker lifecycle, WaveformData cache, inflight dedup. `daw-editor.ts` is ~790 lines (under 800 max); consider extracting `loadFiles` if it grows further.
 
 ## Typed Events
 
@@ -92,6 +93,17 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 - **Always revoke blob URLs** — `URL.revokeObjectURL(blobUrl)` after decode succeeds or in the catch block.
 - `_getOrderedTracks()` sorts DOM-declared tracks by position, file-dropped tracks (not in DOM) sort after, preserving Map insertion order among themselves.
+
+## Web Worker Peak Generation
+
+- **`peaksWorker.ts`** — Inline Blob worker (portable across bundlers). Generates WaveformData binary format from AudioBuffer channel data at a base scale. Uses `generateWaveformData` algorithm from BBC's waveform-data.js (MIT).
+- **`waveformDataUtils.ts`** — `extractPeaks()` converts WaveformData → PeakData. Handles all channels, mono merging (weighted average), slicing, and aligned resampling.
+- **`peakPipeline.ts`** — Orchestrates worker lifecycle, WaveformData cache (WeakMap per AudioBuffer), inflight dedup, and peak extraction at any zoom level.
+- **Peak resolution order:** (1) WaveformData cache hit → `extractPeaks()` (synchronous resample), (2) worker generation → cache → extract.
+- **Zoom re-extraction:** `willUpdate()` detects `samplesPerPixel` changes and re-extracts peaks from cached WaveformData (near-instant, no worker round-trip).
+- **Aligned resampling** — When slicing WaveformData before resampling to a different scale, source slice indices must align to the resampling ratio. Uses `floor(targetStart * ratio)` / `ceil(targetEnd * ratio)` to include all contributing source bins. See browser CLAUDE.md "Aligned Peak Resampling" for full explanation.
+- **CSP fallback** — Worker creation can fail in CSP-restricted environments blocking blob: URLs. The fallback rejects with actionable error message suggesting `worker-src blob:` directive.
+- **Disconnect guard** — `_loadTrack` catch checks `this.isConnected` before dispatching error events (detached elements can't bubble, CLAUDE.md pattern #36).
 
 ## Lit/TypeScript Requirements
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -36,7 +36,7 @@
 - **Derived width, not stored state** — `_totalWidth` is a getter derived from `_duration`, `effectiveSampleRate`, and `samplesPerPixel`. Not a `@state()` property — avoids Lit update loops from setting state in `updated()`.
 - **Error events** — `daw-track-error` dispatched on load failure (with `{ trackId, error }`). `daw-error` dispatched on playback failure (with `{ operation, error }`). Failed fetch promises are removed from cache to allow retry.
 - **Engine promise retry** — `_enginePromise` is cleared on rejection so `_ensureEngine()` can retry instead of caching a permanent failure.
-- **Web worker peak generation** — `PeakPipeline` (in `workers/peakPipeline.ts`) generates `WaveformData` via inline Blob worker at base scale (256), caches per `AudioBuffer` (WeakMap), extracts `PeakData` at current zoom via `resample()`. Near-instant zoom changes. Per-channel peaks when `mono=false`; weighted-average mono merge when `mono=true`.
+- **Web worker peak generation** — `PeakPipeline` (in `workers/peakPipeline.ts`) generates `WaveformData` via inline Blob worker at the current `samplesPerPixel`, caches per `AudioBuffer` (WeakMap), extracts `PeakData` via `resample()`. Resampling only works to coarser (larger) scales — the cached base scale determines the finest renderable zoom. Per-channel peaks when `mono=false`; weighted-average mono merge when `mono=true`.
 
 ## CSS Theming
 
@@ -96,11 +96,11 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 ## Web Worker Peak Generation
 
-- **`peaksWorker.ts`** — Inline Blob worker (portable across bundlers). Generates WaveformData binary format from AudioBuffer channel data at a base scale. Uses `generateWaveformData` algorithm from BBC's waveform-data.js (MIT).
+- **`peaksWorker.ts`** — Inline Blob worker (portable across bundlers). Generates WaveformData binary format from AudioBuffer channel data at a given scale. Uses `generateWaveformData` algorithm from BBC's waveform-data.js (MIT). Includes fix for upstream trailing-bin offset bug in 16-bit multi-channel.
 - **`waveformDataUtils.ts`** — `extractPeaks()` converts WaveformData → PeakData. Handles all channels, mono merging (weighted average), slicing, and aligned resampling.
 - **`peakPipeline.ts`** — Orchestrates worker lifecycle, WaveformData cache (WeakMap per AudioBuffer), inflight dedup, and peak extraction at any zoom level.
 - **Peak resolution order:** (1) WaveformData cache hit → `extractPeaks()` (synchronous resample), (2) worker generation → cache → extract.
-- **Zoom re-extraction:** `willUpdate()` detects `samplesPerPixel` changes and re-extracts peaks from cached WaveformData (near-instant, no worker round-trip).
+- **Zoom re-extraction:** `willUpdate()` detects `samplesPerPixel` changes and re-extracts peaks from cached WaveformData. Only works for scales coarser than the cached base — finer zoom requires regeneration via worker.
 - **Aligned resampling** — When slicing WaveformData before resampling to a different scale, source slice indices must align to the resampling ratio. Uses `floor(targetStart * ratio)` / `ceil(targetEnd * ratio)` to include all contributing source bins. See browser CLAUDE.md "Aligned Peak Resampling" for full explanation.
 - **CSP fallback** — Worker creation can fail in CSP-restricted environments blocking blob: URLs. The fallback rejects with actionable error message suggesting `worker-src blob:` directive.
 - **Disconnect guard** — `_loadTrack` catch checks `this.isConnected` before dispatching error events (detached elements can't bubble, CLAUDE.md pattern #36).

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "files": ["dist"],
   "dependencies": {
-    "lit": "^3.0.0"
+    "lit": "^3.0.0",
+    "waveform-data": "^4.5.2"
   },
   "peerDependencies": {
     "@waveform-playlist/engine": ">=7.0.0",

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -59,7 +59,7 @@ export class DawEditorElement extends LitElement {
 
   @state() private _tracks: Map<string, TrackDescriptor> = new Map();
   @state() private _engineTracks: Map<string, ClipTrack> = new Map();
-  @state() private _peaksData: Map<string, { peaks: Int16Array; bits: 16; length: number }> =
+  @state() private _peaksData: Map<string, { data: Int16Array[]; bits: 16; length: number }> =
     new Map();
   @state() _isPlaying = false;
   @state() private _duration = 0;
@@ -394,30 +394,33 @@ export class DawEditorElement extends LitElement {
     const samplesPerPeak = this.samplesPerPixel;
     const totalSamples = audioBuffer.getChannelData(0).length;
     const peakCount = Math.ceil(totalSamples / samplesPerPeak);
-    const peaks = new Int16Array(peakCount * 2);
 
-    for (let i = 0; i < peakCount; i++) {
-      const start = i * samplesPerPeak;
-      const end = Math.min(start + samplesPerPeak, totalSamples);
-      let min = 0;
-      let max = 0;
+    const data: Int16Array[] = [];
+    for (let ch = 0; ch < numChannels; ch++) {
+      const channelData = audioBuffer.getChannelData(ch);
+      const peaks = new Int16Array(peakCount * 2);
 
-      // Aggregate across channels; channel 0 only when mono=true
-      for (let ch = 0; ch < numChannels; ch++) {
-        const channelData = audioBuffer.getChannelData(ch);
+      for (let i = 0; i < peakCount; i++) {
+        const start = i * samplesPerPeak;
+        const end = Math.min(start + samplesPerPeak, totalSamples);
+        let min = 0;
+        let max = 0;
+
         for (let j = start; j < end; j++) {
           const sample = channelData[j];
           if (sample < min) min = sample;
           if (sample > max) max = sample;
         }
+
+        peaks[i * 2] = Math.round(min * 32767);
+        peaks[i * 2 + 1] = Math.round(max * 32767);
       }
 
-      peaks[i * 2] = Math.round(min * 32767);
-      peaks[i * 2 + 1] = Math.round(max * 32767);
+      data.push(peaks);
     }
 
     this._peaksData = new Map(this._peaksData).set(clipId, {
-      peaks,
+      data,
       bits: 16,
       length: peakCount,
     });
@@ -732,34 +735,48 @@ export class DawEditorElement extends LitElement {
         <daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
         <daw-playhead></daw-playhead>
         ${this._getOrderedTracks().map(
-          ([trackId, track]) => html`
-            <div
-              class="track-row ${trackId === this._selectedTrackId ? 'selected' : ''}"
-              style="height: ${this.waveHeight}px;"
-              data-track-id=${trackId}
-            >
-              ${track.clips.map((clip) => {
-                const peakData = this._peaksData.get(clip.id);
-                const width = clipPixelWidth(
-                  clip.startSample,
-                  clip.durationSamples,
-                  this.samplesPerPixel
-                );
-                const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
-                return html`
-                  <daw-waveform
-                    style="position: absolute; left: ${clipLeft}px;"
-                    .peaks=${peakData?.peaks ?? new Int16Array(0)}
-                    .bits=${16}
-                    .length=${peakData?.length ?? width}
-                    .waveHeight=${this.waveHeight}
-                    .barWidth=${this.barWidth}
-                    .barGap=${this.barGap}
-                  ></daw-waveform>
-                `;
-              })}
-            </div>
-          `
+          ([trackId, track]) => {
+            // Determine channel count from peak data of first clip with peaks
+            const firstPeaks = track.clips
+              .map((c) => this._peaksData.get(c.id))
+              .find((p) => p && p.data.length > 0);
+            const numChannels = firstPeaks ? firstPeaks.data.length : 1;
+            const channelHeight = this.waveHeight;
+            const trackHeight = channelHeight * numChannels;
+
+            return html`
+              <div
+                class="track-row ${trackId === this._selectedTrackId ? 'selected' : ''}"
+                style="height: ${trackHeight}px;"
+                data-track-id=${trackId}
+              >
+                ${track.clips.map((clip) => {
+                  const peakData = this._peaksData.get(clip.id);
+                  const width = clipPixelWidth(
+                    clip.startSample,
+                    clip.durationSamples,
+                    this.samplesPerPixel
+                  );
+                  const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
+                  const channels = peakData?.data ?? [new Int16Array(0)];
+
+                  return channels.map(
+                    (channelPeaks, chIdx) => html`
+                      <daw-waveform
+                        style="position: absolute; left: ${clipLeft}px; top: ${chIdx * channelHeight}px;"
+                        .peaks=${channelPeaks}
+                        .bits=${16}
+                        .length=${peakData?.length ?? width}
+                        .waveHeight=${channelHeight}
+                        .barWidth=${this.barWidth}
+                        .barGap=${this.barGap}
+                      ></daw-waveform>
+                    `
+                  );
+                })}
+              </div>
+            `;
+          }
         )}
       </div>
       <slot></slot>

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -1,7 +1,10 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { ClipTrack, FadeType, Peaks, Bits } from '@waveform-playlist/core';
+import type { ClipTrack, FadeType, Peaks, PeakData } from '@waveform-playlist/core';
 import { createClipFromSeconds, createTrack, clipPixelWidth } from '@waveform-playlist/core';
+import type WaveformData from 'waveform-data';
+import { createPeaksWorker, type PeaksWorkerApi } from '../workers/peaksWorker';
+import { extractPeaks } from '../workers/waveformDataUtils';
 import type { DawTrackElement } from './daw-track';
 import type { DawClipElement } from './daw-clip';
 import type { DawPlayheadElement } from './daw-playhead';
@@ -59,8 +62,7 @@ export class DawEditorElement extends LitElement {
 
   @state() private _tracks: Map<string, TrackDescriptor> = new Map();
   @state() private _engineTracks: Map<string, ClipTrack> = new Map();
-  @state() private _peaksData: Map<string, { data: Peaks[]; bits: Bits; length: number }> =
-    new Map();
+  @state() private _peaksData: Map<string, PeakData> = new Map();
   @state() _isPlaying = false;
   @state() private _duration = 0;
   @state() _selectedTrackId: string | null = null;
@@ -76,6 +78,9 @@ export class DawEditorElement extends LitElement {
   private _enginePromise: Promise<PlaylistEngine> | null = null;
   private _audioInitialized = false;
   private _audioCache = new Map<string, Promise<AudioBuffer>>();
+  private _waveformDataCache = new WeakMap<AudioBuffer, WaveformData>();
+  private _waveformDataInflight = new WeakMap<AudioBuffer, Promise<WaveformData>>();
+  private _peaksWorker: PeaksWorkerApi | null = null;
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
   private _pointer = new PointerHandler(this);
@@ -190,6 +195,8 @@ export class DawEditorElement extends LitElement {
     this._childObserver = null;
     this._trackElements.clear();
     this._audioCache.clear();
+    this._peaksWorker?.terminate();
+    this._peaksWorker = null;
 
     try {
       this._disposeEngine();
@@ -323,7 +330,7 @@ export class DawEditorElement extends LitElement {
           sourceDuration: audioBuffer.duration,
         });
 
-        this._generatePeaks(clip.id, audioBuffer);
+        await this._generatePeaks(clip.id, audioBuffer);
         clips.push(clip);
       }
 
@@ -389,41 +396,60 @@ export class DawEditorElement extends LitElement {
     }
   }
 
-  private _generatePeaks(clipId: string, audioBuffer: AudioBuffer) {
-    const numChannels = this.mono ? 1 : audioBuffer.numberOfChannels;
-    const samplesPerPeak = this.samplesPerPixel;
-    const totalSamples = audioBuffer.getChannelData(0).length;
-    const peakCount = Math.ceil(totalSamples / samplesPerPeak);
+  /**
+   * Generate WaveformData via web worker, then extract PeakData at current zoom.
+   * Caches WaveformData per AudioBuffer for near-instant zoom changes via resample().
+   */
+  private async _generatePeaks(clipId: string, audioBuffer: AudioBuffer) {
+    const waveformData = await this._getWaveformData(audioBuffer);
+    const peakData = extractPeaks(waveformData, this.samplesPerPixel, this.mono);
+    this._peaksData = new Map(this._peaksData).set(clipId, peakData);
+  }
 
-    const data: Int16Array[] = [];
-    for (let ch = 0; ch < numChannels; ch++) {
-      const channelData = audioBuffer.getChannelData(ch);
-      const peaks = new Int16Array(peakCount * 2);
+  private async _getWaveformData(audioBuffer: AudioBuffer): Promise<WaveformData> {
+    // Cache hit
+    const cached = this._waveformDataCache.get(audioBuffer);
+    if (cached) return cached;
 
-      for (let i = 0; i < peakCount; i++) {
-        const start = i * samplesPerPeak;
-        const end = Math.min(start + samplesPerPeak, totalSamples);
-        let min = 0;
-        let max = 0;
+    // Inflight dedup
+    const inflight = this._waveformDataInflight.get(audioBuffer);
+    if (inflight) return inflight;
 
-        for (let j = start; j < end; j++) {
-          const sample = channelData[j];
-          if (sample < min) min = sample;
-          if (sample > max) max = sample;
-        }
-
-        peaks[i * 2] = Math.round(min * 32767);
-        peaks[i * 2 + 1] = Math.round(max * 32767);
-      }
-
-      data.push(peaks);
+    // Generate via worker at base scale (finest zoom level for resample)
+    if (!this._peaksWorker) {
+      this._peaksWorker = createPeaksWorker();
     }
 
-    this._peaksData = new Map(this._peaksData).set(clipId, {
-      data,
-      bits: 16,
-      length: peakCount,
-    });
+    const baseScale = Math.min(this.samplesPerPixel, 256);
+    // .slice() channel buffers to avoid detaching the original AudioBuffer views
+    const channels: ArrayBuffer[] = [];
+    for (let c = 0; c < audioBuffer.numberOfChannels; c++) {
+      channels.push(audioBuffer.getChannelData(c).slice().buffer as ArrayBuffer);
+    }
+
+    const id = 'buffer-' + Math.random().toString(36).slice(2, 11);
+    const promise = this._peaksWorker
+      .generate({
+        id,
+        channels,
+        length: audioBuffer.length,
+        sampleRate: audioBuffer.sampleRate,
+        scale: baseScale,
+        bits: 16,
+        splitChannels: true,
+      })
+      .then((waveformData) => {
+        this._waveformDataCache.set(audioBuffer, waveformData);
+        this._waveformDataInflight.delete(audioBuffer);
+        return waveformData;
+      })
+      .catch((err) => {
+        this._waveformDataInflight.delete(audioBuffer);
+        throw err;
+      });
+
+    this._waveformDataInflight.set(audioBuffer, promise);
+    return promise;
   }
 
   private _recomputeDuration() {
@@ -566,7 +592,7 @@ export class DawEditorElement extends LitElement {
           sourceDuration: audioBuffer.duration,
         });
 
-        this._generatePeaks(clip.id, audioBuffer);
+        await this._generatePeaks(clip.id, audioBuffer);
 
         const trackId = crypto.randomUUID();
         const track = createTrack({ name, clips: [clip] });

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -238,15 +238,22 @@ export class DawEditorElement extends LitElement {
 
   private _onTrackRemoved(trackId: string) {
     this._trackElements.delete(trackId);
-
+    // Clean up per-clip data before removing the track (need clip IDs from engine tracks)
+    const removedTrack = this._engineTracks.get(trackId);
+    if (removedTrack) {
+      const nextPeaks = new Map(this._peaksData);
+      for (const clip of removedTrack.clips) {
+        this._clipBuffers.delete(clip.id);
+        nextPeaks.delete(clip.id);
+      }
+      this._peaksData = nextPeaks;
+    }
     const nextTracks = new Map(this._tracks);
     nextTracks.delete(trackId);
     this._tracks = nextTracks;
-
     const nextEngine = new Map(this._engineTracks);
     nextEngine.delete(trackId);
     this._engineTracks = nextEngine;
-
     this._recomputeDuration();
     if (this._engine) {
       this._engine.setTracks([...nextEngine.values()]);
@@ -610,13 +617,15 @@ export class DawEditorElement extends LitElement {
         URL.revokeObjectURL(blobUrl);
         console.warn('[dawcore] Failed to load file: ' + file.name + ' — ' + String(err));
         failed.push({ file, error: err });
-        this.dispatchEvent(
-          new CustomEvent<DawFilesLoadErrorDetail>('daw-files-load-error', {
-            bubbles: true,
-            composed: true,
-            detail: { file, error: err },
-          })
-        );
+        if (this.isConnected) {
+          this.dispatchEvent(
+            new CustomEvent<DawFilesLoadErrorDetail>('daw-files-load-error', {
+              bubbles: true,
+              composed: true,
+              detail: { file, error: err },
+            })
+          );
+        }
       }
     }
 

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { ClipTrack, FadeType } from '@waveform-playlist/core';
+import type { ClipTrack, FadeType, Peaks, Bits } from '@waveform-playlist/core';
 import { createClipFromSeconds, createTrack, clipPixelWidth } from '@waveform-playlist/core';
 import type { DawTrackElement } from './daw-track';
 import type { DawClipElement } from './daw-clip';
@@ -59,7 +59,7 @@ export class DawEditorElement extends LitElement {
 
   @state() private _tracks: Map<string, TrackDescriptor> = new Map();
   @state() private _engineTracks: Map<string, ClipTrack> = new Map();
-  @state() private _peaksData: Map<string, { data: Int16Array[]; bits: 16; length: number }> =
+  @state() private _peaksData: Map<string, { data: Peaks[]; bits: Bits; length: number }> =
     new Map();
   @state() _isPlaying = false;
   @state() private _duration = 0;
@@ -758,7 +758,7 @@ export class DawEditorElement extends LitElement {
                     this.samplesPerPixel
                   );
                   const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
-                  const channels = peakData?.data ?? [new Int16Array(0)];
+                  const channels: Peaks[] = peakData?.data ?? [new Int16Array(0)];
 
                   return channels.map(
                     (channelPeaks, chIdx) => html`

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -760,50 +760,49 @@ export class DawEditorElement extends LitElement {
           : ''}
         <daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
         <daw-playhead></daw-playhead>
-        ${this._getOrderedTracks().map(
-          ([trackId, track]) => {
-            // Determine channel count from peak data of first clip with peaks
-            const firstPeaks = track.clips
-              .map((c) => this._peaksData.get(c.id))
-              .find((p) => p && p.data.length > 0);
-            const numChannels = firstPeaks ? firstPeaks.data.length : 1;
-            const channelHeight = this.waveHeight;
-            const trackHeight = channelHeight * numChannels;
+        ${this._getOrderedTracks().map(([trackId, track]) => {
+          // Determine channel count from peak data of first clip with peaks
+          const firstPeaks = track.clips
+            .map((c) => this._peaksData.get(c.id))
+            .find((p) => p && p.data.length > 0);
+          const numChannels = firstPeaks ? firstPeaks.data.length : 1;
+          const channelHeight = this.waveHeight;
+          const trackHeight = channelHeight * numChannels;
 
-            return html`
-              <div
-                class="track-row ${trackId === this._selectedTrackId ? 'selected' : ''}"
-                style="height: ${trackHeight}px;"
-                data-track-id=${trackId}
-              >
-                ${track.clips.map((clip) => {
-                  const peakData = this._peaksData.get(clip.id);
-                  const width = clipPixelWidth(
-                    clip.startSample,
-                    clip.durationSamples,
-                    this.samplesPerPixel
-                  );
-                  const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
-                  const channels: Peaks[] = peakData?.data ?? [new Int16Array(0)];
+          return html`
+            <div
+              class="track-row ${trackId === this._selectedTrackId ? 'selected' : ''}"
+              style="height: ${trackHeight}px;"
+              data-track-id=${trackId}
+            >
+              ${track.clips.map((clip) => {
+                const peakData = this._peaksData.get(clip.id);
+                const width = clipPixelWidth(
+                  clip.startSample,
+                  clip.durationSamples,
+                  this.samplesPerPixel
+                );
+                const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
+                const channels: Peaks[] = peakData?.data ?? [new Int16Array(0)];
 
-                  return channels.map(
-                    (channelPeaks, chIdx) => html`
-                      <daw-waveform
-                        style="position: absolute; left: ${clipLeft}px; top: ${chIdx * channelHeight}px;"
-                        .peaks=${channelPeaks}
-                        .bits=${16}
-                        .length=${peakData?.length ?? width}
-                        .waveHeight=${channelHeight}
-                        .barWidth=${this.barWidth}
-                        .barGap=${this.barGap}
-                      ></daw-waveform>
-                    `
-                  );
-                })}
-              </div>
-            `;
-          }
-        )}
+                return channels.map(
+                  (channelPeaks, chIdx) => html`
+                    <daw-waveform
+                      style="position: absolute; left: ${clipLeft}px; top: ${chIdx *
+                      channelHeight}px;"
+                      .peaks=${channelPeaks}
+                      .bits=${16}
+                      .length=${peakData?.length ?? width}
+                      .waveHeight=${channelHeight}
+                      .barWidth=${this.barWidth}
+                      .barGap=${this.barGap}
+                    ></daw-waveform>
+                  `
+                );
+              })}
+            </div>
+          `;
+        })}
       </div>
       <slot></slot>
     `;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -2,9 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { ClipTrack, FadeType, Peaks, PeakData } from '@waveform-playlist/core';
 import { createClipFromSeconds, createTrack, clipPixelWidth } from '@waveform-playlist/core';
-import type WaveformData from 'waveform-data';
-import { createPeaksWorker, type PeaksWorkerApi } from '../workers/peaksWorker';
-import { extractPeaks } from '../workers/waveformDataUtils';
+import { PeakPipeline } from '../workers/peakPipeline';
 import type { DawTrackElement } from './daw-track';
 import type { DawClipElement } from './daw-clip';
 import type { DawPlayheadElement } from './daw-playhead';
@@ -78,9 +76,8 @@ export class DawEditorElement extends LitElement {
   private _enginePromise: Promise<PlaylistEngine> | null = null;
   private _audioInitialized = false;
   private _audioCache = new Map<string, Promise<AudioBuffer>>();
-  private _waveformDataCache = new WeakMap<AudioBuffer, WaveformData>();
-  private _waveformDataInflight = new WeakMap<AudioBuffer, Promise<WaveformData>>();
-  private _peaksWorker: PeaksWorkerApi | null = null;
+  private _clipBuffers = new Map<string, AudioBuffer>();
+  private _peakPipeline = new PeakPipeline();
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
   private _pointer = new PointerHandler(this);
@@ -195,13 +192,31 @@ export class DawEditorElement extends LitElement {
     this._childObserver = null;
     this._trackElements.clear();
     this._audioCache.clear();
-    this._peaksWorker?.terminate();
-    this._peaksWorker = null;
+    this._clipBuffers.clear();
+    this._peakPipeline.terminate();
 
     try {
       this._disposeEngine();
     } catch (err) {
       console.warn('[dawcore] Error disposing engine: ' + String(err));
+    }
+  }
+
+  willUpdate(changedProperties: Map<string, unknown>) {
+    // Re-extract peaks at new zoom level from cached WaveformData (near-instant)
+    if (changedProperties.has('samplesPerPixel') && this._clipBuffers.size > 0) {
+      const reextracted = this._peakPipeline.reextractPeaks(
+        this._clipBuffers,
+        this.samplesPerPixel,
+        this.mono
+      );
+      if (reextracted.size > 0) {
+        const next = new Map(this._peaksData);
+        for (const [clipId, peakData] of reextracted) {
+          next.set(clipId, peakData);
+        }
+        this._peaksData = next;
+      }
     }
   }
 
@@ -330,7 +345,13 @@ export class DawEditorElement extends LitElement {
           sourceDuration: audioBuffer.duration,
         });
 
-        await this._generatePeaks(clip.id, audioBuffer);
+        this._clipBuffers.set(clip.id, audioBuffer);
+        const peakData = await this._peakPipeline.generatePeaks(
+          audioBuffer,
+          this.samplesPerPixel,
+          this.mono
+        );
+        this._peaksData = new Map(this._peaksData).set(clip.id, peakData);
         clips.push(clip);
       }
 
@@ -357,6 +378,8 @@ export class DawEditorElement extends LitElement {
         })
       );
     } catch (err) {
+      // Guard against dispatching on a disconnected element (CLAUDE.md pattern #36)
+      if (!this.isConnected) return;
       console.warn('[dawcore] Failed to load track "' + trackId + '": ' + String(err));
       this.dispatchEvent(
         new CustomEvent<DawTrackErrorDetail>('daw-track-error', {
@@ -394,62 +417,6 @@ export class DawEditorElement extends LitElement {
       this._audioCache.delete(src);
       throw err;
     }
-  }
-
-  /**
-   * Generate WaveformData via web worker, then extract PeakData at current zoom.
-   * Caches WaveformData per AudioBuffer for near-instant zoom changes via resample().
-   */
-  private async _generatePeaks(clipId: string, audioBuffer: AudioBuffer) {
-    const waveformData = await this._getWaveformData(audioBuffer);
-    const peakData = extractPeaks(waveformData, this.samplesPerPixel, this.mono);
-    this._peaksData = new Map(this._peaksData).set(clipId, peakData);
-  }
-
-  private async _getWaveformData(audioBuffer: AudioBuffer): Promise<WaveformData> {
-    // Cache hit
-    const cached = this._waveformDataCache.get(audioBuffer);
-    if (cached) return cached;
-
-    // Inflight dedup
-    const inflight = this._waveformDataInflight.get(audioBuffer);
-    if (inflight) return inflight;
-
-    // Generate via worker at base scale (finest zoom level for resample)
-    if (!this._peaksWorker) {
-      this._peaksWorker = createPeaksWorker();
-    }
-
-    const baseScale = Math.min(this.samplesPerPixel, 256);
-    // .slice() channel buffers to avoid detaching the original AudioBuffer views
-    const channels: ArrayBuffer[] = [];
-    for (let c = 0; c < audioBuffer.numberOfChannels; c++) {
-      channels.push(audioBuffer.getChannelData(c).slice().buffer as ArrayBuffer);
-    }
-
-    const id = 'buffer-' + Math.random().toString(36).slice(2, 11);
-    const promise = this._peaksWorker
-      .generate({
-        id,
-        channels,
-        length: audioBuffer.length,
-        sampleRate: audioBuffer.sampleRate,
-        scale: baseScale,
-        bits: 16,
-        splitChannels: true,
-      })
-      .then((waveformData) => {
-        this._waveformDataCache.set(audioBuffer, waveformData);
-        this._waveformDataInflight.delete(audioBuffer);
-        return waveformData;
-      })
-      .catch((err) => {
-        this._waveformDataInflight.delete(audioBuffer);
-        throw err;
-      });
-
-    this._waveformDataInflight.set(audioBuffer, promise);
-    return promise;
   }
 
   private _recomputeDuration() {
@@ -592,7 +559,13 @@ export class DawEditorElement extends LitElement {
           sourceDuration: audioBuffer.duration,
         });
 
-        await this._generatePeaks(clip.id, audioBuffer);
+        this._clipBuffers.set(clip.id, audioBuffer);
+        const peakData = await this._peakPipeline.generatePeaks(
+          audioBuffer,
+          this.samplesPerPixel,
+          this.mono
+        );
+        this._peaksData = new Map(this._peaksData).set(clip.id, peakData);
 
         const trackId = crypto.randomUUID();
         const track = createTrack({ name, clips: [clip] });

--- a/packages/dawcore/src/workers/peakPipeline.ts
+++ b/packages/dawcore/src/workers/peakPipeline.ts
@@ -2,7 +2,12 @@
  * Peak generation pipeline: AudioBuffer → web worker → WaveformData → PeakData.
  *
  * Manages worker lifecycle, WaveformData caching per AudioBuffer (WeakMap),
- * inflight dedup, and peak extraction at any zoom level via resample().
+ * inflight dedup, and peak extraction via resample() for any zoom level
+ * coarser than the base scale.
+ *
+ * The base scale determines the finest zoom level that can be rendered without
+ * regenerating. Resampling only works to coarser (larger) scales. Set baseScale
+ * to the finest zoom level the user might need.
  */
 
 import type WaveformData from 'waveform-data';
@@ -18,6 +23,7 @@ export class PeakPipeline {
   /**
    * Generate PeakData for a clip from its AudioBuffer.
    * Uses cached WaveformData when available; otherwise generates via worker.
+   * The worker generates at `scale` (= samplesPerPixel) for exact rendering.
    */
   async generatePeaks(
     audioBuffer: AudioBuffer,
@@ -35,7 +41,9 @@ export class PeakPipeline {
 
   /**
    * Re-extract peaks for all clips at a new zoom level using cached WaveformData.
-   * Returns a new Map of clipId → PeakData. Clips without cached WaveformData are skipped.
+   * Only works for zoom levels coarser than (or equal to) the cached base scale.
+   * Returns a new Map of clipId → PeakData. Clips without cached data or where
+   * the target scale is finer than the cached base are skipped.
    */
   reextractPeaks(
     clipBuffers: ReadonlyMap<string, AudioBuffer>,
@@ -46,6 +54,8 @@ export class PeakPipeline {
     for (const [clipId, audioBuffer] of clipBuffers) {
       const cached = this._cache.get(audioBuffer);
       if (cached) {
+        // Skip if target scale is finer than cached — resample can't downsample
+        if (samplesPerPixel < cached.scale) continue;
         try {
           result.set(clipId, extractPeaks(cached, samplesPerPixel, isMono));
         } catch (err) {
@@ -66,7 +76,8 @@ export class PeakPipeline {
     samplesPerPixel: number
   ): Promise<WaveformData> {
     const cached = this._cache.get(audioBuffer);
-    if (cached) return cached;
+    // Use cache if it's at a scale fine enough for the requested zoom
+    if (cached && cached.scale <= samplesPerPixel) return cached;
 
     const inflight = this._inflight.get(audioBuffer);
     if (inflight) return inflight;
@@ -75,7 +86,7 @@ export class PeakPipeline {
       this._worker = createPeaksWorker();
     }
 
-    const baseScale = Math.min(samplesPerPixel, 256);
+    // Generate at the requested scale — this is the finest zoom we can resample from
     // .slice() channel buffers to avoid detaching the original AudioBuffer views
     const channels: ArrayBuffer[] = [];
     for (let c = 0; c < audioBuffer.numberOfChannels; c++) {
@@ -87,7 +98,7 @@ export class PeakPipeline {
         channels,
         length: audioBuffer.length,
         sampleRate: audioBuffer.sampleRate,
-        scale: baseScale,
+        scale: samplesPerPixel,
         bits: 16,
         splitChannels: true,
       })

--- a/packages/dawcore/src/workers/peakPipeline.ts
+++ b/packages/dawcore/src/workers/peakPipeline.ts
@@ -1,0 +1,108 @@
+/**
+ * Peak generation pipeline: AudioBuffer → web worker → WaveformData → PeakData.
+ *
+ * Manages worker lifecycle, WaveformData caching per AudioBuffer (WeakMap),
+ * inflight dedup, and peak extraction at any zoom level via resample().
+ */
+
+import type WaveformData from 'waveform-data';
+import type { PeakData } from '@waveform-playlist/core';
+import { createPeaksWorker, type PeaksWorkerApi } from './peaksWorker';
+import { extractPeaks } from './waveformDataUtils';
+
+export class PeakPipeline {
+  private _worker: PeaksWorkerApi | null = null;
+  private _cache = new WeakMap<AudioBuffer, WaveformData>();
+  private _inflight = new WeakMap<AudioBuffer, Promise<WaveformData>>();
+
+  /**
+   * Generate PeakData for a clip from its AudioBuffer.
+   * Uses cached WaveformData when available; otherwise generates via worker.
+   */
+  async generatePeaks(
+    audioBuffer: AudioBuffer,
+    samplesPerPixel: number,
+    isMono: boolean
+  ): Promise<PeakData> {
+    const waveformData = await this._getWaveformData(audioBuffer, samplesPerPixel);
+    try {
+      return extractPeaks(waveformData, samplesPerPixel, isMono);
+    } catch (err) {
+      console.warn('[dawcore] extractPeaks failed: ' + String(err));
+      throw err;
+    }
+  }
+
+  /**
+   * Re-extract peaks for all clips at a new zoom level using cached WaveformData.
+   * Returns a new Map of clipId → PeakData. Clips without cached WaveformData are skipped.
+   */
+  reextractPeaks(
+    clipBuffers: ReadonlyMap<string, AudioBuffer>,
+    samplesPerPixel: number,
+    isMono: boolean
+  ): Map<string, PeakData> {
+    const result = new Map<string, PeakData>();
+    for (const [clipId, audioBuffer] of clipBuffers) {
+      const cached = this._cache.get(audioBuffer);
+      if (cached) {
+        try {
+          result.set(clipId, extractPeaks(cached, samplesPerPixel, isMono));
+        } catch (err) {
+          console.warn('[dawcore] reextractPeaks failed for clip ' + clipId + ': ' + String(err));
+        }
+      }
+    }
+    return result;
+  }
+
+  terminate() {
+    this._worker?.terminate();
+    this._worker = null;
+  }
+
+  private async _getWaveformData(
+    audioBuffer: AudioBuffer,
+    samplesPerPixel: number
+  ): Promise<WaveformData> {
+    const cached = this._cache.get(audioBuffer);
+    if (cached) return cached;
+
+    const inflight = this._inflight.get(audioBuffer);
+    if (inflight) return inflight;
+
+    if (!this._worker) {
+      this._worker = createPeaksWorker();
+    }
+
+    const baseScale = Math.min(samplesPerPixel, 256);
+    // .slice() channel buffers to avoid detaching the original AudioBuffer views
+    const channels: ArrayBuffer[] = [];
+    for (let c = 0; c < audioBuffer.numberOfChannels; c++) {
+      channels.push(audioBuffer.getChannelData(c).slice().buffer as ArrayBuffer);
+    }
+
+    const promise = this._worker
+      .generate({
+        channels,
+        length: audioBuffer.length,
+        sampleRate: audioBuffer.sampleRate,
+        scale: baseScale,
+        bits: 16,
+        splitChannels: true,
+      })
+      .then((waveformData) => {
+        this._cache.set(audioBuffer, waveformData);
+        this._inflight.delete(audioBuffer);
+        return waveformData;
+      })
+      .catch((err) => {
+        this._inflight.delete(audioBuffer);
+        console.warn('[dawcore] Peak generation via worker failed: ' + String(err));
+        throw err;
+      });
+
+    this._inflight.set(audioBuffer, promise);
+    return promise;
+  }
+}

--- a/packages/dawcore/src/workers/peaksWorker.ts
+++ b/packages/dawcore/src/workers/peaksWorker.ts
@@ -1,0 +1,279 @@
+/**
+ * Inline Web Worker for generating WaveformData binary format from AudioBuffer channels.
+ *
+ * Uses a Blob URL approach (portable across all bundlers) with the generateWaveformData
+ * algorithm adapted from BBC's waveform-data.js (MIT licensed, adapted from Audacity).
+ *
+ * The worker generates peaks at a base scale (finest zoom level). The main thread
+ * then uses WaveformData.resample() for near-instant zoom changes.
+ */
+
+import WaveformData from 'waveform-data';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Worker code (runs inside the Blob URL worker)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Self-contained worker source.
+ * Contains the generateWaveformData function from waveform-data.js/src/waveform-generator.js
+ * (MIT License, BBC). Pure JS, zero dependencies.
+ */
+const workerSource = `
+"use strict";
+
+var INT8_MAX = 127;
+var INT8_MIN = -128;
+var INT16_MAX = 32767;
+var INT16_MIN = -32768;
+
+function calculateWaveformDataLength(audio_sample_count, scale) {
+  var data_length = Math.floor(audio_sample_count / scale);
+  var samples_remaining = audio_sample_count - (data_length * scale);
+  if (samples_remaining > 0) {
+    data_length++;
+  }
+  return data_length;
+}
+
+function generateWaveformData(options) {
+  var scale = options.scale;
+  var amplitude_scale = options.amplitude_scale;
+  var split_channels = options.split_channels;
+  var length = options.length;
+  var sample_rate = options.sample_rate;
+  var channels = options.channels.map(function(channel) {
+    return new Float32Array(channel);
+  });
+  var output_channels = split_channels ? channels.length : 1;
+  var header_size = 24;
+  var data_length = calculateWaveformDataLength(length, scale);
+  var bytes_per_sample = options.bits === 8 ? 1 : 2;
+  var total_size = header_size + data_length * 2 * bytes_per_sample * output_channels;
+  var buffer = new ArrayBuffer(total_size);
+  var data_view = new DataView(buffer);
+
+  var scale_counter = 0;
+  var offset = header_size;
+
+  var min_value = new Array(output_channels);
+  var max_value = new Array(output_channels);
+
+  for (var channel = 0; channel < output_channels; channel++) {
+    min_value[channel] = Infinity;
+    max_value[channel] = -Infinity;
+  }
+
+  var range_min = options.bits === 8 ? INT8_MIN : INT16_MIN;
+  var range_max = options.bits === 8 ? INT8_MAX : INT16_MAX;
+
+  data_view.setInt32(0, 2, true);
+  data_view.setUint32(4, options.bits === 8, true);
+  data_view.setInt32(8, sample_rate, true);
+  data_view.setInt32(12, scale, true);
+  data_view.setInt32(16, data_length, true);
+  data_view.setInt32(20, output_channels, true);
+
+  for (var i = 0; i < length; i++) {
+    var sample = 0;
+
+    if (output_channels === 1) {
+      for (var ch = 0; ch < channels.length; ++ch) {
+        sample += channels[ch][i];
+      }
+      sample = Math.floor(range_max * sample * amplitude_scale / channels.length);
+
+      if (sample < min_value[0]) {
+        min_value[0] = sample;
+        if (min_value[0] < range_min) {
+          min_value[0] = range_min;
+        }
+      }
+      if (sample > max_value[0]) {
+        max_value[0] = sample;
+        if (max_value[0] > range_max) {
+          max_value[0] = range_max;
+        }
+      }
+    }
+    else {
+      for (var ch2 = 0; ch2 < output_channels; ++ch2) {
+        sample = Math.floor(range_max * channels[ch2][i] * amplitude_scale);
+
+        if (sample < min_value[ch2]) {
+          min_value[ch2] = sample;
+          if (min_value[ch2] < range_min) {
+            min_value[ch2] = range_min;
+          }
+        }
+        if (sample > max_value[ch2]) {
+          max_value[ch2] = sample;
+          if (max_value[ch2] > range_max) {
+            max_value[ch2] = range_max;
+          }
+        }
+      }
+    }
+
+    if (++scale_counter === scale) {
+      for (var ch3 = 0; ch3 < output_channels; ch3++) {
+        if (options.bits === 8) {
+          data_view.setInt8(offset++, min_value[ch3]);
+          data_view.setInt8(offset++, max_value[ch3]);
+        }
+        else {
+          data_view.setInt16(offset, min_value[ch3], true);
+          data_view.setInt16(offset + 2, max_value[ch3], true);
+          offset += 4;
+        }
+        min_value[ch3] = Infinity;
+        max_value[ch3] = -Infinity;
+      }
+      scale_counter = 0;
+    }
+  }
+
+  if (scale_counter > 0) {
+    for (var ch4 = 0; ch4 < output_channels; ch4++) {
+      if (options.bits === 8) {
+        data_view.setInt8(offset++, min_value[ch4]);
+        data_view.setInt8(offset++, max_value[ch4]);
+      }
+      else {
+        data_view.setInt16(offset, min_value[ch4], true);
+        data_view.setInt16(offset + 2, max_value[ch4], true);
+      }
+    }
+  }
+
+  return buffer;
+}
+
+self.onmessage = function(e) {
+  var msg = e.data;
+  try {
+    var result = generateWaveformData({
+      scale: msg.scale,
+      bits: msg.bits,
+      amplitude_scale: msg.amplitude_scale,
+      split_channels: msg.split_channels,
+      length: msg.length,
+      sample_rate: msg.sample_rate,
+      channels: msg.channels
+    });
+    self.postMessage({ id: msg.id, buffer: result }, [result]);
+  } catch (err) {
+    self.postMessage({ id: msg.id, error: err.message || String(err) });
+  }
+};
+`;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Promise-based worker API (runs on the main thread)
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface PeaksWorkerApi {
+  generate(params: {
+    id: string;
+    channels: ArrayBuffer[];
+    length: number;
+    sampleRate: number;
+    scale: number;
+    bits: 8 | 16;
+    splitChannels: boolean;
+  }): Promise<WaveformData>;
+  terminate(): void;
+}
+
+interface PendingEntry {
+  resolve: (value: WaveformData) => void;
+  reject: (reason: unknown) => void;
+}
+
+let idCounter = 0;
+
+export function createPeaksWorker(): PeaksWorkerApi {
+  let worker: Worker;
+  try {
+    const blob = new Blob([workerSource], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    worker = new Worker(url);
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    // Worker creation can fail in CSP-restricted environments that block blob: URLs.
+    // Return a no-op API that rejects all generate calls gracefully.
+    console.warn('[waveform-playlist] Failed to create peaks worker (CSP restriction?):', err);
+    return {
+      generate() {
+        return Promise.reject(new Error('Worker creation failed'));
+      },
+      terminate() {
+        /* no-op */
+      },
+    };
+  }
+
+  const pending = new Map<string, PendingEntry>();
+  let terminated = false;
+
+  worker.onmessage = (e: MessageEvent) => {
+    const msg = e.data;
+    const entry = pending.get(msg.id);
+    if (!entry) return;
+    pending.delete(msg.id);
+
+    if (msg.error) {
+      entry.reject(new Error(msg.error));
+    } else {
+      try {
+        const waveformData = WaveformData.create(msg.buffer);
+        entry.resolve(waveformData);
+      } catch (err) {
+        entry.reject(err);
+      }
+    }
+  };
+
+  worker.onerror = (e: ErrorEvent) => {
+    terminated = true;
+    worker.terminate();
+    for (const [, entry] of pending) {
+      entry.reject(e.error ?? new Error(e.message));
+    }
+    pending.clear();
+  };
+
+  return {
+    generate(params) {
+      if (terminated) return Promise.reject(new Error('Worker terminated'));
+      const messageId = String(++idCounter);
+
+      return new Promise<WaveformData>((resolve, reject) => {
+        pending.set(messageId, { resolve, reject });
+
+        worker.postMessage(
+          {
+            id: messageId,
+            scale: params.scale,
+            bits: params.bits,
+            amplitude_scale: 1.0,
+            split_channels: params.splitChannels,
+            length: params.length,
+            sample_rate: params.sampleRate,
+            channels: params.channels,
+          },
+          params.channels // Transfer ownership
+        );
+      });
+    },
+
+    terminate() {
+      terminated = true;
+      worker.terminate();
+      for (const [, entry] of pending) {
+        entry.reject(new Error('Worker terminated'));
+      }
+      pending.clear();
+    },
+  };
+}

--- a/packages/dawcore/src/workers/peaksWorker.ts
+++ b/packages/dawcore/src/workers/peaksWorker.ts
@@ -142,6 +142,7 @@ function generateWaveformData(options) {
       else {
         data_view.setInt16(offset, min_value[ch4], true);
         data_view.setInt16(offset + 2, max_value[ch4], true);
+        offset += 4;
       }
     }
   }

--- a/packages/dawcore/src/workers/peaksWorker.ts
+++ b/packages/dawcore/src/workers/peaksWorker.ts
@@ -174,7 +174,6 @@ self.onmessage = function(e) {
 
 export interface PeaksWorkerApi {
   generate(params: {
-    id: string;
     channels: ArrayBuffer[];
     length: number;
     sampleRate: number;
@@ -190,8 +189,6 @@ interface PendingEntry {
   reject: (reason: unknown) => void;
 }
 
-let idCounter = 0;
-
 export function createPeaksWorker(): PeaksWorkerApi {
   let worker: Worker;
   try {
@@ -201,11 +198,14 @@ export function createPeaksWorker(): PeaksWorkerApi {
     URL.revokeObjectURL(url);
   } catch (err) {
     // Worker creation can fail in CSP-restricted environments that block blob: URLs.
-    // Return a no-op API that rejects all generate calls gracefully.
-    console.warn('[waveform-playlist] Failed to create peaks worker (CSP restriction?):', err);
+    console.warn('[dawcore] Failed to create peaks worker (CSP restriction?): ' + String(err));
     return {
       generate() {
-        return Promise.reject(new Error('Worker creation failed'));
+        return Promise.reject(
+          new Error(
+            'Peaks worker unavailable (CSP may block blob: URLs). Add blob: to worker-src directive.'
+          )
+        );
       },
       terminate() {
         /* no-op */
@@ -215,11 +215,15 @@ export function createPeaksWorker(): PeaksWorkerApi {
 
   const pending = new Map<string, PendingEntry>();
   let terminated = false;
+  let idCounter = 0;
 
   worker.onmessage = (e: MessageEvent) => {
     const msg = e.data;
     const entry = pending.get(msg.id);
-    if (!entry) return;
+    if (!entry) {
+      console.warn('[dawcore] Received worker message for unknown id: ' + String(msg.id));
+      return;
+    }
     pending.delete(msg.id);
 
     if (msg.error) {
@@ -235,10 +239,12 @@ export function createPeaksWorker(): PeaksWorkerApi {
   };
 
   worker.onerror = (e: ErrorEvent) => {
+    const reason = e.error ?? new Error(e.message);
+    console.warn('[dawcore] Peaks worker crashed: ' + String(reason));
     terminated = true;
     worker.terminate();
     for (const [, entry] of pending) {
-      entry.reject(e.error ?? new Error(e.message));
+      entry.reject(reason);
     }
     pending.clear();
   };

--- a/packages/dawcore/src/workers/waveformDataUtils.ts
+++ b/packages/dawcore/src/workers/waveformDataUtils.ts
@@ -25,7 +25,7 @@ function sliceAndResample(
       const targetStart = Math.floor(offsetSamples / samplesPerPixel);
       const targetEnd = Math.ceil((offsetSamples + durationSamples) / samplesPerPixel);
 
-      const sourceStart = Math.floor(targetStart * ratio);
+      const sourceStart = Math.max(0, Math.floor(targetStart * ratio));
       const sourceEnd = Math.min(waveformData.length, Math.ceil(targetEnd * ratio));
 
       if (sourceStart >= sourceEnd) {
@@ -69,7 +69,11 @@ export function extractPeaks(
 
   if (processedData === null) {
     const bits = waveformData.bits as 8 | 16;
-    return { length: 0, data: [], bits };
+    const numChannels = isMono ? 1 : waveformData.channels;
+    const emptyData: Peaks[] = Array.from({ length: numChannels }, () =>
+      bits === 8 ? new Int8Array(0) : new Int16Array(0)
+    );
+    return { length: 0, data: emptyData, bits };
   }
 
   const numChannels = processedData.channels;

--- a/packages/dawcore/src/workers/waveformDataUtils.ts
+++ b/packages/dawcore/src/workers/waveformDataUtils.ts
@@ -1,0 +1,116 @@
+/**
+ * Utilities for converting WaveformData to PeakData format.
+ * Adapted from @waveform-playlist/browser waveformDataLoader.ts.
+ */
+
+import WaveformData from 'waveform-data';
+import type { PeakData, Peaks } from '@waveform-playlist/core';
+
+/**
+ * Slice and resample WaveformData with aligned source indices.
+ */
+function sliceAndResample(
+  waveformData: WaveformData,
+  samplesPerPixel: number,
+  offsetSamples?: number,
+  durationSamples?: number
+): WaveformData | null {
+  let processedData = waveformData;
+
+  if (offsetSamples !== undefined && durationSamples !== undefined) {
+    if (processedData.scale !== samplesPerPixel) {
+      const sourceScale = waveformData.scale;
+      const ratio = samplesPerPixel / sourceScale;
+
+      const targetStart = Math.floor(offsetSamples / samplesPerPixel);
+      const targetEnd = Math.ceil((offsetSamples + durationSamples) / samplesPerPixel);
+
+      const sourceStart = Math.floor(targetStart * ratio);
+      const sourceEnd = Math.min(waveformData.length, Math.ceil(targetEnd * ratio));
+
+      if (sourceStart >= sourceEnd) {
+        return null;
+      }
+
+      processedData = processedData.slice({
+        startIndex: sourceStart,
+        endIndex: sourceEnd,
+      });
+      processedData = processedData.resample({ scale: samplesPerPixel });
+    } else {
+      const startIndex = Math.floor(offsetSamples / samplesPerPixel);
+      const endIndex = Math.ceil((offsetSamples + durationSamples) / samplesPerPixel);
+      processedData = processedData.slice({ startIndex, endIndex });
+    }
+  } else if (processedData.scale !== samplesPerPixel) {
+    processedData = processedData.resample({ scale: samplesPerPixel });
+  }
+
+  return processedData;
+}
+
+/**
+ * Extract peaks from a WaveformData object, handling all channels, mono merging,
+ * slicing, and resampling.
+ */
+export function extractPeaks(
+  waveformData: WaveformData,
+  samplesPerPixel: number,
+  isMono: boolean,
+  offsetSamples?: number,
+  durationSamples?: number
+): PeakData {
+  const processedData = sliceAndResample(
+    waveformData,
+    samplesPerPixel,
+    offsetSamples,
+    durationSamples
+  );
+
+  if (processedData === null) {
+    const bits = waveformData.bits as 8 | 16;
+    return { length: 0, data: [], bits };
+  }
+
+  const numChannels = processedData.channels;
+  const bits = processedData.bits as 8 | 16;
+
+  const channelPeaks: Peaks[] = [];
+  for (let c = 0; c < numChannels; c++) {
+    const channel = processedData.channel(c);
+    const minArray = channel.min_array();
+    const maxArray = channel.max_array();
+    const len = minArray.length;
+
+    const peaks: Peaks = bits === 8 ? new Int8Array(len * 2) : new Int16Array(len * 2);
+
+    for (let i = 0; i < len; i++) {
+      peaks[i * 2] = minArray[i];
+      peaks[i * 2 + 1] = maxArray[i];
+    }
+    channelPeaks.push(peaks);
+  }
+
+  if (isMono && channelPeaks.length > 1) {
+    const weight = 1 / channelPeaks.length;
+    const numPeaks = channelPeaks[0].length / 2;
+    const monoPeaks: Peaks =
+      bits === 8 ? new Int8Array(numPeaks * 2) : new Int16Array(numPeaks * 2);
+
+    for (let i = 0; i < numPeaks; i++) {
+      let min = 0;
+      let max = 0;
+      for (let c = 0; c < channelPeaks.length; c++) {
+        min += weight * channelPeaks[c][i * 2];
+        max += weight * channelPeaks[c][i * 2 + 1];
+      }
+      monoPeaks[i * 2] = min;
+      monoPeaks[i * 2 + 1] = max;
+    }
+
+    return { length: numPeaks, data: [monoPeaks], bits };
+  }
+
+  const peakLength = channelPeaks.length > 0 ? channelPeaks[0].length / 2 : 0;
+  return { length: peakLength, data: channelPeaks, bits };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/browser:
     dependencies:
@@ -153,7 +153,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/core:
     devDependencies:
@@ -165,13 +165,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/dawcore:
     dependencies:
       lit:
         specifier: ^3.0.0
         version: 3.3.2
+      waveform-data:
+        specifier: ^4.5.2
+        version: 4.5.2
     devDependencies:
       '@waveform-playlist/core':
         specifier: workspace:*
@@ -211,7 +214,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/loaders:
     dependencies:
@@ -230,7 +233,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/media-element-playout:
     dependencies:
@@ -302,7 +305,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/recording:
     dependencies:
@@ -342,7 +345,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/spectrogram:
     dependencies:
@@ -376,7 +379,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/ui-components:
     dependencies:
@@ -474,7 +477,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   packages/worklets:
     devDependencies:
@@ -489,7 +492,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.25)
+        version: 3.2.4(@types/node@20.19.25)(jsdom@28.1.0)
 
   website:
     dependencies:
@@ -7153,23 +7156,6 @@ packages:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-    dev: true
-
-  /@vitest/mocker@3.2.4(vite@6.4.1):
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-      vite: 6.4.1(@types/node@20.19.25)
     dev: true
 
   /@vitest/mocker@3.2.4(vite@7.2.4):
@@ -14157,7 +14143,7 @@ packages:
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1)
+      '@vitest/mocker': 3.2.4(vite@7.2.4)
       '@vitest/spy': 3.2.4
       esbuild: 0.25.12
       prettier: 3.6.2
@@ -15191,7 +15177,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@3.2.4(@types/node@20.19.25):
+  /vitest@3.2.4(@types/node@20.19.25)(happy-dom@17.6.3):
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -15231,73 +15217,6 @@ packages:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.2.4(@types/node@20.19.25)
-      vite-node: 3.2.4(@types/node@20.19.25)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-    dev: true
-
-  /vitest@3.2.4(@types/node@20.19.25)(happy-dom@17.6.3):
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/chai': 5.2.3
-      '@types/node': 20.19.25
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1)
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
       happy-dom: 17.6.3
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -15308,7 +15227,7 @@ packages:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@20.19.25)
+      vite: 7.2.4(@types/node@20.19.25)
       vite-node: 3.2.4(@types/node@20.19.25)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
@@ -15357,7 +15276,7 @@ packages:
       '@types/chai': 5.2.3
       '@types/node': 20.19.25
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1)
+      '@vitest/mocker': 3.2.4(vite@7.2.4)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15376,7 +15295,7 @@ packages:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@20.19.25)
+      vite: 7.2.4(@types/node@20.19.25)
       vite-node: 3.2.4(@types/node@20.19.25)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
@@ -15425,7 +15344,7 @@ packages:
       '@types/chai': 5.2.3
       '@types/node': 20.19.25
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1)
+      '@vitest/mocker': 3.2.4(vite@7.2.4)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15444,7 +15363,7 @@ packages:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@20.19.25)
+      vite: 7.2.4(@types/node@20.19.25)
       vite-node: 3.2.4(@types/node@20.19.25)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- **Per-channel peak generation** — `_generatePeaks()` now produces a separate `Int16Array` per channel instead of aggregating all channels into one waveform
- **Stacked channel rendering** — Each clip renders one `<daw-waveform>` per channel, positioned with `top: chIdx * channelHeight`
- **Dynamic track height** — Track row height scales to `waveHeight * numChannels` based on the clip's actual channel count

Mono files render as before (single channel). Stereo files now display L/R channels separately. The `mono` attribute on `<daw-editor>` forces single-channel rendering regardless of source.

## Test plan

- [x] 82 tests passing, typecheck clean, lint 0 errors
- [ ] Manual: drop a stereo WAV/MP3 file — should show 2 stacked waveforms
- [ ] Manual: drop a mono file — should show 1 waveform (same as before)
- [ ] Manual: set `mono` attribute on editor — stereo files render as single channel
- [ ] Manual: verify playback, seek, selection still work with multi-channel tracks