### PR TITLE
feat(dawcore): eager AudioContext resume

### DIFF
--- a/docs/superpowers/plans/2026-03-20-eager-audiocontext-resume.md
+++ b/docs/superpowers/plans/2026-03-20-eager-audiocontext-resume.md
@@ -1,0 +1,525 @@
+# Eager AudioContext Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resume the global AudioContext on first user interaction (before play), eliminating ~200-500ms first-play latency.
+
+**Architecture:** A Lit reactive controller (`AudioResumeController`) listens for `pointerdown`/`keydown` on a configurable target (host element, document, or CSS selector). On first event, it calls `resumeGlobalAudioContext()` fire-and-forget and removes listeners. `<daw-editor>` exposes an `eager-resume` attribute that wires the controller.
+
+**Tech Stack:** Lit reactive controllers, `resumeGlobalAudioContext()` from `@waveform-playlist/playout`, vitest + happy-dom
+
+**Spec:** `docs/superpowers/specs/2026-03-18-eager-audiocontext-resume-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `packages/dawcore/src/controllers/audio-resume-controller.ts` | Reactive controller: one-shot AudioContext resume on user gesture |
+| Create | `packages/dawcore/src/__tests__/audio-resume-controller.test.ts` | Unit tests for the controller |
+| Modify | `packages/dawcore/src/elements/daw-editor.ts` | `eagerResume` property + controller wiring (~5 lines) |
+| Modify | `packages/dawcore/src/__tests__/daw-editor.test.ts` | Integration tests for eager-resume attribute |
+| Modify | `packages/dawcore/src/index.ts` | Export `AudioResumeController` |
+
+---
+
+### Task 1: AudioResumeController — inert mode and pointerdown
+
+**Files:**
+- Create: `packages/dawcore/src/controllers/audio-resume-controller.ts`
+- Create: `packages/dawcore/src/__tests__/audio-resume-controller.test.ts`
+
+- [ ] **Step 1: Write failing tests for inert mode and pointerdown resume**
+
+```typescript
+// packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@waveform-playlist/playout', () => ({
+  resumeGlobalAudioContext: vi.fn(),
+}));
+
+import { AudioResumeController } from '../controllers/audio-resume-controller';
+import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
+
+// Capture rAF callbacks so we can flush them synchronously in tests
+let rafCallbacks: Array<(time: number) => void>;
+
+function createMockHost() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  return Object.assign(el, {
+    addController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+    isConnected: true,
+  }) as any;
+}
+
+/** Flush pending requestAnimationFrame callbacks */
+function flushRaf() {
+  const cbs = rafCallbacks.splice(0);
+  cbs.forEach((cb) => cb(performance.now()));
+}
+
+describe('AudioResumeController', () => {
+  let host: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rafCallbacks = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (time: number) => void) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      })
+    );
+    host = createMockHost();
+  });
+
+  afterEach(() => {
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('skips listener attachment when target is undefined (inert mode)', () => {
+    const addSpy = vi.spyOn(host, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.hostConnected();
+    flushRaf();
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls resumeGlobalAudioContext on first pointerdown', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/audio-resume-controller.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal AudioResumeController implementation**
+
+```typescript
+// packages/dawcore/src/controllers/audio-resume-controller.ts
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
+
+export class AudioResumeController implements ReactiveController {
+  private _host: ReactiveControllerHost & HTMLElement;
+  private _target: EventTarget | null = null;
+  private _attached = false;
+
+  /** CSS selector, or 'document'. When undefined, controller is inert. */
+  target?: string;
+
+  constructor(host: ReactiveControllerHost & HTMLElement) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    // Defer to next frame so Lit's willUpdate() can set `target` from
+    // the host's attribute before we read it. Same pattern as ViewportController.
+    requestAnimationFrame(() => {
+      if (!this._host.isConnected || this._attached || this.target === undefined) return;
+
+      const resolvedTarget = this._resolveTarget();
+      if (!resolvedTarget) return;
+
+      this._target = resolvedTarget;
+      this._attached = true;
+      resolvedTarget.addEventListener('pointerdown', this._onGesture, {
+        once: true,
+        capture: true,
+      });
+      resolvedTarget.addEventListener('keydown', this._onGesture, {
+        once: true,
+        capture: true,
+      });
+    });
+  }
+
+  hostDisconnected() {
+    this._removeListeners();
+    this._attached = false;
+  }
+
+  private _onGesture = (e: Event) => {
+    resumeGlobalAudioContext();
+    // Remove the other listener (the fired one was auto-removed by { once: true })
+    const otherType = e.type === 'pointerdown' ? 'keydown' : 'pointerdown';
+    this._target?.removeEventListener(otherType, this._onGesture, {
+      capture: true,
+    });
+    this._target = null;
+  };
+
+  private _resolveTarget(): EventTarget | null {
+    const t = this.target;
+    if (t === undefined) return null;
+    if (t === '') return this._host;
+    if (t === 'document') return document;
+
+    const el = document.querySelector(t);
+    if (!el) {
+      console.warn(
+        '[dawcore] AudioResumeController: target not found for "' + t + '", using host'
+      );
+      return this._host;
+    }
+    return el;
+  }
+
+  private _removeListeners() {
+    if (!this._target) return;
+    this._target.removeEventListener('pointerdown', this._onGesture, {
+      capture: true,
+    });
+    this._target.removeEventListener('keydown', this._onGesture, {
+      capture: true,
+    });
+    this._target = null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/audio-resume-controller.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/dawcore/src/controllers/audio-resume-controller.ts packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+git commit -m "feat(dawcore): AudioResumeController — inert mode and pointerdown resume"
+```
+
+---
+
+### Task 2: AudioResumeController — keydown, one-shot, and disconnect
+
+**Files:**
+- Modify: `packages/dawcore/src/__tests__/audio-resume-controller.test.ts`
+
+- [ ] **Step 1: Write failing tests for keydown, one-shot behavior, and disconnect cleanup**
+
+Add to the existing describe block:
+
+```typescript
+  it('calls resumeGlobalAudioContext on first keydown', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('keydown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+
+  it('only calls resume once (second event is no-op)', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    host.dispatchEvent(new Event('keydown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+
+  it('removes listeners on hostDisconnected before any event fires', () => {
+    const removeSpy = vi.spyOn(host, 'removeEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    controller.hostDisconnected();
+
+    // Should remove both pointerdown and keydown
+    const captureRemovals = removeSpy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureRemovals.length).toBe(2);
+    expect(resumeGlobalAudioContext).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/audio-resume-controller.test.ts`
+Expected: PASS (5 tests) — implementation from Task 1 should already handle these
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+git commit -m "test(dawcore): AudioResumeController keydown, one-shot, and disconnect tests"
+```
+
+---
+
+### Task 3: AudioResumeController — target resolution (selector, document, fallback)
+
+**Files:**
+- Modify: `packages/dawcore/src/__tests__/audio-resume-controller.test.ts`
+
+- [ ] **Step 1: Write failing tests for target resolution**
+
+Add to the existing describe block:
+
+```typescript
+  it('attaches to document when target is "document"', () => {
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = 'document';
+    controller.hostConnected();
+    flushRaf();
+
+    document.dispatchEvent(new Event('pointerdown'));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    docSpy.mockRestore();
+  });
+
+  it('resolves CSS selector target', () => {
+    const target = document.createElement('div');
+    target.id = 'audio-scope';
+    document.body.appendChild(target);
+
+    const targetSpy = vi.spyOn(target, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '#audio-scope';
+    controller.hostConnected();
+    flushRaf();
+
+    expect(targetSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+
+    target.remove();
+    targetSpy.mockRestore();
+  });
+
+  it('falls back to host when selector does not match', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const hostSpy = vi.spyOn(host, 'addEventListener');
+
+    const controller = new AudioResumeController(host);
+    controller.target = '#nonexistent';
+    controller.hostConnected();
+    flushRaf();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('#nonexistent')
+    );
+    expect(hostSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+
+    warnSpy.mockRestore();
+    hostSpy.mockRestore();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/audio-resume-controller.test.ts`
+Expected: PASS (8 tests) — implementation from Task 1 should handle these
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+git commit -m "test(dawcore): AudioResumeController target resolution tests"
+```
+
+---
+
+### Task 4: `<daw-editor>` integration — eager-resume attribute
+
+**Files:**
+- Modify: `packages/dawcore/src/elements/daw-editor.ts`
+- Modify: `packages/dawcore/src/__tests__/daw-editor.test.ts`
+- Modify: `packages/dawcore/src/index.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add to `packages/dawcore/src/__tests__/daw-editor.test.ts`:
+
+```typescript
+  it('attaches AudioResumeController listeners when eager-resume is set', async () => {
+    const el = document.createElement('daw-editor') as any;
+    el.setAttribute('eager-resume', '');
+    const spy = vi.spyOn(el, 'addEventListener');
+    document.body.appendChild(el);
+
+    // Wait for Lit update cycle
+    await new Promise((r) => setTimeout(r, 50));
+
+    const captureListeners = spy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBeGreaterThanOrEqual(2);
+
+    document.body.removeChild(el);
+    spy.mockRestore();
+  });
+
+  it('does not attach listeners when eager-resume is not set', async () => {
+    const el = document.createElement('daw-editor') as any;
+    const spy = vi.spyOn(el, 'addEventListener');
+    document.body.appendChild(el);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const captureListeners = spy.mock.calls.filter(
+      ([type]) => type === 'pointerdown' || type === 'keydown'
+    ).filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBe(0);
+
+    document.body.removeChild(el);
+    spy.mockRestore();
+  });
+
+  it('passes eager-resume="document" to controller target', async () => {
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const el = document.createElement('daw-editor') as any;
+    el.setAttribute('eager-resume', 'document');
+    document.body.appendChild(el);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const docCapture = docSpy.mock.calls.filter(
+      ([type, , opts]) =>
+        (type === 'pointerdown' || type === 'keydown') &&
+        (opts as any)?.capture === true
+    );
+    expect(docCapture.length).toBeGreaterThanOrEqual(2);
+
+    document.body.removeChild(el);
+    docSpy.mockRestore();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-editor.test.ts`
+Expected: FAIL — `eager-resume` attribute not recognized / no listeners attached
+
+- [ ] **Step 3: Add eagerResume property and controller to daw-editor.ts**
+
+At the top of the file, add import:
+
+```typescript
+import { AudioResumeController } from '../controllers/audio-resume-controller';
+```
+
+In the class body (near other controller declarations around line 85-90), add:
+
+```typescript
+  private _audioResume = new AudioResumeController(this);
+
+  @property({ attribute: 'eager-resume' })
+  eagerResume?: string;
+```
+
+In `willUpdate()` (around line 224), add before the existing `samplesPerPixel` check:
+
+```typescript
+    if (changedProperties.has('eagerResume')) {
+      this._audioResume.target = this.eagerResume;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-editor.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Export AudioResumeController from index.ts**
+
+Add to `packages/dawcore/src/index.ts`:
+
+```typescript
+export { AudioResumeController } from './controllers/audio-resume-controller';
+```
+
+- [ ] **Step 6: Verify full test suite passes**
+
+Run: `cd packages/dawcore && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 7: Verify typecheck passes**
+
+Run: `cd packages/dawcore && pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/dawcore/src/elements/daw-editor.ts packages/dawcore/src/__tests__/daw-editor.test.ts packages/dawcore/src/index.ts
+git commit -m "feat(dawcore): eager-resume attribute on daw-editor
+
+Wires AudioResumeController to <daw-editor eager-resume> attribute.
+Accepts 'document', CSS selector, or empty (host element).
+Exports AudioResumeController for standalone use."
+```
+
+---
+
+### Task 5: Verify build and lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build dawcore package**
+
+Run: `pnpm --filter @dawcore/components build`
+Expected: Clean build, no errors
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm lint`
+Expected: No errors. If formatting issues, run `pnpm format` first.
+
+- [ ] **Step 3: Verify daw-editor.ts stays within file size budget**
+
+Run: `wc -l packages/dawcore/src/elements/daw-editor.ts`
+Expected: <= 800 lines
+
+---
+
+### Task 6: Update CLAUDE.md
+
+**Files:**
+- Modify: `packages/dawcore/CLAUDE.md`
+
+- [ ] **Step 1: Add AudioResumeController to Reactive Controllers section**
+
+In the "Reactive Controllers" section of `packages/dawcore/CLAUDE.md`, add:
+
+```markdown
+- `AudioResumeController` — One-shot AudioContext resume on first user gesture (`pointerdown`/`keydown`). Configurable target: host element (default), `'document'`, or CSS selector. Used by `<daw-editor eager-resume>`. Exported for standalone use.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/dawcore/CLAUDE.md
+git commit -m "docs(dawcore): add AudioResumeController to CLAUDE.md"
+```

--- a/docs/superpowers/specs/2026-03-18-eager-audiocontext-resume-design.md
+++ b/docs/superpowers/specs/2026-03-18-eager-audiocontext-resume-design.md
@@ -78,7 +78,7 @@ When the attribute is absent, `eagerResume` is `undefined`. When present with no
 
 **Behavior:** The controller is self-contained — it only reads from its constructor options, never from host properties. The editor creates it in the constructor and sets the `target` property on it. In `hostConnected()`, the controller reads `this.target` to resolve the listener target. When `target` is `undefined`, the controller skips listener attachment (inert).
 
-The editor sets the controller's `target` from `eagerResume` in `willUpdate()` (runs before `hostConnected()` on first render, and on subsequent attribute changes — though dynamic changes after first connection have no effect since listeners are already attached or skipped).
+The editor sets the controller's `target` from `eagerResume` in `willUpdate()`. Note: `hostConnected()` fires BEFORE `willUpdate()` in Lit's lifecycle, so the controller defers its work via `requestAnimationFrame` — by the time the rAF fires, `willUpdate()` has already set `target`.
 
 This follows `ViewportController.scrollSelector` — a public property set by the host, read by the controller in `hostConnected()`.
 

--- a/docs/superpowers/specs/2026-03-18-eager-audiocontext-resume-design.md
+++ b/docs/superpowers/specs/2026-03-18-eager-audiocontext-resume-design.md
@@ -1,0 +1,133 @@
+# Eager AudioContext Resume — Design Spec
+
+**Date:** 2026-03-18
+**Scope:** `@dawcore/components` (dawcore package only)
+**Branch:** TBD
+
+## Problem
+
+Web browsers suspend `AudioContext` until a user gesture (click, keypress). Currently, `<daw-editor>` defers `engine.init()` — which calls `Tone.start()` to resume the context — to the first `play()` call. This adds ~200-500ms of latency on the first play press.
+
+## Solution
+
+Resume the `AudioContext` on the first user interaction within the editor (or a broader scope), before play is pressed. By the time the user clicks play, the context is already running and `engine.init()` resolves instantly.
+
+**Critical:** Use `resumeGlobalAudioContext()` (raw context resume), NOT `Tone.start()`. `Tone.start()` adds ~2s latency on Safari if called redundantly.
+
+## Components
+
+### 1. `AudioResumeController`
+
+**File:** `packages/dawcore/src/controllers/audio-resume-controller.ts`
+
+**Type:** Lit reactive controller. Follows the pattern of `ViewportController` — constructor takes host + options, calls `host.addController(this)`, resolves target in `hostConnected()`.
+
+**API:**
+
+```typescript
+class AudioResumeController implements ReactiveController {
+  /** CSS selector, or 'document'. When undefined, controller is inert. */
+  target?: string;
+
+  constructor(host: ReactiveControllerHost & HTMLElement);
+}
+```
+
+Standalone usage:
+
+```typescript
+class MyElement extends LitElement {
+  private _audioResume = new AudioResumeController(this);
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._audioResume.target = 'document';
+  }
+}
+```
+
+**Target resolution (in `hostConnected()`):**
+
+- **omitted / empty string** — listen on host element
+- **`'document'`** — listen on `document`
+- **any other string** — `document.querySelector(selector)`. Warn and fall back to host if not found.
+
+**Listeners:** `pointerdown` + `keydown` with `{ once: true, capture: true }`.
+
+- `capture: true` ensures resume fires before any other handler, so the context is already resuming by the time a play handler runs.
+- `{ once: true }` auto-removes the fired listener.
+
+**Handler shape:** A single shared handler function used for both event types. On first fire, it calls `resumeGlobalAudioContext()` (fire-and-forget, no await) and removes the other listener via `target.removeEventListener(otherEvent, handler, { capture: true })`. This ensures cross-listener cleanup works correctly.
+
+**`hostDisconnected()`:** Removes both listeners if they haven't fired yet.
+
+**Dynamic changes not supported.** Once listeners are attached in `hostConnected()`, changing the target has no effect. The resume only needs to happen once per page lifecycle.
+
+**Export:** From `packages/dawcore/src/index.ts` for standalone consumer use. This is a new pattern (existing exports are elements + types only) but necessary for consumers who want to attach the controller to their own Lit elements without `<daw-editor>`.
+
+### 2. `<daw-editor>` Integration
+
+**Property:**
+
+```typescript
+@property({ attribute: 'eager-resume' })
+eagerResume?: string;
+```
+
+When the attribute is absent, `eagerResume` is `undefined`. When present with no value (`<daw-editor eager-resume>`), Lit's String converter yields `""`. The controller checks `this.host.eagerResume !== undefined` (not a falsy check) to distinguish "not set" from "set to empty string."
+
+**Behavior:** The controller is self-contained — it only reads from its constructor options, never from host properties. The editor creates it in the constructor and sets the `target` property on it. In `hostConnected()`, the controller reads `this.target` to resolve the listener target. When `target` is `undefined`, the controller skips listener attachment (inert).
+
+The editor sets the controller's `target` from `eagerResume` in `willUpdate()` (runs before `hostConnected()` on first render, and on subsequent attribute changes — though dynamic changes after first connection have no effect since listeners are already attached or skipped).
+
+This follows `ViewportController.scrollSelector` — a public property set by the host, read by the controller in `hostConnected()`.
+
+**Attribute usage:**
+
+```html
+<!-- Listen on the editor element itself -->
+<daw-editor eager-resume></daw-editor>
+
+<!-- Listen on document (any interaction on the page) -->
+<daw-editor eager-resume="document"></daw-editor>
+
+<!-- Listen on a specific ancestor -->
+<daw-editor eager-resume="#my-app"></daw-editor>
+```
+
+**File size budget:** `daw-editor.ts` is currently 793 lines (hard max: 800). The integration adds ~5 lines (import, property declaration, constructor line). This stays within budget. If future additions push past 800, the `loadFiles` extraction (noted in CLAUDE.md) should happen first.
+
+## Testing
+
+### `AudioResumeController` unit tests:
+
+1. Calls `resumeGlobalAudioContext()` on first `pointerdown`
+2. Calls `resumeGlobalAudioContext()` on first `keydown`
+3. Only calls resume once (second event is no-op, listeners removed)
+4. Removes listeners on `hostDisconnected()` before any event fires
+5. Resolves CSS selector target via `document.querySelector()`
+6. Falls back to host when selector doesn't match (with `console.warn`)
+7. `target: 'document'` attaches to document
+8. Skips listener attachment when target resolves to `undefined` (inert mode)
+
+### `<daw-editor>` integration tests:
+
+9. `eager-resume` attribute creates controller and attaches listeners
+10. `eager-resume="document"` passes `'document'` as target
+11. No controller listeners when `eager-resume` not set
+
+**Mocking:** Mock `resumeGlobalAudioContext` from `@waveform-playlist/playout`.
+
+## Files Changed
+
+- **New:** `packages/dawcore/src/controllers/audio-resume-controller.ts`
+- **New:** `packages/dawcore/src/__tests__/audio-resume-controller.test.ts`
+- **Modified:** `packages/dawcore/src/elements/daw-editor.ts` — add `eagerResume` property + controller (~5 lines)
+- **Modified:** `packages/dawcore/src/__tests__/daw-editor.test.ts` — integration tests
+- **Modified:** `packages/dawcore/src/index.ts` — export `AudioResumeController`
+
+## Non-Goals
+
+- React browser package (`@waveform-playlist/browser`) — not in scope
+- Changing `engine.init()` / `Tone.start()` behavior — the existing init path remains unchanged
+- Automatic resume without user gesture — browsers require a gesture, this just moves it earlier

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -60,6 +60,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - `AnimationController` — Start/stop RAF loops, auto-cleanup on `hostDisconnected`. Used by `<daw-playhead>`.
 - `ViewportController` — Scroll-aware visible range with overscan buffer (1.5x). Attached to `.scroll-area` via `scrollSelector`. See Virtual Scrolling section.
 - `EngineController` — (Scaffolded, not yet wired) DOM traversal to find closest `<daw-editor>`. Will be used by sub-elements that need engine access.
+- `AudioResumeController` — One-shot AudioContext resume on first user gesture (`pointerdown`/`keydown`). Configurable target: host element (default), `'document'`, or CSS selector. Used by `<daw-editor eager-resume>`. Exported for standalone use.
 
 ## Ported Utilities
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -8,6 +8,10 @@
 
 **Testing:** vitest with happy-dom in `src/__tests__/`. Run with `cd packages/dawcore && npx vitest run`.
 
+**Testing gotchas:**
+- `isConnected` is a readonly getter in happy-dom — cannot be set via `Object.assign` on elements. Append the element to `document.body` instead.
+- Mocks for async functions (e.g., `resumeGlobalAudioContext`) must return `Promise.resolve()`, not `undefined`. Calling `.catch()` on `undefined` crashes.
+
 **Dev page:** `pnpm dev:page` starts Vite at `http://localhost:5173/dev/index.html`. Uses `website/static/` as publicDir for audio files.
 
 ## Dev Page Dependencies
@@ -62,6 +66,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - `EngineController` — (Scaffolded, not yet wired) DOM traversal to find closest `<daw-editor>`. Will be used by sub-elements that need engine access.
 - `AudioResumeController` — One-shot AudioContext resume on first user gesture (`pointerdown`/`keydown`). Configurable target: host element (default), `'document'`, or CSS selector. Used by `<daw-editor eager-resume>`. Exported for standalone use.
 
+**Lit controller lifecycle gotcha:** `hostConnected()` fires during `connectedCallback()`, BEFORE the first `willUpdate()`. Controllers that read properties set from attributes must defer work with `requestAnimationFrame` (as `ViewportController` and `AudioResumeController` do), otherwise the property will still be `undefined`.
+
 ## Ported Utilities
 
 - `peak-rendering.ts` — `aggregatePeaks`, `calculateBarRects`, `calculateFirstBarPosition` (from `ui-components`)
@@ -80,7 +86,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **sampleRate comes from decoded audio** — Always use `audioBuffer.sampleRate` for clip creation. The global AudioContext decodes at the hardware rate (may be 44100 or 48000). Set `this.sampleRate` from the first decoded buffer so the ruler, peaks, and engine all agree.
 - **Use `getGlobalAudioContext()` for decode** — Import from `@waveform-playlist/playout`. Same context Tone.js uses. `decodeAudioData` works while suspended (pre-gesture). Never create a separate AudioContext for decoding.
 - **Pointer interactions extracted** — `interactions/pointer-handler.ts` handles pointerdown/move/up, caches timeline ref and rect, distinguishes click vs drag. The host implements `PointerHandlerHost` interface.
-- **Peak pipeline extracted** — `workers/peakPipeline.ts` manages worker lifecycle, WaveformData cache, inflight dedup. `daw-editor.ts` is ~790 lines (under 800 max); consider extracting `loadFiles` if it grows further.
+- **Peak pipeline extracted** — `workers/peakPipeline.ts` manages worker lifecycle, WaveformData cache, inflight dedup.
 
 ## Typed Events
 
@@ -117,7 +123,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`, re-exported from `viewport-controller.ts`. Used by `daw-waveform._getVisibleChunkIndices()`.
 - **Permissive defaults** — Controller initializes `visibleStart=-Infinity, visibleEnd=Infinity` so all chunks render before scroll container is attached.
 - **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.
-- **File size budget** — `daw-editor.ts` is at 800 lines (the hard max). Extract `loadFiles` (~100 lines) before adding more code.
+- **File size budget** — `daw-editor.ts` is at exactly 800 lines (the hard max). Any new code in this file requires extracting something else first. `loadFiles` was already extracted to `interactions/file-loader.ts`.
 
 ## Track Controls
 

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@waveform-playlist/playout', () => ({
-  resumeGlobalAudioContext: vi.fn(),
+  resumeGlobalAudioContext: vi.fn(() => Promise.resolve()),
 }));
 
 import { AudioResumeController } from '../controllers/audio-resume-controller';
@@ -150,5 +150,57 @@ describe('AudioResumeController', () => {
 
     warnSpy.mockRestore();
     hostSpy.mockRestore();
+  });
+
+  it('skips attachment when host is disconnected before rAF fires', () => {
+    const addSpy = vi.spyOn(host, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+
+    // Disconnect before rAF fires
+    host.remove();
+    flushRaf();
+
+    const captureListeners = addSpy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBe(0);
+  });
+
+  it('logs warning when resumeGlobalAudioContext rejects', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(resumeGlobalAudioContext).mockRejectedValueOnce(new Error('Context closed'));
+
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    // Allow microtask to settle
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('eager resume failed'));
+    warnSpy.mockRestore();
+  });
+
+  it('warns and becomes inert on invalid CSS selector', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const addSpy = vi.spyOn(host, 'addEventListener');
+
+    const controller = new AudioResumeController(host);
+    controller.target = '[invalid';
+    controller.hostConnected();
+    flushRaf();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to resolve target'));
+    const captureListeners = addSpy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBe(0);
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -203,4 +203,25 @@ describe('AudioResumeController', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('ignores stale rAF from previous hostConnected after disconnect/reconnect', () => {
+    const addSpy = vi.spyOn(host, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+
+    // First connect schedules rAF-A
+    controller.hostConnected();
+    // Disconnect invalidates rAF-A
+    controller.hostDisconnected();
+    // Reconnect schedules rAF-B
+    controller.hostConnected();
+    // Both rAFs fire — only rAF-B should attach listeners
+    flushRaf();
+
+    const captureListeners = addSpy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    // Exactly 2 listeners (pointerdown + keydown), not 4
+    expect(captureListeners.length).toBe(2);
+  });
 });

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -145,9 +145,7 @@ describe('AudioResumeController', () => {
     controller.hostConnected();
     flushRaf();
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('#nonexistent')
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('#nonexistent'));
     expect(hostSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
 
     warnSpy.mockRestore();

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@waveform-playlist/playout', () => ({
+  resumeGlobalAudioContext: vi.fn(),
+}));
+
+import { AudioResumeController } from '../controllers/audio-resume-controller';
+import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
+
+let rafCallbacks: Array<(time: number) => void>;
+
+function createMockHost() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  // isConnected is a read-only getter on HTMLElement; add the controller methods directly
+  Object.assign(el, {
+    addController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  });
+  return el as any;
+}
+
+function flushRaf() {
+  const cbs = rafCallbacks.splice(0);
+  cbs.forEach((cb) => cb(performance.now()));
+}
+
+describe('AudioResumeController', () => {
+  let host: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rafCallbacks = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (time: number) => void) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      })
+    );
+    host = createMockHost();
+  });
+
+  afterEach(() => {
+    host.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('skips listener attachment when target is undefined (inert mode)', () => {
+    const addSpy = vi.spyOn(host, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.hostConnected();
+    flushRaf();
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls resumeGlobalAudioContext on first pointerdown', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -66,4 +66,91 @@ describe('AudioResumeController', () => {
 
     expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
   });
+
+  it('calls resumeGlobalAudioContext on first keydown', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('keydown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+
+  it('only calls resume once (second event is no-op)', () => {
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    host.dispatchEvent(new Event('keydown', { bubbles: true }));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+  });
+
+  it('removes listeners on hostDisconnected before any event fires', () => {
+    const removeSpy = vi.spyOn(host, 'removeEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    controller.hostDisconnected();
+
+    const captureRemovals = removeSpy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureRemovals.length).toBe(2);
+    expect(resumeGlobalAudioContext).not.toHaveBeenCalled();
+  });
+
+  it('attaches to document when target is "document"', () => {
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = 'document';
+    controller.hostConnected();
+    flushRaf();
+
+    document.dispatchEvent(new Event('pointerdown'));
+
+    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    docSpy.mockRestore();
+  });
+
+  it('resolves CSS selector target', () => {
+    const target = document.createElement('div');
+    target.id = 'audio-scope';
+    document.body.appendChild(target);
+
+    const targetSpy = vi.spyOn(target, 'addEventListener');
+    const controller = new AudioResumeController(host);
+    controller.target = '#audio-scope';
+    controller.hostConnected();
+    flushRaf();
+
+    expect(targetSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+
+    target.remove();
+    targetSpy.mockRestore();
+  });
+
+  it('falls back to host when selector does not match', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const hostSpy = vi.spyOn(host, 'addEventListener');
+
+    const controller = new AudioResumeController(host);
+    controller.target = '#nonexistent';
+    controller.hostConnected();
+    flushRaf();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('#nonexistent')
+    );
+    expect(hostSpy.mock.calls.some(([type]) => type === 'pointerdown')).toBe(true);
+
+    warnSpy.mockRestore();
+    hostSpy.mockRestore();
+  });
 });

--- a/packages/dawcore/src/__tests__/daw-editor.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 
 beforeAll(async () => {
   await import('../elements/daw-clip');
@@ -49,5 +49,60 @@ describe('DawEditorElement', () => {
     expect(el.tracks[0].name).toBe('Test Track');
 
     document.body.removeChild(el);
+  });
+
+  it('attaches AudioResumeController listeners when eager-resume is set', async () => {
+    const el = document.createElement('daw-editor') as any;
+    el.setAttribute('eager-resume', '');
+    const spy = vi.spyOn(el, 'addEventListener');
+    document.body.appendChild(el);
+
+    // Wait for Lit update cycle + rAF
+    await new Promise((r) => setTimeout(r, 50));
+
+    const captureListeners = spy.mock.calls.filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBeGreaterThanOrEqual(2);
+
+    document.body.removeChild(el);
+    spy.mockRestore();
+  });
+
+  it('does not attach listeners when eager-resume is not set', async () => {
+    const el = document.createElement('daw-editor') as any;
+    const spy = vi.spyOn(el, 'addEventListener');
+    document.body.appendChild(el);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const captureListeners = spy.mock.calls.filter(
+      ([type]) => type === 'pointerdown' || type === 'keydown'
+    ).filter(
+      ([, , opts]) => (opts as any)?.capture === true
+    );
+    expect(captureListeners.length).toBe(0);
+
+    document.body.removeChild(el);
+    spy.mockRestore();
+  });
+
+  it('passes eager-resume="document" to controller target', async () => {
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const el = document.createElement('daw-editor') as any;
+    el.setAttribute('eager-resume', 'document');
+    document.body.appendChild(el);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const docCapture = docSpy.mock.calls.filter(
+      ([type, , opts]) =>
+        (type === 'pointerdown' || type === 'keydown') &&
+        (opts as any)?.capture === true
+    );
+    expect(docCapture.length).toBeGreaterThanOrEqual(2);
+
+    document.body.removeChild(el);
+    docSpy.mockRestore();
   });
 });

--- a/packages/dawcore/src/__tests__/daw-editor.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor.test.ts
@@ -60,9 +60,7 @@ describe('DawEditorElement', () => {
     // Wait for Lit update cycle + rAF
     await new Promise((r) => setTimeout(r, 50));
 
-    const captureListeners = spy.mock.calls.filter(
-      ([, , opts]) => (opts as any)?.capture === true
-    );
+    const captureListeners = spy.mock.calls.filter(([, , opts]) => (opts as any)?.capture === true);
     expect(captureListeners.length).toBeGreaterThanOrEqual(2);
 
     document.body.removeChild(el);
@@ -76,11 +74,9 @@ describe('DawEditorElement', () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    const captureListeners = spy.mock.calls.filter(
-      ([type]) => type === 'pointerdown' || type === 'keydown'
-    ).filter(
-      ([, , opts]) => (opts as any)?.capture === true
-    );
+    const captureListeners = spy.mock.calls
+      .filter(([type]) => type === 'pointerdown' || type === 'keydown')
+      .filter(([, , opts]) => (opts as any)?.capture === true);
     expect(captureListeners.length).toBe(0);
 
     document.body.removeChild(el);
@@ -97,8 +93,7 @@ describe('DawEditorElement', () => {
 
     const docCapture = docSpy.mock.calls.filter(
       ([type, , opts]) =>
-        (type === 'pointerdown' || type === 'keydown') &&
-        (opts as any)?.capture === true
+        (type === 'pointerdown' || type === 'keydown') && (opts as any)?.capture === true
     );
     expect(docCapture.length).toBeGreaterThanOrEqual(2);
 

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -5,6 +5,7 @@ export class AudioResumeController implements ReactiveController {
   private _host: ReactiveControllerHost & HTMLElement;
   private _target: EventTarget | null = null;
   private _attached = false;
+  private _generation = 0;
 
   /** CSS selector, or 'document'. When undefined, controller is inert. */
   target?: string;
@@ -17,7 +18,9 @@ export class AudioResumeController implements ReactiveController {
   hostConnected() {
     // Defer to next frame so Lit's willUpdate() can set `target` from
     // the host's attribute before we read it. Same pattern as ViewportController.
+    const gen = ++this._generation;
     requestAnimationFrame(() => {
+      if (gen !== this._generation) return; // stale callback from previous connect
       if (!this._host.isConnected || this._attached || this.target === undefined) return;
 
       let resolvedTarget: EventTarget | null;

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -59,9 +59,7 @@ export class AudioResumeController implements ReactiveController {
 
     const el = document.querySelector(t);
     if (!el) {
-      console.warn(
-        '[dawcore] AudioResumeController: target not found for "' + t + '", using host'
-      );
+      console.warn('[dawcore] AudioResumeController: target not found for "' + t + '", using host');
       return this._host;
     }
     return el;

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -20,7 +20,18 @@ export class AudioResumeController implements ReactiveController {
     requestAnimationFrame(() => {
       if (!this._host.isConnected || this._attached || this.target === undefined) return;
 
-      const resolvedTarget = this._resolveTarget();
+      let resolvedTarget: EventTarget | null;
+      try {
+        resolvedTarget = this._resolveTarget();
+      } catch (err) {
+        console.warn(
+          '[dawcore] AudioResumeController: failed to resolve target "' +
+            this.target +
+            '": ' +
+            String(err)
+        );
+        return;
+      }
       if (!resolvedTarget) return;
 
       this._target = resolvedTarget;
@@ -42,7 +53,11 @@ export class AudioResumeController implements ReactiveController {
   }
 
   private _onGesture = (e: Event) => {
-    resumeGlobalAudioContext();
+    resumeGlobalAudioContext().catch((err) => {
+      console.warn(
+        '[dawcore] AudioResumeController: eager resume failed, will retry on play: ' + String(err)
+      );
+    });
     // Remove the other listener (the fired one was auto-removed by { once: true })
     const otherType = e.type === 'pointerdown' ? 'keydown' : 'pointerdown';
     this._target?.removeEventListener(otherType, this._onGesture, {
@@ -59,7 +74,12 @@ export class AudioResumeController implements ReactiveController {
 
     const el = document.querySelector(t);
     if (!el) {
-      console.warn('[dawcore] AudioResumeController: target not found for "' + t + '", using host');
+      console.warn(
+        '[dawcore] AudioResumeController: target "' +
+          t +
+          '" not found in DOM at attach time, falling back to host element. ' +
+          'Ensure the target exists before <daw-editor> connects.'
+      );
       return this._host;
     }
     return el;

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -1,0 +1,80 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
+
+export class AudioResumeController implements ReactiveController {
+  private _host: ReactiveControllerHost & HTMLElement;
+  private _target: EventTarget | null = null;
+  private _attached = false;
+
+  /** CSS selector, or 'document'. When undefined, controller is inert. */
+  target?: string;
+
+  constructor(host: ReactiveControllerHost & HTMLElement) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    // Defer to next frame so Lit's willUpdate() can set `target` from
+    // the host's attribute before we read it. Same pattern as ViewportController.
+    requestAnimationFrame(() => {
+      if (!this._host.isConnected || this._attached || this.target === undefined) return;
+
+      const resolvedTarget = this._resolveTarget();
+      if (!resolvedTarget) return;
+
+      this._target = resolvedTarget;
+      this._attached = true;
+      resolvedTarget.addEventListener('pointerdown', this._onGesture, {
+        once: true,
+        capture: true,
+      });
+      resolvedTarget.addEventListener('keydown', this._onGesture, {
+        once: true,
+        capture: true,
+      });
+    });
+  }
+
+  hostDisconnected() {
+    this._removeListeners();
+    this._attached = false;
+  }
+
+  private _onGesture = (e: Event) => {
+    resumeGlobalAudioContext();
+    // Remove the other listener (the fired one was auto-removed by { once: true })
+    const otherType = e.type === 'pointerdown' ? 'keydown' : 'pointerdown';
+    this._target?.removeEventListener(otherType, this._onGesture, {
+      capture: true,
+    });
+    this._target = null;
+  };
+
+  private _resolveTarget(): EventTarget | null {
+    const t = this.target;
+    if (t === undefined) return null;
+    if (t === '') return this._host;
+    if (t === 'document') return document;
+
+    const el = document.querySelector(t);
+    if (!el) {
+      console.warn(
+        '[dawcore] AudioResumeController: target not found for "' + t + '", using host'
+      );
+      return this._host;
+    }
+    return el;
+  }
+
+  private _removeListeners() {
+    if (!this._target) return;
+    this._target.removeEventListener('pointerdown', this._onGesture, {
+      capture: true,
+    });
+    this._target.removeEventListener('keydown', this._onGesture, {
+      capture: true,
+    });
+    this._target = null;
+  }
+}

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -10,6 +10,7 @@ import type { PlaylistEngine } from '@waveform-playlist/engine';
 import '../elements/daw-track-controls';
 import { hostStyles } from '../styles/theme';
 import { ViewportController } from '../controllers/viewport-controller';
+import { AudioResumeController } from '../controllers/audio-resume-controller';
 import { PointerHandler } from '../interactions/pointer-handler';
 import type {
   DawSelectionDetail,
@@ -82,6 +83,8 @@ export class DawEditorElement extends LitElement {
   _peakPipeline = new PeakPipeline();
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
+  private _audioResume = new AudioResumeController(this);
+  @property({ attribute: 'eager-resume' }) eagerResume?: string;
   private _pointer = new PointerHandler(this);
   private _viewport = (() => {
     const v = new ViewportController(this);
@@ -222,6 +225,10 @@ export class DawEditorElement extends LitElement {
   }
 
   willUpdate(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('eagerResume')) {
+      this._audioResume.target = this.eagerResume;
+    }
+
     // Re-extract peaks at new zoom level from cached WaveformData (near-instant)
     if (changedProperties.has('samplesPerPixel') && this._clipBuffers.size > 0) {
       const reextracted = this._peakPipeline.reextractPeaks(

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { ClipTrack, FadeType, Peaks, PeakData } from '@waveform-playlist/core';
+import type { TrackDescriptor, ClipDescriptor } from '../types';
 import { createClipFromSeconds, createTrack, clipPixelWidth } from '@waveform-playlist/core';
 import { PeakPipeline } from '../workers/peakPipeline';
 import type { DawTrackElement } from './daw-track';
@@ -20,28 +21,6 @@ import type {
   LoadFilesResult,
 } from '../events';
 import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
-
-export interface TrackDescriptor {
-  name: string;
-  src: string;
-  volume: number;
-  pan: number;
-  muted: boolean;
-  soloed: boolean;
-  clips: ClipDescriptor[];
-}
-
-interface ClipDescriptor {
-  src: string;
-  start: number;
-  duration: number;
-  offset: number;
-  gain: number;
-  name: string;
-  fadeIn: number;
-  fadeOut: number;
-  fadeType: FadeType;
-}
 
 @customElement('daw-editor')
 export class DawEditorElement extends LitElement {
@@ -84,7 +63,8 @@ export class DawEditorElement extends LitElement {
   private _trackElements = new Map<string, DawTrackElement>();
   private _childObserver: MutationObserver | null = null;
   private _audioResume = new AudioResumeController(this);
-  @property({ attribute: 'eager-resume' }) eagerResume?: string;
+  @property({ attribute: 'eager-resume' })
+  eagerResume?: string;
   private _pointer = new PointerHandler(this);
   private _viewport = (() => {
     const v = new ViewportController(this);
@@ -228,7 +208,6 @@ export class DawEditorElement extends LitElement {
     if (changedProperties.has('eagerResume')) {
       this._audioResume.target = this.eagerResume;
     }
-
     // Re-extract peaks at new zoom level from cached WaveformData (near-instant)
     if (changedProperties.has('samplesPerPixel') && this._clipBuffers.size > 0) {
       const reextracted = this._peakPipeline.reextractPeaks(

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -27,6 +27,7 @@ export { DawTrackControlsElement } from './elements/daw-track-controls';
 
 export { AudioResumeController } from './controllers/audio-resume-controller';
 
+export type { TrackDescriptor, ClipDescriptor } from './types';
 export type { PointerEngineContract } from './interactions/pointer-handler';
 
 export type {

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -25,6 +25,8 @@ export { DawRulerElement } from './elements/daw-ruler';
 export { DawSelectionElement } from './elements/daw-selection';
 export { DawTrackControlsElement } from './elements/daw-track-controls';
 
+export { AudioResumeController } from './controllers/audio-resume-controller';
+
 export type { PointerEngineContract } from './interactions/pointer-handler';
 
 export type {

--- a/packages/dawcore/src/interactions/file-loader.ts
+++ b/packages/dawcore/src/interactions/file-loader.ts
@@ -7,7 +7,7 @@ import type { ClipTrack, PeakData } from '@waveform-playlist/core';
 import { createClipFromSeconds, createTrack } from '@waveform-playlist/core';
 import type { PeakPipeline } from '../workers/peakPipeline';
 import type { DawTrackIdDetail, DawFilesLoadErrorDetail, LoadFilesResult } from '../events';
-import type { TrackDescriptor } from '../elements/daw-editor';
+import type { TrackDescriptor } from '../types';
 
 export interface FileLoaderHost {
   readonly samplesPerPixel: number;

--- a/packages/dawcore/src/types.ts
+++ b/packages/dawcore/src/types.ts
@@ -1,0 +1,23 @@
+import type { FadeType } from '@waveform-playlist/core';
+
+export interface TrackDescriptor {
+  name: string;
+  src: string;
+  volume: number;
+  pan: number;
+  muted: boolean;
+  soloed: boolean;
+  clips: ClipDescriptor[];
+}
+
+export interface ClipDescriptor {
+  src: string;
+  start: number;
+  duration: number;
+  offset: number;
+  gain: number;
+  name: string;
+  fadeIn: number;
+  fadeOut: number;
+  fadeType: FadeType;
+}


### PR DESCRIPTION
## Summary
- Adds `AudioResumeController` — a Lit reactive controller that resumes the global AudioContext on the first user gesture (`pointerdown`/`keydown`), eliminating ~200-500ms first-play latency
- Wires it into `<daw-editor>` via the `eager-resume` attribute: `<daw-editor eager-resume="document">` listens on the whole page, `<daw-editor eager-resume>` listens on the editor itself, or pass a CSS selector
- Exports `AudioResumeController` from the package for standalone use on custom Lit elements
- Uses `resumeGlobalAudioContext()` (raw context resume), not `Tone.start()` which adds ~2s Safari latency

## Test plan
- [ ] 8 unit tests for AudioResumeController (inert mode, pointerdown, keydown, one-shot, disconnect cleanup, document target, CSS selector, fallback)
- [ ] 3 integration tests for `<daw-editor>` (eager-resume attribute, document target, no listeners without attribute)
- [ ] Manual: open dev page with `<daw-editor eager-resume="document">`, click anywhere, then play — first play should have no perceptible delay
- [ ] Manual: without `eager-resume`, first play still works (just with the normal ~200-500ms init delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)