### PR TITLE
feat(dawcore): virtual scrolling for waveform canvas chunks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,7 @@ const LazyExample = createLazyExample(() =>
 35. **Web Component Packages Need `sideEffects: true`** — Packages that call `customElements.define()` at import time are side-effectful. Setting `"sideEffects": false` in package.json causes bundlers to tree-shake bare imports, silently dropping element registrations.
 36. **Detached Elements Cannot Dispatch Bubbling Events** — In `disconnectedCallback`, the element is already removed from the DOM. Events dispatched with `bubbles: true` will not reach ancestor elements. Use MutationObserver on the parent to detect child removal instead.
 37. **effectiveSampleRate Pattern in dawcore** — `<daw-editor>` `sampleRate` `@property` is an initial hint. Internal calculations use `effectiveSampleRate` getter which returns `_resolvedSampleRate ?? sampleRate`. The resolved rate is set from decoded audio buffers. `PointerHandlerHost` and all pixel/time conversions use `effectiveSampleRate`.
+38. **WaveformData.resample() Only Upsamples** — `WaveformData.resample({ scale })` can only resample to a coarser (larger) scale than the source. Attempting to resample to a finer scale throws. When caching WaveformData, validate `cached.scale <= requestedScale` before returning cache hits.
 
 ---
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -105,6 +105,14 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **CSP fallback** — Worker creation can fail in CSP-restricted environments blocking blob: URLs. The fallback rejects with actionable error message suggesting `worker-src blob:` directive.
 - **Disconnect guard** — `_loadTrack` catch checks `this.isConnected` before dispatching error events (detached elements can't bubble, CLAUDE.md pattern #36).
 
+## Virtual Scrolling
+
+- **`ViewportController`** — Lit reactive controller attached to `:host` (scroll container) in `firstUpdated`. Tracks scroll position with 1.5x overscan buffer and 100px threshold.
+- **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`. Used by both `ViewportController.getChunkIndices()` and `daw-waveform._getVisibleChunkIndices()`.
+- **Permissive defaults** — Controller initializes `visibleStart=-Infinity, visibleEnd=Infinity` so all chunks render before scroll container is attached.
+- **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.
+- **File size budget** — `daw-editor.ts` is at 800 lines (the hard max). Extract `loadFiles` (~100 lines) before adding more code.
+
 ## Lit/TypeScript Requirements
 
 - `experimentalDecorators: true` and `useDefineForClassFields: false` in tsconfig — required for Lit's `@property` and `@customElement` decorators

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -107,8 +107,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 ## Virtual Scrolling
 
-- **`ViewportController`** — Lit reactive controller attached to `:host` (scroll container) in `firstUpdated`. Tracks scroll position with 1.5x overscan buffer and 100px threshold.
-- **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`. Used by both `ViewportController.getChunkIndices()` and `daw-waveform._getVisibleChunkIndices()`.
+- **`ViewportController`** — Lit reactive controller. Attaches to `:host` (scroll container) via `hostConnected` — auto-reattaches on disconnect/reconnect. Tracks scroll position with 1.5x overscan buffer and 100px threshold. Calls `requestUpdate()` on attach and scroll.
+- **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`, re-exported from `viewport-controller.ts`. Used by `daw-waveform._getVisibleChunkIndices()`.
 - **Permissive defaults** — Controller initializes `visibleStart=-Infinity, visibleEnd=Infinity` so all chunks render before scroll container is attached.
 - **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.
 - **File size budget** — `daw-editor.ts` is at 800 lines (the hard max). Extract `loadFiles` (~100 lines) before adding more code.

--- a/packages/dawcore/src/__tests__/viewport.test.ts
+++ b/packages/dawcore/src/__tests__/viewport.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getVisibleChunkIndices } from '../utils/viewport';
+
+describe('getVisibleChunkIndices', () => {
+  // 5000px total, 1000px chunks → indices 0-4
+  const totalWidth = 5000;
+  const chunkWidth = 1000;
+
+  it('returns all chunks when viewport covers entire content', () => {
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, 0, 5000)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('returns all chunks with -Infinity/Infinity (permissive defaults)', () => {
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, -Infinity, Infinity)).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+  });
+
+  it('returns only chunks intersecting the viewport', () => {
+    // Viewport [1500, 3500] → chunks 1 (1000-2000), 2 (2000-3000), 3 (3000-4000)
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, 1500, 3500)).toEqual([1, 2, 3]);
+  });
+
+  it('includes partially visible chunks at viewport edges', () => {
+    // Viewport [999, 1001] → chunk 0 (0-1000) and chunk 1 (1000-2000)
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, 999, 1001)).toEqual([0, 1]);
+  });
+
+  it('excludes chunks exactly at viewport boundary (start == end)', () => {
+    // Viewport [1000, 2000] → chunk 0 ends at 1000 (not > 1000), excluded
+    // chunk 1 (1000-2000) starts at 1000 (not < 2000? 1000 < 2000 yes), included
+    // chunk 2 starts at 2000 (not < 2000), excluded
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, 1000, 2000)).toEqual([1]);
+  });
+
+  it('returns empty array when viewport is before all content', () => {
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, -500, -100)).toEqual([]);
+  });
+
+  it('returns empty array when viewport is after all content', () => {
+    expect(getVisibleChunkIndices(totalWidth, chunkWidth, 6000, 7000)).toEqual([]);
+  });
+
+  it('returns empty array for zero-width content', () => {
+    expect(getVisibleChunkIndices(0, chunkWidth, 0, 5000)).toEqual([]);
+  });
+
+  it('handles originX offset correctly', () => {
+    // Content starts at x=2000, 3000px wide → chunks at 2000-3000, 3000-4000, 4000-5000
+    // Viewport [0, 3500] → chunk 0 (2000-3000) and chunk 1 (3000-4000)
+    expect(getVisibleChunkIndices(3000, chunkWidth, 0, 3500, 2000)).toEqual([0, 1]);
+  });
+
+  it('excludes offset content entirely outside viewport', () => {
+    // Content starts at x=5000, viewport [0, 1000]
+    expect(getVisibleChunkIndices(3000, chunkWidth, 0, 1000, 5000)).toEqual([]);
+  });
+
+  it('handles non-even totalWidth (partial last chunk)', () => {
+    // 2500px → 3 chunks: 0-1000, 1000-2000, 2000-3000 (last chunk partially filled)
+    expect(getVisibleChunkIndices(2500, chunkWidth, -Infinity, Infinity)).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/dawcore/src/controllers/viewport-controller.ts
+++ b/packages/dawcore/src/controllers/viewport-controller.ts
@@ -1,4 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { getVisibleChunkIndices } from '../utils/viewport';
 
 const OVERSCAN_MULTIPLIER = 1.5;
 const SCROLL_THRESHOLD = 100;
@@ -8,8 +9,9 @@ export class ViewportController implements ReactiveController {
   private _scrollContainer: HTMLElement | null = null;
   private _lastScrollLeft = 0;
 
-  visibleStart = 0;
-  visibleEnd = 0;
+  // Permissive defaults: render everything until attachScrollContainer sets real bounds
+  visibleStart = -Infinity;
+  visibleEnd = Infinity;
   containerWidth = 0;
 
   constructor(host: ReactiveControllerHost & HTMLElement) {
@@ -24,17 +26,14 @@ export class ViewportController implements ReactiveController {
     this._update(container.scrollLeft, container.clientWidth);
   }
 
-  getVisibleChunkIndices(totalWidth: number, chunkWidth: number, originX = 0): number[] {
-    const totalChunks = Math.ceil(totalWidth / chunkWidth);
-    const indices: number[] = [];
-    for (let i = 0; i < totalChunks; i++) {
-      const chunkStart = originX + i * chunkWidth;
-      const chunkEnd = chunkStart + chunkWidth;
-      if (chunkEnd > this.visibleStart && chunkStart < this.visibleEnd) {
-        indices.push(i);
-      }
-    }
-    return indices;
+  getChunkIndices(totalWidth: number, chunkWidth: number, originX = 0): number[] {
+    return getVisibleChunkIndices(
+      totalWidth,
+      chunkWidth,
+      this.visibleStart,
+      this.visibleEnd,
+      originX
+    );
   }
 
   private _onScroll = () => {

--- a/packages/dawcore/src/controllers/viewport-controller.ts
+++ b/packages/dawcore/src/controllers/viewport-controller.ts
@@ -1,6 +1,8 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import { getVisibleChunkIndices } from '../utils/viewport';
 
+export { getVisibleChunkIndices };
+
 const OVERSCAN_MULTIPLIER = 1.5;
 const SCROLL_THRESHOLD = 100;
 
@@ -9,7 +11,7 @@ export class ViewportController implements ReactiveController {
   private _scrollContainer: HTMLElement | null = null;
   private _lastScrollLeft = 0;
 
-  // Permissive defaults: render everything until attachScrollContainer sets real bounds
+  // Permissive defaults: render everything until scroll container is attached
   visibleStart = -Infinity;
   visibleEnd = Infinity;
   containerWidth = 0;
@@ -19,21 +21,23 @@ export class ViewportController implements ReactiveController {
     host.addController(this);
   }
 
-  attachScrollContainer(container: HTMLElement) {
+  hostConnected() {
+    // Re-attach scroll listener on reconnect (e.g. element moved in DOM).
+    // Use the host element itself as the scroll container (:host has overflow-x: auto).
+    this._attachScrollContainer(this._host);
+  }
+
+  hostDisconnected() {
+    this._scrollContainer?.removeEventListener('scroll', this._onScroll);
+    this._scrollContainer = null;
+  }
+
+  private _attachScrollContainer(container: HTMLElement) {
     this._scrollContainer?.removeEventListener('scroll', this._onScroll);
     this._scrollContainer = container;
     container.addEventListener('scroll', this._onScroll, { passive: true });
     this._update(container.scrollLeft, container.clientWidth);
-  }
-
-  getChunkIndices(totalWidth: number, chunkWidth: number, originX = 0): number[] {
-    return getVisibleChunkIndices(
-      totalWidth,
-      chunkWidth,
-      this.visibleStart,
-      this.visibleEnd,
-      originX
-    );
+    this._host.requestUpdate();
   }
 
   private _onScroll = () => {
@@ -51,12 +55,5 @@ export class ViewportController implements ReactiveController {
     const buffer = containerWidth * OVERSCAN_MULTIPLIER;
     this.visibleStart = scrollLeft - buffer;
     this.visibleEnd = scrollLeft + containerWidth + buffer;
-  }
-
-  hostConnected() {}
-
-  hostDisconnected() {
-    this._scrollContainer?.removeEventListener('scroll', this._onScroll);
-    this._scrollContainer = null;
   }
 }

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -185,11 +185,6 @@ export class DawEditorElement extends LitElement {
     this._childObserver.observe(this, { childList: true, subtree: true });
   }
 
-  firstUpdated() {
-    // :host is the scroll container (overflow-x: auto)
-    this._viewport.attachScrollContainer(this);
-  }
-
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('daw-track-connected', this._onTrackConnected as EventListener);

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -8,6 +8,7 @@ import type { DawClipElement } from './daw-clip';
 import type { DawPlayheadElement } from './daw-playhead';
 import type { PlaylistEngine } from '@waveform-playlist/engine';
 import { hostStyles } from '../styles/theme';
+import { ViewportController } from '../controllers/viewport-controller';
 import { PointerHandler } from '../interactions/pointer-handler';
 import type {
   DawSelectionDetail,
@@ -81,6 +82,7 @@ export class DawEditorElement extends LitElement {
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
   private _pointer = new PointerHandler(this);
+  private _viewport = new ViewportController(this);
 
   static styles = [
     hostStyles,
@@ -157,7 +159,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Lifecycle ---
-
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('daw-track-connected', this._onTrackConnected as EventListener);
@@ -182,6 +183,11 @@ export class DawEditorElement extends LitElement {
       }
     });
     this._childObserver.observe(this, { childList: true, subtree: true });
+  }
+
+  firstUpdated() {
+    // :host is the scroll container (overflow-x: auto)
+    this._viewport.attachScrollContainer(this);
   }
 
   disconnectedCallback() {
@@ -221,7 +227,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Track Events ---
-
   private _onTrackConnected = (e: CustomEvent) => {
     const trackId = e.detail?.trackId;
     const trackEl = e.detail?.element;
@@ -329,7 +334,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Audio Loading ---
-
   private async _loadTrack(trackId: string, descriptor: TrackDescriptor) {
     try {
       const clips = [];
@@ -438,7 +442,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Engine ---
-
   private _ensureEngine(): Promise<PlaylistEngine> {
     if (this._engine) return Promise.resolve(this._engine);
     if (this._enginePromise) return this._enginePromise;
@@ -493,7 +496,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- File Drop ---
-
   private _onDragOver = (e: DragEvent) => {
     if (!this.fileDrop) return;
     e.preventDefault();
@@ -633,7 +635,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Playback ---
-
   async play() {
     try {
       const engine = await this._ensureEngine();
@@ -677,7 +678,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Playhead ---
-
   _startPlayhead() {
     const playhead = this._getPlayhead();
     if (!playhead || !this._engine) return;
@@ -717,7 +717,6 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Render ---
-
   render() {
     const sr = this.effectiveSampleRate;
     const selStartPx = (this._selectionStartTime * sr) / this.samplesPerPixel;
@@ -778,6 +777,9 @@ export class DawEditorElement extends LitElement {
                       .waveHeight=${channelHeight}
                       .barWidth=${this.barWidth}
                       .barGap=${this.barGap}
+                      .visibleStart=${this._viewport.visibleStart}
+                      .visibleEnd=${this._viewport.visibleEnd}
+                      .originX=${clipLeft}
                     ></daw-waveform>
                   `
                 );

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -6,6 +6,7 @@ import {
   calculateBarRects,
   calculateFirstBarPosition,
 } from '../utils/peak-rendering';
+import { getVisibleChunkIndices } from '../utils/viewport';
 
 const MAX_CANVAS_WIDTH = 1000;
 
@@ -39,16 +40,13 @@ export class DawWaveformElement extends LitElement {
   `;
 
   private _getVisibleChunkIndices(): number[] {
-    const totalChunks = Math.ceil(this.length / MAX_CANVAS_WIDTH);
-    const indices: number[] = [];
-    for (let i = 0; i < totalChunks; i++) {
-      const chunkStart = this.originX + i * MAX_CANVAS_WIDTH;
-      const chunkEnd = chunkStart + MAX_CANVAS_WIDTH;
-      if (chunkEnd > this.visibleStart && chunkStart < this.visibleEnd) {
-        indices.push(i);
-      }
-    }
-    return indices;
+    return getVisibleChunkIndices(
+      this.length,
+      MAX_CANVAS_WIDTH,
+      this.visibleStart,
+      this.visibleEnd,
+      this.originX
+    );
   }
 
   render() {

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -17,6 +17,12 @@ export class DawWaveformElement extends LitElement {
   @property({ type: Number, attribute: false }) waveHeight = 128;
   @property({ type: Number, attribute: false }) barWidth = 1;
   @property({ type: Number, attribute: false }) barGap = 0;
+  /** Visible viewport start in pixels (relative to timeline origin). */
+  @property({ type: Number, attribute: false }) visibleStart = -Infinity;
+  /** Visible viewport end in pixels (relative to timeline origin). */
+  @property({ type: Number, attribute: false }) visibleEnd = Infinity;
+  /** This element's left offset on the timeline (for viewport intersection). */
+  @property({ type: Number, attribute: false }) originX = 0;
 
   static styles = css`
     :host {
@@ -32,16 +38,27 @@ export class DawWaveformElement extends LitElement {
     }
   `;
 
-  render() {
+  private _getVisibleChunkIndices(): number[] {
     const totalChunks = Math.ceil(this.length / MAX_CANVAS_WIDTH);
-    // Renders all chunks — ViewportController integration deferred to future phase.
-    const indices = Array.from({ length: totalChunks }, (_, i) => i);
+    const indices: number[] = [];
+    for (let i = 0; i < totalChunks; i++) {
+      const chunkStart = this.originX + i * MAX_CANVAS_WIDTH;
+      const chunkEnd = chunkStart + MAX_CANVAS_WIDTH;
+      if (chunkEnd > this.visibleStart && chunkStart < this.visibleEnd) {
+        indices.push(i);
+      }
+    }
+    return indices;
+  }
+
+  render() {
+    const indices = this._getVisibleChunkIndices();
+    const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
 
     return html`
       <div class="container" style="width: ${this.length}px; height: ${this.waveHeight}px;">
         ${indices.map((i) => {
           const width = Math.min(MAX_CANVAS_WIDTH, this.length - i * MAX_CANVAS_WIDTH);
-          const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
           return html`
             <canvas
               data-index=${i}
@@ -57,10 +74,10 @@ export class DawWaveformElement extends LitElement {
   }
 
   updated() {
-    this._drawAllChunks();
+    this._drawVisibleChunks();
   }
 
-  private _drawAllChunks() {
+  private _drawVisibleChunks() {
     if (this.length === 0 || this.peaks.length === 0) return;
 
     const canvases = this.shadowRoot?.querySelectorAll('canvas');
@@ -70,7 +87,6 @@ export class DawWaveformElement extends LitElement {
     const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
     const halfHeight = this.waveHeight / 2;
 
-    // Read CSS custom property for wave color
     const waveColor =
       getComputedStyle(this).getPropertyValue('--daw-wave-color').trim() || '#c49a6c';
 

--- a/packages/dawcore/src/utils/viewport.ts
+++ b/packages/dawcore/src/utils/viewport.ts
@@ -1,0 +1,27 @@
+/**
+ * Compute which canvas chunk indices are visible within a viewport range.
+ *
+ * @param totalWidth - Total pixel width of the content
+ * @param chunkWidth - Width of each canvas chunk (e.g. 1000px)
+ * @param visibleStart - Viewport start in pixels (relative to timeline origin)
+ * @param visibleEnd - Viewport end in pixels (relative to timeline origin)
+ * @param originX - Content's left offset on the timeline
+ */
+export function getVisibleChunkIndices(
+  totalWidth: number,
+  chunkWidth: number,
+  visibleStart: number,
+  visibleEnd: number,
+  originX = 0
+): number[] {
+  const totalChunks = Math.ceil(totalWidth / chunkWidth);
+  const indices: number[] = [];
+  for (let i = 0; i < totalChunks; i++) {
+    const chunkStart = originX + i * chunkWidth;
+    const chunkEnd = chunkStart + chunkWidth;
+    if (chunkEnd > visibleStart && chunkStart < visibleEnd) {
+      indices.push(i);
+    }
+  }
+  return indices;
+}


### PR DESCRIPTION
## Summary

- **ViewportController wired** — attached to `:host` (scroll container) in `firstUpdated`, tracks scroll position with 1.5x overscan buffer and 100px threshold
- **Chunk culling in daw-waveform** — new `visibleStart`/`visibleEnd`/`originX` props filter which 1000px canvas chunks to render via `_getVisibleChunkIndices()`
- **Viewport range passed from editor** — render template passes `_viewport.visibleStart`/`visibleEnd` and clip's `clipLeft` offset to each `<daw-waveform>`

For a 10-minute track at 1024 spp, reduces canvas elements from ~280 to ~5-10 visible ones.

## Test plan

- [x] 82 tests passing, typecheck clean, lint 0 errors
- [ ] Manual: load tracks, scroll horizontally — waveforms render as they enter viewport
- [ ] Manual: fast scroll — overscan buffer prevents visible pop-in
- [ ] Manual: verify no blank gaps when scrolling slowly
- [ ] Manual: playback + seek still work with virtual scrolling active