### PR TITLE
feat(dawcore): track controls — volume, pan, mute, solo, remove

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,7 @@ const LazyExample = createLazyExample(() =>
 36. **Detached Elements Cannot Dispatch Bubbling Events** — In `disconnectedCallback`, the element is already removed from the DOM. Events dispatched with `bubbles: true` will not reach ancestor elements. Use MutationObserver on the parent to detect child removal instead.
 37. **effectiveSampleRate Pattern in dawcore** — `<daw-editor>` `sampleRate` `@property` is an initial hint. Internal calculations use `effectiveSampleRate` getter which returns `_resolvedSampleRate ?? sampleRate`. The resolved rate is set from decoded audio buffers. `PointerHandlerHost` and all pixel/time conversions use `effectiveSampleRate`.
 38. **WaveformData.resample() Only Upsamples** — `WaveformData.resample({ scale })` can only resample to a coarser (larger) scale than the source. Attempting to resample to a finer scale throws. When caching WaveformData, validate `cached.scale <= requestedScale` before returning cache hits.
+39. **Track ID Alignment in dawcore** — `createTrack()` from core generates its own `id` via `generateId()`. The dawcore editor uses a different ID (`<daw-track>.trackId` or `crypto.randomUUID()` for drops) as its map key. Must set `track.id = trackId` after `createTrack()` so engine methods (`setTrackSolo`, `setTrackMute`, etc.) can find the track by ID.
 
 ---
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -10,6 +10,11 @@
 
 **Dev page:** `pnpm dev:page` starts Vite at `http://localhost:5173/dev/index.html`. Uses `website/static/` as publicDir for audio files.
 
+## Dev Page Dependencies
+
+- **`pnpm dev:page` resolves peer packages from `dist/`** — No Vite source aliases. After changing `@waveform-playlist/engine` or `@waveform-playlist/playout` source, run `pnpm build` in those packages before testing on the dev page.
+- **Incremental track removal** — `engine.removeTrack(trackId)` uses `adapter.removeTrack()` when available (disposes single track, preserves playback). Falls back to `adapter.setTracks()` (full rebuild, stops Transport).
+
 ## Element Types
 
 **Data elements (light DOM):**

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -53,7 +53,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 ## Reactive Controllers
 
 - `AnimationController` — Start/stop RAF loops, auto-cleanup on `hostDisconnected`. Used by `<daw-playhead>`.
-- `ViewportController` — (Scaffolded, not yet wired) Scroll-aware visible range with overscan buffer (1.5x). Will be integrated when `<daw-editor>` supports virtual scrolling.
+- `ViewportController` — Scroll-aware visible range with overscan buffer (1.5x). Attached to `.scroll-area` via `scrollSelector`. See Virtual Scrolling section.
 - `EngineController` — (Scaffolded, not yet wired) DOM traversal to find closest `<daw-editor>`. Will be used by sub-elements that need engine access.
 
 ## Ported Utilities
@@ -107,7 +107,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 ## Virtual Scrolling
 
-- **`ViewportController`** — Lit reactive controller. Attaches to `:host` (scroll container) via `hostConnected` — auto-reattaches on disconnect/reconnect. Tracks scroll position with 1.5x overscan buffer and 100px threshold. Calls `requestUpdate()` on attach and scroll.
+- **`ViewportController`** — Lit reactive controller. Attaches to `.scroll-area` (via `scrollSelector`) in `hostConnected` — auto-reattaches on disconnect/reconnect. Tracks scroll position with 1.5x overscan buffer and 100px threshold. Calls `requestUpdate()` on attach and scroll.
 - **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`, re-exported from `viewport-controller.ts`. Used by `daw-waveform._getVisibleChunkIndices()`.
 - **Permissive defaults** — Controller initializes `visibleStart=-Infinity, visibleEnd=Infinity` so all chunks render before scroll container is attached.
 - **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -113,6 +113,24 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.
 - **File size budget** — `daw-editor.ts` is at 800 lines (the hard max). Extract `loadFiles` (~100 lines) before adding more code.
 
+## Track Controls
+
+- **`<daw-track-controls>`** — Shadow DOM element. Receives track state as props from editor, dispatches `daw-track-control` and `daw-track-remove` events.
+- **Controls outside scroll container** — Flex layout: fixed `.controls-column` (180px, `--daw-controls-width`) + `.scroll-area` (overflow-x: auto). Controls stay fixed while waveforms scroll.
+- **Direct engine forwarding** — `daw-track-control` handler updates `_tracks` descriptor AND forwards to engine directly. Does not go through `<daw-track>` DOM element roundtrip (file-dropped tracks have no DOM element).
+- **Track ID alignment** — `createTrack()` generates its own `id`. Must set `track.id = trackId` after creation so `engine.setTrackSolo/Mute/Volume/Pan(trackId, ...)` can find the track. Applied in both `_loadTrack` and `file-loader.ts`.
+
+## File Loader Extraction
+
+- **`interactions/file-loader.ts`** — `loadFiles()` extracted via `FileLoaderHost` interface to keep editor under 800 lines.
+- **Non-private fields** — Fields accessed by the loader (`_tracks`, `_engineTracks`, `_peaksData`, `_clipBuffers`, `_audioCache`, `_peakPipeline`, `_resolvedSampleRate`, `_fetchAndDecode`, `_recomputeDuration`, `_ensureEngine`) are non-private (no `private` keyword, `_` prefix convention only).
+
+## Empty State
+
+- Hide playhead, selection, and ruler when `orderedTracks.length === 0`
+- Timeline width: `100%` when empty (not hardcoded pixels) for full-width dropzone
+- `.scroll-area` has `min-height: var(--daw-min-height, 200px)` for visible empty dropzone
+
 ## Lit/TypeScript Requirements
 
 - `experimentalDecorators: true` and `useDefineForClassFields: false` in tsconfig — required for Lit's `@property` and `@customElement` decorators

--- a/packages/dawcore/src/controllers/viewport-controller.ts
+++ b/packages/dawcore/src/controllers/viewport-controller.ts
@@ -21,10 +21,18 @@ export class ViewportController implements ReactiveController {
     host.addController(this);
   }
 
+  /** CSS selector for the scroll container inside the host's Shadow DOM. */
+  scrollSelector = '';
+
   hostConnected() {
-    // Re-attach scroll listener on reconnect (e.g. element moved in DOM).
-    // Use the host element itself as the scroll container (:host has overflow-x: auto).
-    this._attachScrollContainer(this._host);
+    // Defer to allow Shadow DOM to render before querying
+    requestAnimationFrame(() => {
+      if (!this._host.isConnected) return;
+      const container = this.scrollSelector
+        ? (this._host.shadowRoot?.querySelector(this.scrollSelector) as HTMLElement)
+        : this._host;
+      if (container) this._attachScrollContainer(container);
+    });
   }
 
   hostDisconnected() {

--- a/packages/dawcore/src/controllers/viewport-controller.ts
+++ b/packages/dawcore/src/controllers/viewport-controller.ts
@@ -31,7 +31,15 @@ export class ViewportController implements ReactiveController {
       const container = this.scrollSelector
         ? (this._host.shadowRoot?.querySelector(this.scrollSelector) as HTMLElement)
         : this._host;
-      if (container) this._attachScrollContainer(container);
+      if (container) {
+        this._attachScrollContainer(container);
+      } else if (this.scrollSelector) {
+        console.warn(
+          '[dawcore] ViewportController: scroll container not found for "' +
+            this.scrollSelector +
+            '"'
+        );
+      }
     });
   }
 

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -274,16 +274,14 @@ export class DawEditorElement extends LitElement {
     this._engineTracks = nextEngine;
     this._recomputeDuration();
     if (this._engine) {
-      const wasPlaying = this._isPlaying;
-      const currentTime = wasPlaying ? this._engine.getCurrentTime() : this._currentTime;
-      this._engine.setTracks([...nextEngine.values()]);
-      // Resume playback if it was playing and tracks remain
-      if (wasPlaying && nextEngine.size > 0) {
-        this._engine.play(currentTime);
-        this._startPlayhead();
+      // setTracks rebuilds the playout (stops Transport). Capture position first.
+      if (this._isPlaying) {
+        this._currentTime = this._engine.getCurrentTime();
       }
+      this._engine.setTracks([...nextEngine.values()]);
+      // Stop playback — playout was rebuilt (standard DAW behavior)
+      this._stopPlayhead();
     }
-    // Reset playhead when all tracks removed
     if (nextEngine.size === 0) {
       this._currentTime = 0;
       this._stopPlayhead();

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -323,11 +323,9 @@ export class DawEditorElement extends LitElement {
       }
     }
 
-    // Also sync the <daw-track> DOM element if it exists
-    const trackEl = this._trackElements.get(trackId);
-    if (trackEl && prop in trackEl) {
-      (trackEl as unknown as Record<string, unknown>)[prop] = value;
-    }
+    // Note: we don't sync back to the <daw-track> DOM element to avoid
+    // a redundant daw-track-update → _onTrackUpdate loop. The _tracks
+    // descriptor map is the source of truth for control values.
   };
 
   private _onTrackRemoveRequest = (e: CustomEvent) => {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -274,13 +274,8 @@ export class DawEditorElement extends LitElement {
     this._engineTracks = nextEngine;
     this._recomputeDuration();
     if (this._engine) {
-      // setTracks rebuilds the playout (stops Transport). Capture position first.
-      if (this._isPlaying) {
-        this._currentTime = this._engine.getCurrentTime();
-      }
-      this._engine.setTracks([...nextEngine.values()]);
-      // Stop playback — playout was rebuilt (standard DAW behavior)
-      this._stopPlayhead();
+      // Incremental removal preserves playback (no playout rebuild)
+      this._engine.removeTrack(trackId);
     }
     if (nextEngine.size === 0) {
       this._currentTime = 0;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -274,7 +274,14 @@ export class DawEditorElement extends LitElement {
     this._engineTracks = nextEngine;
     this._recomputeDuration();
     if (this._engine) {
+      const wasPlaying = this._isPlaying;
+      const currentTime = wasPlaying ? this._engine.getCurrentTime() : this._currentTime;
       this._engine.setTracks([...nextEngine.values()]);
+      // Resume playback if it was playing and tracks remain
+      if (wasPlaying && nextEngine.size > 0) {
+        this._engine.play(currentTime);
+        this._startPlayhead();
+      }
     }
     // Reset playhead when all tracks removed
     if (nextEngine.size === 0) {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -106,6 +106,7 @@ export class DawEditorElement extends LitElement {
         flex: 1;
         overflow-x: auto;
         overflow-y: hidden;
+        min-height: var(--daw-min-height, 200px);
       }
       .timeline {
         position: relative;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -7,6 +7,7 @@ import type { DawTrackElement } from './daw-track';
 import type { DawClipElement } from './daw-clip';
 import type { DawPlayheadElement } from './daw-playhead';
 import type { PlaylistEngine } from '@waveform-playlist/engine';
+import '../elements/daw-track-controls';
 import { hostStyles } from '../styles/theme';
 import { ViewportController } from '../controllers/viewport-controller';
 import { PointerHandler } from '../interactions/pointer-handler';
@@ -14,10 +15,10 @@ import type {
   DawSelectionDetail,
   DawTrackIdDetail,
   DawTrackErrorDetail,
-  DawFilesLoadErrorDetail,
   DawErrorDetail,
   LoadFilesResult,
 } from '../events';
+import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
 
 interface TrackDescriptor {
   name: string;
@@ -57,11 +58,11 @@ export class DawEditorElement extends LitElement {
    * Resolved sample rate from decoded audio. Falls back to the `sampleRate`
    * property until the first audio buffer is decoded.
    */
-  private _resolvedSampleRate: number | null = null;
+  _resolvedSampleRate: number | null = null;
 
-  @state() private _tracks: Map<string, TrackDescriptor> = new Map();
-  @state() private _engineTracks: Map<string, ClipTrack> = new Map();
-  @state() private _peaksData: Map<string, PeakData> = new Map();
+  @state() _tracks: Map<string, TrackDescriptor> = new Map();
+  @state() _engineTracks: Map<string, ClipTrack> = new Map();
+  @state() _peaksData: Map<string, PeakData> = new Map();
   @state() _isPlaying = false;
   @state() private _duration = 0;
   @state() _selectedTrackId: string | null = null;
@@ -76,21 +77,33 @@ export class DawEditorElement extends LitElement {
   _engine: PlaylistEngine | null = null;
   private _enginePromise: Promise<PlaylistEngine> | null = null;
   private _audioInitialized = false;
-  private _audioCache = new Map<string, Promise<AudioBuffer>>();
-  private _clipBuffers = new Map<string, AudioBuffer>();
-  private _peakPipeline = new PeakPipeline();
+  _audioCache = new Map<string, Promise<AudioBuffer>>();
+  _clipBuffers = new Map<string, AudioBuffer>();
+  _peakPipeline = new PeakPipeline();
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
   private _pointer = new PointerHandler(this);
-  private _viewport = new ViewportController(this);
+  private _viewport = (() => {
+    const v = new ViewportController(this);
+    v.scrollSelector = '.scroll-area';
+    return v;
+  })();
 
   static styles = [
     hostStyles,
     css`
       :host {
-        display: block;
+        display: flex;
         position: relative;
         background: var(--daw-background, #1a1a2e);
+        overflow: hidden;
+      }
+      .controls-column {
+        flex-shrink: 0;
+        width: var(--daw-controls-width, 180px);
+      }
+      .scroll-area {
+        flex: 1;
         overflow-x: auto;
         overflow-y: hidden;
       }
@@ -163,6 +176,8 @@ export class DawEditorElement extends LitElement {
     super.connectedCallback();
     this.addEventListener('daw-track-connected', this._onTrackConnected as EventListener);
     this.addEventListener('daw-track-update', this._onTrackUpdate as EventListener);
+    this.addEventListener('daw-track-control', this._onTrackControl as EventListener);
+    this.addEventListener('daw-track-remove', this._onTrackRemoveRequest as EventListener);
 
     // Detect track removal via MutationObserver (detached elements can't bubble events).
     this._childObserver = new MutationObserver((mutations) => {
@@ -189,6 +204,8 @@ export class DawEditorElement extends LitElement {
     super.disconnectedCallback();
     this.removeEventListener('daw-track-connected', this._onTrackConnected as EventListener);
     this.removeEventListener('daw-track-update', this._onTrackUpdate as EventListener);
+    this.removeEventListener('daw-track-control', this._onTrackControl as EventListener);
+    this.removeEventListener('daw-track-remove', this._onTrackRemoveRequest as EventListener);
     this._childObserver?.disconnect();
     this._childObserver = null;
     this._trackElements.clear();
@@ -285,6 +302,41 @@ export class DawEditorElement extends LitElement {
     }
   };
 
+  private _onTrackControl = (e: CustomEvent) => {
+    const { trackId, prop, value } = e.detail ?? {};
+    if (!trackId || !prop) return;
+
+    // Update descriptor directly (works for both DOM and file-dropped tracks)
+    const oldDescriptor = this._tracks.get(trackId);
+    if (oldDescriptor && prop in oldDescriptor) {
+      const descriptor = { ...oldDescriptor, [prop]: value };
+      this._tracks = new Map(this._tracks).set(trackId, descriptor);
+
+      // Forward to engine
+      if (this._engine) {
+        if (prop === 'volume') this._engine.setTrackVolume(trackId, value as number);
+        if (prop === 'pan') this._engine.setTrackPan(trackId, value as number);
+        if (prop === 'muted') this._engine.setTrackMute(trackId, value as boolean);
+        if (prop === 'soloed') this._engine.setTrackSolo(trackId, value as boolean);
+      }
+    }
+
+    // Also sync the <daw-track> DOM element if it exists
+    const trackEl = this._trackElements.get(trackId);
+    if (trackEl && prop in trackEl) {
+      (trackEl as unknown as Record<string, unknown>)[prop] = value;
+    }
+  };
+
+  private _onTrackRemoveRequest = (e: CustomEvent) => {
+    const { trackId } = e.detail ?? {};
+    if (!trackId) return;
+    const trackEl = this._trackElements.get(trackId);
+    if (trackEl) {
+      trackEl.remove();
+    }
+  };
+
   private _readTrackDescriptor(trackEl: DawTrackElement): TrackDescriptor {
     const clipEls = trackEl.querySelectorAll('daw-clip') as NodeListOf<DawClipElement>;
     const clips: ClipDescriptor[] = [];
@@ -369,6 +421,8 @@ export class DawEditorElement extends LitElement {
         muted: descriptor.muted,
         soloed: descriptor.soloed,
       });
+      // Align track.id with the editor's trackId so engine.setTrackSolo/Mute/etc. find it
+      track.id = trackId;
 
       this._engineTracks = new Map(this._engineTracks).set(trackId, track);
       this._recomputeDuration();
@@ -397,7 +451,7 @@ export class DawEditorElement extends LitElement {
     }
   }
 
-  private async _fetchAndDecode(src: string): Promise<AudioBuffer> {
+  async _fetchAndDecode(src: string): Promise<AudioBuffer> {
     if (this._audioCache.has(src)) {
       return this._audioCache.get(src)!;
     }
@@ -425,7 +479,7 @@ export class DawEditorElement extends LitElement {
     }
   }
 
-  private _recomputeDuration() {
+  _recomputeDuration() {
     let maxSample = 0;
     for (const track of this._engineTracks.values()) {
       for (const clip of track.clips) {
@@ -437,7 +491,7 @@ export class DawEditorElement extends LitElement {
   }
 
   // --- Engine ---
-  private _ensureEngine(): Promise<PlaylistEngine> {
+  _ensureEngine(): Promise<PlaylistEngine> {
     if (this._engine) return Promise.resolve(this._engine);
     if (this._enginePromise) return this._enginePromise;
     this._enginePromise = this._buildEngine().catch((err) => {
@@ -524,109 +578,7 @@ export class DawEditorElement extends LitElement {
   };
 
   async loadFiles(files: FileList | File[]): Promise<LoadFilesResult> {
-    if (!files) {
-      console.warn('[dawcore] loadFiles called with null/undefined');
-      return { loaded: [], failed: [] };
-    }
-
-    const fileArray = Array.from(files);
-    const loaded: string[] = [];
-    const failed: Array<{ file: File; error: unknown }> = [];
-
-    for (const file of fileArray) {
-      // Accept files with empty type (browser may not report MIME for .opus etc.)
-      if (file.type && !file.type.startsWith('audio/')) {
-        const skipped = new Error('Non-audio MIME type: ' + file.type);
-        failed.push({ file, error: skipped });
-        console.warn('[dawcore] Skipping non-audio file: ' + file.name + ' (' + file.type + ')');
-        continue;
-      }
-
-      const blobUrl = URL.createObjectURL(file);
-      try {
-        const audioBuffer = await this._fetchAndDecode(blobUrl);
-        URL.revokeObjectURL(blobUrl);
-        // Blob URLs are unique per call — evict from cache since they can't be reused
-        this._audioCache.delete(blobUrl);
-
-        this._resolvedSampleRate = audioBuffer.sampleRate;
-
-        const name = file.name.replace(/\.\w+$/, '');
-        const clip = createClipFromSeconds({
-          audioBuffer,
-          startTime: 0,
-          duration: audioBuffer.duration,
-          offset: 0,
-          gain: 1,
-          name,
-          sampleRate: audioBuffer.sampleRate,
-          sourceDuration: audioBuffer.duration,
-        });
-
-        this._clipBuffers.set(clip.id, audioBuffer);
-        const peakData = await this._peakPipeline.generatePeaks(
-          audioBuffer,
-          this.samplesPerPixel,
-          this.mono
-        );
-        this._peaksData = new Map(this._peaksData).set(clip.id, peakData);
-
-        const trackId = crypto.randomUUID();
-        const track = createTrack({ name, clips: [clip] });
-
-        // Add to both maps so editor.tracks includes dropped files
-        this._tracks = new Map(this._tracks).set(trackId, {
-          name,
-          src: '',
-          volume: 1,
-          pan: 0,
-          muted: false,
-          soloed: false,
-          clips: [
-            {
-              src: '',
-              start: 0,
-              duration: audioBuffer.duration,
-              offset: 0,
-              gain: 1,
-              name,
-              fadeIn: 0,
-              fadeOut: 0,
-              fadeType: 'linear',
-            },
-          ],
-        });
-        this._engineTracks = new Map(this._engineTracks).set(trackId, track);
-        this._recomputeDuration();
-
-        const engine = await this._ensureEngine();
-        engine.setTracks([...this._engineTracks.values()]);
-
-        loaded.push(trackId);
-        this.dispatchEvent(
-          new CustomEvent<DawTrackIdDetail>('daw-track-ready', {
-            bubbles: true,
-            composed: true,
-            detail: { trackId },
-          })
-        );
-      } catch (err) {
-        URL.revokeObjectURL(blobUrl);
-        console.warn('[dawcore] Failed to load file: ' + file.name + ' — ' + String(err));
-        failed.push({ file, error: err });
-        if (this.isConnected) {
-          this.dispatchEvent(
-            new CustomEvent<DawFilesLoadErrorDetail>('daw-files-load-error', {
-              bubbles: true,
-              composed: true,
-              detail: { file, error: err },
-            })
-          );
-        }
-      }
-    }
-
-    return { loaded, failed };
+    return loadFilesImpl(this, files);
   }
 
   // --- Playback ---
@@ -717,71 +669,97 @@ export class DawEditorElement extends LitElement {
     const selStartPx = (this._selectionStartTime * sr) / this.samplesPerPixel;
     const selEndPx = (this._selectionEndTime * sr) / this.samplesPerPixel;
 
+    // Precompute track info once for both controls column and timeline
+    const orderedTracks = this._getOrderedTracks().map(([trackId, track]) => {
+      const descriptor = this._tracks.get(trackId);
+      const firstPeaks = track.clips
+        .map((c) => this._peaksData.get(c.id))
+        .find((p) => p && p.data.length > 0);
+      const numChannels = firstPeaks ? firstPeaks.data.length : 1;
+      return {
+        trackId,
+        track,
+        descriptor,
+        numChannels,
+        trackHeight: this.waveHeight * numChannels,
+      };
+    });
+
     return html`
-      <div
-        class="timeline ${this._dragOver ? 'drag-over' : ''}"
-        style="width: ${Math.max(this._totalWidth, 100)}px;"
-        data-playing=${this._isPlaying}
-        @pointerdown=${this._pointer.onPointerDown}
-        @dragover=${this._onDragOver}
-        @dragleave=${this._onDragLeave}
-        @drop=${this._onDrop}
-      >
-        ${this.timescale
-          ? html`<daw-ruler
-              .samplesPerPixel=${this.samplesPerPixel}
-              .sampleRate=${this.effectiveSampleRate}
-              .duration=${this._duration}
-            ></daw-ruler>`
-          : ''}
-        <daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
-        <daw-playhead></daw-playhead>
-        ${this._getOrderedTracks().map(([trackId, track]) => {
-          // Determine channel count from peak data of first clip with peaks
-          const firstPeaks = track.clips
-            .map((c) => this._peaksData.get(c.id))
-            .find((p) => p && p.data.length > 0);
-          const numChannels = firstPeaks ? firstPeaks.data.length : 1;
-          const channelHeight = this.waveHeight;
-          const trackHeight = channelHeight * numChannels;
-
-          return html`
-            <div
-              class="track-row ${trackId === this._selectedTrackId ? 'selected' : ''}"
-              style="height: ${trackHeight}px;"
-              data-track-id=${trackId}
-            >
-              ${track.clips.map((clip) => {
-                const peakData = this._peaksData.get(clip.id);
-                const width = clipPixelWidth(
-                  clip.startSample,
-                  clip.durationSamples,
-                  this.samplesPerPixel
-                );
-                const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
-                const channels: Peaks[] = peakData?.data ?? [new Int16Array(0)];
-
-                return channels.map(
-                  (channelPeaks, chIdx) => html`
-                    <daw-waveform
-                      style="position: absolute; left: ${clipLeft}px; top: ${chIdx *
-                      channelHeight}px;"
-                      .peaks=${channelPeaks}
-                      .bits=${16}
-                      .length=${peakData?.length ?? width}
-                      .waveHeight=${channelHeight}
-                      .barWidth=${this.barWidth}
-                      .barGap=${this.barGap}
-                      .visibleStart=${this._viewport.visibleStart}
-                      .visibleEnd=${this._viewport.visibleEnd}
-                      .originX=${clipLeft}
-                    ></daw-waveform>
-                  `
-                );
-              })}
-            </div>
-          `;
-        })}
+      <div class="controls-column">
+        ${this.timescale ? html`<div style="height: 26px;"></div>` : ''}
+        ${orderedTracks.map(
+          (t) => html`
+            <daw-track-controls
+              style="height: ${t.trackHeight}px;"
+              .trackId=${t.trackId}
+              .trackName=${t.descriptor?.name ?? 'Untitled'}
+              .volume=${t.descriptor?.volume ?? 1}
+              .pan=${t.descriptor?.pan ?? 0}
+              .muted=${t.descriptor?.muted ?? false}
+              .soloed=${t.descriptor?.soloed ?? false}
+            ></daw-track-controls>
+          `
+        )}
+      </div>
+      <div class="scroll-area">
+        <div
+          class="timeline ${this._dragOver ? 'drag-over' : ''}"
+          style="width: ${Math.max(this._totalWidth, 100)}px;"
+          data-playing=${this._isPlaying}
+          @pointerdown=${this._pointer.onPointerDown}
+          @dragover=${this._onDragOver}
+          @dragleave=${this._onDragLeave}
+          @drop=${this._onDrop}
+        >
+          ${this.timescale
+            ? html`<daw-ruler
+                .samplesPerPixel=${this.samplesPerPixel}
+                .sampleRate=${this.effectiveSampleRate}
+                .duration=${this._duration}
+              ></daw-ruler>`
+            : ''}
+          <daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
+          <daw-playhead></daw-playhead>
+          ${orderedTracks.map((t) => {
+            const channelHeight = this.waveHeight;
+            return html`
+              <div
+                class="track-row ${t.trackId === this._selectedTrackId ? 'selected' : ''}"
+                style="height: ${t.trackHeight}px;"
+                data-track-id=${t.trackId}
+              >
+                ${t.track.clips.map((clip) => {
+                  const peakData = this._peaksData.get(clip.id);
+                  const width = clipPixelWidth(
+                    clip.startSample,
+                    clip.durationSamples,
+                    this.samplesPerPixel
+                  );
+                  const clipLeft = Math.floor(clip.startSample / this.samplesPerPixel);
+                  const channels: Peaks[] = peakData?.data ?? [new Int16Array(0)];
+                  return channels.map(
+                    (channelPeaks, chIdx) => html`
+                      <daw-waveform
+                        style="position: absolute; left: ${clipLeft}px; top: ${chIdx *
+                        channelHeight}px;"
+                        .peaks=${channelPeaks}
+                        .bits=${16}
+                        .length=${peakData?.length ?? width}
+                        .waveHeight=${channelHeight}
+                        .barWidth=${this.barWidth}
+                        .barGap=${this.barGap}
+                        .visibleStart=${this._viewport.visibleStart}
+                        .visibleEnd=${this._viewport.visibleEnd}
+                        .originX=${clipLeft}
+                      ></daw-waveform>
+                    `
+                  );
+                })}
+              </div>
+            `;
+          })}
+        </div>
       </div>
       <slot></slot>
     `;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -20,7 +20,7 @@ import type {
 } from '../events';
 import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
 
-interface TrackDescriptor {
+export interface TrackDescriptor {
   name: string;
   src: string;
   volume: number;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -314,12 +314,14 @@ export class DawEditorElement extends LitElement {
       const descriptor = { ...oldDescriptor, [prop]: value };
       this._tracks = new Map(this._tracks).set(trackId, descriptor);
 
-      // Forward to engine
+      // Forward to engine with validated values
       if (this._engine) {
-        if (prop === 'volume') this._engine.setTrackVolume(trackId, value as number);
-        if (prop === 'pan') this._engine.setTrackPan(trackId, value as number);
-        if (prop === 'muted') this._engine.setTrackMute(trackId, value as boolean);
-        if (prop === 'soloed') this._engine.setTrackSolo(trackId, value as boolean);
+        if (prop === 'volume')
+          this._engine.setTrackVolume(trackId, Math.max(0, Math.min(1, Number(value))));
+        if (prop === 'pan')
+          this._engine.setTrackPan(trackId, Math.max(-1, Math.min(1, Number(value))));
+        if (prop === 'muted') this._engine.setTrackMute(trackId, Boolean(value));
+        if (prop === 'soloed') this._engine.setTrackSolo(trackId, Boolean(value));
       }
     }
 
@@ -405,7 +407,7 @@ export class DawEditorElement extends LitElement {
           sourceDuration: audioBuffer.duration,
         });
 
-        this._clipBuffers.set(clip.id, audioBuffer);
+        this._clipBuffers = new Map(this._clipBuffers).set(clip.id, audioBuffer);
         const peakData = await this._peakPipeline.generatePeaks(
           audioBuffer,
           this.samplesPerPixel,

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -706,7 +706,7 @@ export class DawEditorElement extends LitElement {
       <div class="scroll-area">
         <div
           class="timeline ${this._dragOver ? 'drag-over' : ''}"
-          style="width: ${Math.max(this._totalWidth, 100)}px;"
+          style="width: ${this._totalWidth > 0 ? this._totalWidth + 'px' : '100%'};"
           data-playing=${this._isPlaying}
           @pointerdown=${this._pointer.onPointerDown}
           @dragover=${this._onDragOver}

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -276,6 +276,11 @@ export class DawEditorElement extends LitElement {
     if (this._engine) {
       this._engine.setTracks([...nextEngine.values()]);
     }
+    // Reset playhead when all tracks removed
+    if (nextEngine.size === 0) {
+      this._currentTime = 0;
+      this._stopPlayhead();
+    }
   }
 
   private _onTrackUpdate = (e: CustomEvent) => {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -303,13 +303,14 @@ export class DawEditorElement extends LitElement {
     }
   };
 
+  private static _CONTROL_PROPS = new Set(['volume', 'pan', 'muted', 'soloed']);
+
   private _onTrackControl = (e: CustomEvent) => {
     const { trackId, prop, value } = e.detail ?? {};
-    if (!trackId || !prop) return;
+    if (!trackId || !prop || !DawEditorElement._CONTROL_PROPS.has(prop)) return;
 
-    // Update descriptor directly (works for both DOM and file-dropped tracks)
     const oldDescriptor = this._tracks.get(trackId);
-    if (oldDescriptor && prop in oldDescriptor) {
+    if (oldDescriptor) {
       const descriptor = { ...oldDescriptor, [prop]: value };
       this._tracks = new Map(this._tracks).set(trackId, descriptor);
 
@@ -334,7 +335,9 @@ export class DawEditorElement extends LitElement {
     if (!trackId) return;
     const trackEl = this._trackElements.get(trackId);
     if (trackEl) {
-      trackEl.remove();
+      trackEl.remove(); // MutationObserver will trigger _onTrackRemoved
+    } else {
+      this._onTrackRemoved(trackId); // File-dropped tracks: no DOM element
     }
   };
 
@@ -687,22 +690,24 @@ export class DawEditorElement extends LitElement {
     });
 
     return html`
-      <div class="controls-column">
-        ${this.timescale ? html`<div style="height: 30px;"></div>` : ''}
-        ${orderedTracks.map(
-          (t) => html`
-            <daw-track-controls
-              style="height: ${t.trackHeight}px;"
-              .trackId=${t.trackId}
-              .trackName=${t.descriptor?.name ?? 'Untitled'}
-              .volume=${t.descriptor?.volume ?? 1}
-              .pan=${t.descriptor?.pan ?? 0}
-              .muted=${t.descriptor?.muted ?? false}
-              .soloed=${t.descriptor?.soloed ?? false}
-            ></daw-track-controls>
-          `
-        )}
-      </div>
+      ${orderedTracks.length > 0
+        ? html`<div class="controls-column">
+            ${this.timescale ? html`<div style="height: 30px;"></div>` : ''}
+            ${orderedTracks.map(
+              (t) => html`
+                <daw-track-controls
+                  style="height: ${t.trackHeight}px;"
+                  .trackId=${t.trackId}
+                  .trackName=${t.descriptor?.name ?? 'Untitled'}
+                  .volume=${t.descriptor?.volume ?? 1}
+                  .pan=${t.descriptor?.pan ?? 0}
+                  .muted=${t.descriptor?.muted ?? false}
+                  .soloed=${t.descriptor?.soloed ?? false}
+                ></daw-track-controls>
+              `
+            )}
+          </div>`
+        : ''}
       <div class="scroll-area">
         <div
           class="timeline ${this._dragOver ? 'drag-over' : ''}"

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -687,7 +687,7 @@ export class DawEditorElement extends LitElement {
 
     return html`
       <div class="controls-column">
-        ${this.timescale ? html`<div style="height: 26px;"></div>` : ''}
+        ${this.timescale ? html`<div style="height: 30px;"></div>` : ''}
         ${orderedTracks.map(
           (t) => html`
             <daw-track-controls

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -110,7 +110,7 @@ export class DawEditorElement extends LitElement {
       }
       .timeline {
         position: relative;
-        min-height: 50px;
+        min-height: 100%;
         cursor: text;
       }
       .track-row {
@@ -713,15 +713,17 @@ export class DawEditorElement extends LitElement {
           @dragleave=${this._onDragLeave}
           @drop=${this._onDrop}
         >
-          ${this.timescale
+          ${orderedTracks.length > 0 && this.timescale
             ? html`<daw-ruler
                 .samplesPerPixel=${this.samplesPerPixel}
                 .sampleRate=${this.effectiveSampleRate}
                 .duration=${this._duration}
               ></daw-ruler>`
             : ''}
-          <daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
-          <daw-playhead></daw-playhead>
+          ${orderedTracks.length > 0
+            ? html`<daw-selection .startPx=${selStartPx} .endPx=${selEndPx}></daw-selection>
+                <daw-playhead></daw-playhead>`
+            : ''}
           ${orderedTracks.map((t) => {
             const channelHeight = this.waveHeight;
             return html`

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -578,6 +578,13 @@ export class DawEditorElement extends LitElement {
       await this.loadFiles(files);
     } catch (err) {
       console.warn('[dawcore] File drop failed: ' + String(err));
+      this.dispatchEvent(
+        new CustomEvent<DawErrorDetail>('daw-error', {
+          bubbles: true,
+          composed: true,
+          detail: { operation: 'file-drop', error: err },
+        })
+      );
     }
   };
 

--- a/packages/dawcore/src/elements/daw-track-controls.ts
+++ b/packages/dawcore/src/elements/daw-track-controls.ts
@@ -1,0 +1,247 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('daw-track-controls')
+export class DawTrackControlsElement extends LitElement {
+  /** Track ID — set by the editor to link controls to a track row. */
+  @property({ attribute: false }) trackId: string | null = null;
+  @property({ attribute: false }) trackName = '';
+  @property({ type: Number, attribute: false }) volume = 1;
+  @property({ type: Number, attribute: false }) pan = 0;
+  @property({ type: Boolean, attribute: false }) muted = false;
+  @property({ type: Boolean, attribute: false }) soloed = false;
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      box-sizing: border-box;
+      padding: 6px 8px;
+      background: var(--daw-controls-background, #0f0f1a);
+      color: var(--daw-controls-text, #c49a6c);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      font-family: system-ui, sans-serif;
+      font-size: 11px;
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+    .name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-weight: 600;
+      font-size: 11px;
+    }
+    .remove-btn {
+      background: none;
+      border: none;
+      color: var(--daw-controls-text, #c49a6c);
+      cursor: pointer;
+      padding: 0 2px;
+      font-size: 14px;
+      line-height: 1;
+      opacity: 0.4;
+    }
+    .remove-btn:hover {
+      opacity: 1;
+      color: #d08070;
+    }
+    .buttons {
+      display: flex;
+      gap: 3px;
+      margin-bottom: 6px;
+    }
+    .btn {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 3px;
+      color: var(--daw-controls-text, #c49a6c);
+      cursor: pointer;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 2px 8px;
+      text-align: center;
+    }
+    .btn:hover {
+      background: rgba(255, 255, 255, 0.12);
+    }
+    .btn.active {
+      background: rgba(99, 199, 95, 0.25);
+      border-color: rgba(99, 199, 95, 0.5);
+      color: #63c75f;
+    }
+    .btn.muted-active {
+      background: rgba(208, 128, 112, 0.25);
+      border-color: rgba(208, 128, 112, 0.5);
+      color: #d08070;
+    }
+    .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      height: 20px;
+    }
+    .slider-label {
+      width: 50px;
+      font-size: 9px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      opacity: 0.6;
+      flex-shrink: 0;
+      display: flex;
+      justify-content: space-between;
+    }
+    .slider-label-name {
+      opacity: 0.5;
+    }
+    .slider-label-value {
+      font-family: 'Courier New', monospace;
+    }
+    input[type='range'] {
+      flex: 1;
+      min-width: 0;
+      height: 20px;
+      margin: 0;
+      -webkit-appearance: none;
+      appearance: none;
+      background: transparent;
+      cursor: pointer;
+    }
+    input[type='range']::-webkit-slider-runnable-track {
+      height: 3px;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 2px;
+    }
+    input[type='range']::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--daw-controls-text, #c49a6c);
+      margin-top: -4.5px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    }
+    input[type='range']::-moz-range-track {
+      height: 3px;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 2px;
+      border: none;
+    }
+    input[type='range']::-moz-range-thumb {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--daw-controls-text, #c49a6c);
+      border: none;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    }
+  `;
+
+  private _onVolumeInput = (e: Event) => {
+    const value = Number((e.target as HTMLInputElement).value);
+    this._dispatchControl('volume', value);
+  };
+
+  private _onPanInput = (e: Event) => {
+    const value = Number((e.target as HTMLInputElement).value);
+    this._dispatchControl('pan', value);
+  };
+
+  private _onMuteClick = () => {
+    this._dispatchControl('muted', !this.muted);
+  };
+
+  private _onSoloClick = () => {
+    this._dispatchControl('soloed', !this.soloed);
+  };
+
+  private _onRemoveClick = () => {
+    if (!this.trackId) return;
+    this.dispatchEvent(
+      new CustomEvent('daw-track-remove', {
+        bubbles: true,
+        composed: true,
+        detail: { trackId: this.trackId },
+      })
+    );
+  };
+
+  private _dispatchControl(prop: string, value: number | boolean) {
+    if (!this.trackId) return;
+    this.dispatchEvent(
+      new CustomEvent('daw-track-control', {
+        bubbles: true,
+        composed: true,
+        detail: { trackId: this.trackId, prop, value },
+      })
+    );
+  }
+
+  render() {
+    const volPercent = Math.round(this.volume * 100);
+    const panPercent = Math.round(Math.abs(this.pan) * 100);
+    const panDisplay = this.pan === 0 ? 'C' : (this.pan > 0 ? 'R' : 'L') + panPercent;
+
+    return html`
+      <div class="header">
+        <span class="name" title=${this.trackName}>${this.trackName || 'Untitled'}</span>
+        <button class="remove-btn" @click=${this._onRemoveClick} title="Remove track">
+          &times;
+        </button>
+      </div>
+      <div class="buttons">
+        <button
+          class="btn ${this.muted ? 'muted-active' : ''}"
+          @click=${this._onMuteClick}
+          title="Mute"
+        >
+          M
+        </button>
+        <button class="btn ${this.soloed ? 'active' : ''}" @click=${this._onSoloClick} title="Solo">
+          S
+        </button>
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">
+          <span class="slider-label-name">Vol</span>
+          <span class="slider-label-value">${volPercent}%</span>
+        </span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          .value=${String(this.volume)}
+          @input=${this._onVolumeInput}
+        />
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">
+          <span class="slider-label-name">Pan</span>
+          <span class="slider-label-value">${panDisplay}</span>
+        </span>
+        <input
+          type="range"
+          min="-1"
+          max="1"
+          step="0.01"
+          .value=${String(this.pan)}
+          @input=${this._onPanInput}
+        />
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'daw-track-controls': DawTrackControlsElement;
+  }
+}

--- a/packages/dawcore/src/elements/daw-track-controls.ts
+++ b/packages/dawcore/src/elements/daw-track-controls.ts
@@ -146,12 +146,12 @@ export class DawTrackControlsElement extends LitElement {
 
   private _onVolumeInput = (e: Event) => {
     const value = Number((e.target as HTMLInputElement).value);
-    this._dispatchControl('volume', value);
+    if (Number.isFinite(value)) this._dispatchControl('volume', value);
   };
 
   private _onPanInput = (e: Event) => {
     const value = Number((e.target as HTMLInputElement).value);
-    this._dispatchControl('pan', value);
+    if (Number.isFinite(value)) this._dispatchControl('pan', value);
   };
 
   private _onMuteClick = () => {

--- a/packages/dawcore/src/events.ts
+++ b/packages/dawcore/src/events.ts
@@ -41,6 +41,16 @@ export interface DawErrorDetail {
   error: unknown;
 }
 
+export interface DawTrackControlDetail {
+  trackId: string;
+  prop: string;
+  value: number | boolean;
+}
+
+export interface DawTrackRemoveDetail {
+  trackId: string;
+}
+
 // ---------------------------------------------------------------------------
 // Event map — augments HTMLElementEventMap for typed addEventListener
 // ---------------------------------------------------------------------------
@@ -58,6 +68,8 @@ export interface DawEventMap {
   'daw-pause': CustomEvent<void>;
   'daw-stop': CustomEvent<void>;
   'daw-error': CustomEvent<DawErrorDetail>;
+  'daw-track-control': CustomEvent<DawTrackControlDetail>;
+  'daw-track-remove': CustomEvent<DawTrackRemoveDetail>;
 }
 
 // Helper type for creating typed custom events

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -38,5 +38,7 @@ export type {
   DawTrackErrorDetail,
   DawFilesLoadErrorDetail,
   DawErrorDetail,
+  DawTrackControlDetail,
+  DawTrackRemoveDetail,
   LoadFilesResult,
 } from './events';

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -9,6 +9,7 @@ import './elements/daw-stop-button';
 import './elements/daw-editor';
 import './elements/daw-ruler';
 import './elements/daw-selection';
+import './elements/daw-track-controls';
 
 export { DawClipElement } from './elements/daw-clip';
 export { DawTrackElement } from './elements/daw-track';
@@ -22,6 +23,7 @@ export { DawStopButtonElement } from './elements/daw-stop-button';
 export { DawEditorElement } from './elements/daw-editor';
 export { DawRulerElement } from './elements/daw-ruler';
 export { DawSelectionElement } from './elements/daw-selection';
+export { DawTrackControlsElement } from './elements/daw-track-controls';
 
 export type { PointerEngineContract } from './interactions/pointer-handler';
 

--- a/packages/dawcore/src/interactions/file-loader.ts
+++ b/packages/dawcore/src/interactions/file-loader.ts
@@ -1,0 +1,153 @@
+/**
+ * File loading logic extracted from daw-editor to keep the editor under 800 lines.
+ * Operates on the editor instance via a narrow interface.
+ */
+
+import type { ClipTrack, FadeType, PeakData } from '@waveform-playlist/core';
+import { createClipFromSeconds, createTrack } from '@waveform-playlist/core';
+import type { PeakPipeline } from '../workers/peakPipeline';
+import type { DawTrackIdDetail, DawFilesLoadErrorDetail, LoadFilesResult } from '../events';
+
+export interface FileLoaderHost {
+  readonly samplesPerPixel: number;
+  readonly mono: boolean;
+  readonly isConnected: boolean;
+  _resolvedSampleRate: number | null;
+  _tracks: Map<
+    string,
+    {
+      name: string;
+      src: string;
+      volume: number;
+      pan: number;
+      muted: boolean;
+      soloed: boolean;
+      clips: Array<{
+        src: string;
+        start: number;
+        duration: number;
+        offset: number;
+        gain: number;
+        name: string;
+        fadeIn: number;
+        fadeOut: number;
+        fadeType: FadeType;
+      }>;
+    }
+  >;
+  _engineTracks: Map<string, ClipTrack>;
+  _peaksData: Map<string, PeakData>;
+  _clipBuffers: Map<string, AudioBuffer>;
+  _audioCache: Map<string, Promise<AudioBuffer>>;
+  _peakPipeline: PeakPipeline;
+  _fetchAndDecode(src: string): Promise<AudioBuffer>;
+  _recomputeDuration(): void;
+  _ensureEngine(): Promise<{ setTracks(tracks: ClipTrack[]): void }>;
+  dispatchEvent(event: Event): boolean;
+}
+
+export async function loadFiles(
+  host: FileLoaderHost,
+  files: FileList | File[]
+): Promise<LoadFilesResult> {
+  if (!files) {
+    console.warn('[dawcore] loadFiles called with null/undefined');
+    return { loaded: [], failed: [] };
+  }
+
+  const fileArray = Array.from(files);
+  const loaded: string[] = [];
+  const failed: Array<{ file: File; error: unknown }> = [];
+
+  for (const file of fileArray) {
+    if (file.type && !file.type.startsWith('audio/')) {
+      failed.push({ file, error: new Error('Non-audio MIME type: ' + file.type) });
+      console.warn('[dawcore] Skipping non-audio file: ' + file.name + ' (' + file.type + ')');
+      continue;
+    }
+
+    const blobUrl = URL.createObjectURL(file);
+    try {
+      const audioBuffer = await host._fetchAndDecode(blobUrl);
+      URL.revokeObjectURL(blobUrl);
+      host._audioCache.delete(blobUrl);
+
+      host._resolvedSampleRate = audioBuffer.sampleRate;
+
+      const name = file.name.replace(/\.\w+$/, '');
+      const clip = createClipFromSeconds({
+        audioBuffer,
+        startTime: 0,
+        duration: audioBuffer.duration,
+        offset: 0,
+        gain: 1,
+        name,
+        sampleRate: audioBuffer.sampleRate,
+        sourceDuration: audioBuffer.duration,
+      });
+
+      host._clipBuffers.set(clip.id, audioBuffer);
+      const peakData = await host._peakPipeline.generatePeaks(
+        audioBuffer,
+        host.samplesPerPixel,
+        host.mono
+      );
+      host._peaksData = new Map(host._peaksData).set(clip.id, peakData);
+
+      const trackId = crypto.randomUUID();
+      const track = createTrack({ name, clips: [clip] });
+      track.id = trackId;
+
+      host._tracks = new Map(host._tracks).set(trackId, {
+        name,
+        src: '',
+        volume: 1,
+        pan: 0,
+        muted: false,
+        soloed: false,
+        clips: [
+          {
+            src: '',
+            start: 0,
+            duration: audioBuffer.duration,
+            offset: 0,
+            gain: 1,
+            name,
+            fadeIn: 0,
+            fadeOut: 0,
+            fadeType: 'linear',
+          },
+        ],
+      });
+      host._engineTracks = new Map(host._engineTracks).set(trackId, track);
+      host._recomputeDuration();
+
+      const engine = await host._ensureEngine();
+      engine.setTracks([...host._engineTracks.values()]);
+
+      loaded.push(trackId);
+      host.dispatchEvent(
+        new CustomEvent<DawTrackIdDetail>('daw-track-ready', {
+          bubbles: true,
+          composed: true,
+          detail: { trackId },
+        })
+      );
+    } catch (err) {
+      URL.revokeObjectURL(blobUrl);
+      console.warn('[dawcore] Failed to load file: ' + file.name + ' — ' + String(err));
+      failed.push({ file, error: err });
+      if (host.isConnected) {
+        host.dispatchEvent(
+          new CustomEvent<DawFilesLoadErrorDetail>('daw-files-load-error', {
+            bubbles: true,
+            composed: true,
+            detail: { file, error: err },
+          })
+        );
+      }
+    }
+  }
+
+  return { loaded, failed };
+}

--- a/packages/dawcore/src/interactions/file-loader.ts
+++ b/packages/dawcore/src/interactions/file-loader.ts
@@ -86,7 +86,7 @@ export async function loadFiles(
         sourceDuration: audioBuffer.duration,
       });
 
-      host._clipBuffers.set(clip.id, audioBuffer);
+      host._clipBuffers = new Map(host._clipBuffers).set(clip.id, audioBuffer);
       const peakData = await host._peakPipeline.generatePeaks(
         audioBuffer,
         host.samplesPerPixel,

--- a/packages/dawcore/src/interactions/file-loader.ts
+++ b/packages/dawcore/src/interactions/file-loader.ts
@@ -3,38 +3,18 @@
  * Operates on the editor instance via a narrow interface.
  */
 
-import type { ClipTrack, FadeType, PeakData } from '@waveform-playlist/core';
+import type { ClipTrack, PeakData } from '@waveform-playlist/core';
 import { createClipFromSeconds, createTrack } from '@waveform-playlist/core';
 import type { PeakPipeline } from '../workers/peakPipeline';
 import type { DawTrackIdDetail, DawFilesLoadErrorDetail, LoadFilesResult } from '../events';
+import type { TrackDescriptor } from '../elements/daw-editor';
 
 export interface FileLoaderHost {
   readonly samplesPerPixel: number;
   readonly mono: boolean;
   readonly isConnected: boolean;
   _resolvedSampleRate: number | null;
-  _tracks: Map<
-    string,
-    {
-      name: string;
-      src: string;
-      volume: number;
-      pan: number;
-      muted: boolean;
-      soloed: boolean;
-      clips: Array<{
-        src: string;
-        start: number;
-        duration: number;
-        offset: number;
-        gain: number;
-        name: string;
-        fadeIn: number;
-        fadeOut: number;
-        fadeType: FadeType;
-      }>;
-    }
-  >;
+  _tracks: Map<string, TrackDescriptor>;
   _engineTracks: Map<string, ClipTrack>;
   _peaksData: Map<string, PeakData>;
   _clipBuffers: Map<string, AudioBuffer>;

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -125,7 +125,13 @@ export class PlaylistEngine {
     if (this._selectedTrackId === trackId) {
       this._selectedTrackId = null;
     }
-    this._adapter?.setTracks(this._tracks);
+    // Use incremental removeTrack when available (avoids full playout rebuild,
+    // preserves playback). Falls back to setTracks for adapters without it.
+    if (this._adapter?.removeTrack) {
+      this._adapter.removeTrack(trackId);
+    } else {
+      this._adapter?.setTracks(this._tracks);
+    }
     this._emitStateChange();
   }
 

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -10,6 +10,8 @@ export interface PlayoutAdapter {
   setTracks(tracks: ClipTrack[]): void;
   /** Incrementally add a single track without rebuilding the entire playout. */
   addTrack?(track: ClipTrack): void;
+  /** Incrementally remove a single track without rebuilding the entire playout. */
+  removeTrack?(trackId: string): void;
   play(startTime: number, endTime?: number): void;
   pause(): void;
   stop(): void;

--- a/packages/playout/src/TonePlayoutAdapter.ts
+++ b/packages/playout/src/TonePlayoutAdapter.ts
@@ -185,6 +185,12 @@ export function createToneAdapter(options?: ToneAdapterOptions): PlayoutAdapter 
       playout.applyInitialSoloState();
     },
 
+    removeTrack(trackId: string): void {
+      if (!playout) return;
+      playout.removeTrack(trackId);
+      playout.applyInitialSoloState();
+    },
+
     play(startTime: number, endTime?: number): void {
       if (!playout) {
         console.warn(


### PR DESCRIPTION
## Summary

- **`<daw-track-controls>`** — New Shadow DOM element with track name, Mute/Solo buttons, volume slider (0-100%), pan slider (L100-C-R100), and remove button
- **Flex layout** — Editor uses `display: flex` with fixed controls column (180px, customizable via `--daw-controls-width`) + scrollable timeline area. Controls stay fixed while waveforms scroll.
- **Direct engine control** — `daw-track-control` events update the track descriptor and forward to engine directly (works for both DOM tracks and file-dropped tracks)
- **Track removal** — `daw-track-remove` event removes the `<daw-track>` element, detected by MutationObserver
- **Track ID alignment** — `track.id` set to editor's `trackId` after `createTrack()` so engine lookups match
- **`loadFiles` extracted** — Moved to `interactions/file-loader.ts` via `FileLoaderHost` interface (editor 745 lines, well under 800 max)

## Test plan

- [x] 93 tests passing, typecheck clean, lint 0 errors
- [ ] Manual: volume slider changes track volume during playback
- [ ] Manual: pan slider pans track left/right
- [ ] Manual: Mute button silences track, Solo isolates it
- [ ] Manual: Remove button removes track from editor
- [ ] Manual: controls stay fixed while scrolling timeline
- [ ] Manual: file-dropped tracks show controls too