### PR TITLE
feat(dawcore): incremental canvas rendering for daw-waveform

### DIFF
--- a/docs/superpowers/plans/2026-03-20-incremental-canvas-render.md
+++ b/docs/superpowers/plans/2026-03-20-incremental-canvas-render.md
@@ -1,0 +1,621 @@
+# Incremental Canvas Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add dirty pixel tracking to `daw-waveform` so only changed peak regions are cleared and redrawn, enabling efficient incremental rendering for recording.
+
+**Architecture:** Replace the current full-redraw-on-every-update approach with a dirty `Set<number>` of peak indices. A `requestAnimationFrame`-batched draw loop clears and redraws only the dirty region per canvas chunk. Full redraws (zoom, load) mark all peaks dirty through the same code path.
+
+**Tech Stack:** Lit web components, vitest + happy-dom, canvas 2D API
+
+**Spec:** `docs/superpowers/specs/2026-03-20-incremental-canvas-render-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `packages/dawcore/src/elements/daw-waveform.ts` | Dirty tracking, `updatePeaks()`, rAF draw, peaks getter/setter |
+| Modify | `packages/dawcore/src/__tests__/daw-waveform.test.ts` | Tests for incremental rendering |
+| Modify | `packages/dawcore/src/elements/daw-editor.ts` | Remove `.bits` binding from template |
+
+---
+
+### Task 1: Convert `peaks` from Lit `@property` to getter/setter with dirty marking
+
+**Files:**
+- Modify: `packages/dawcore/src/elements/daw-waveform.ts`
+- Modify: `packages/dawcore/src/__tests__/daw-waveform.test.ts`
+
+- [ ] **Step 1: Write tests for derived bits and peak count**
+
+Add to `packages/dawcore/src/__tests__/daw-waveform.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
+
+let rafCallbacks: Array<(time: number) => void>;
+
+function flushRaf() {
+  const cbs = rafCallbacks.splice(0);
+  cbs.forEach((cb) => cb(performance.now()));
+}
+
+beforeAll(async () => {
+  await import('../elements/daw-waveform');
+});
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: (time: number) => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  vi.stubGlobal('devicePixelRatio', 1);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+```
+
+Replace the existing `'has default property values'` test and add:
+
+```typescript
+  it('has default property values', () => {
+    const el = document.createElement('daw-waveform') as any;
+    expect(el.waveHeight).toBe(128);
+    expect(el.barWidth).toBe(1);
+    expect(el.barGap).toBe(0);
+    expect(el.length).toBe(0);
+    expect(el.peaks).toBeInstanceOf(Int16Array);
+    expect(el.peaks.length).toBe(0);
+  });
+
+  it('derives bits=8 from Int8Array peaks', () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.peaks = new Int8Array([0, 10, -5, 20]);
+    expect(el.bits).toBe(8);
+  });
+
+  it('derives bits=16 from Int16Array peaks (default)', () => {
+    const el = document.createElement('daw-waveform') as any;
+    expect(el.bits).toBe(16); // default Int16Array
+    el.peaks = new Int16Array([0, 1000, -500, 2000]);
+    expect(el.bits).toBe(16);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: Tests should still pass (peaks property exists). This is the baseline.
+
+- [ ] **Step 3: Convert peaks from @property to getter/setter**
+
+In `packages/dawcore/src/elements/daw-waveform.ts`, replace:
+
+```typescript
+@property({ type: Object, attribute: false }) peaks: Peaks = new Int16Array(0);
+@property({ type: Number, attribute: false }) bits: Bits = 16;
+```
+
+With:
+
+```typescript
+private _peaks: Peaks = new Int16Array(0);
+private _dirtyPixels: Set<number> = new Set();
+private _drawScheduled = false;
+
+set peaks(value: Peaks) {
+  this._peaks = value;
+  this._markAllDirty();
+  this.requestUpdate();
+}
+
+get peaks(): Peaks {
+  return this._peaks;
+}
+```
+
+Keep the `Bits` import (needed for the getter return type):
+
+```typescript
+import type { Peaks, Bits } from '@waveform-playlist/core';
+```
+
+Add public getter to derive bits from the typed array:
+
+```typescript
+get bits(): Bits {
+  return this._peaks instanceof Int8Array ? 8 : 16;
+}
+```
+
+Add `_markAllDirty()`:
+
+```typescript
+private _markAllDirty() {
+  const peakCount = Math.floor(this._peaks.length / 2);
+  for (let i = 0; i < peakCount; i++) {
+    this._dirtyPixels.add(i);
+  }
+  this._scheduleDraw();
+}
+
+private _rafId = 0;
+
+private _scheduleDraw() {
+  if (!this._drawScheduled) {
+    this._drawScheduled = true;
+    this._rafId = requestAnimationFrame(() => {
+      this._drawScheduled = false;
+      this._drawDirty();
+    });
+  }
+}
+
+disconnectedCallback() {
+  super.disconnectedCallback();
+  if (this._drawScheduled) {
+    cancelAnimationFrame(this._rafId);
+    this._drawScheduled = false;
+  }
+  this._dirtyPixels.clear();
+}
+```
+
+Add empty `_drawDirty()` stub (implemented in Task 2):
+
+```typescript
+private _drawDirty() {
+  this._dirtyPixels.clear();
+}
+```
+
+Update `_drawVisibleChunks()` to use `this._peaks` and `this.bits` (the public getter) instead of the old `this.peaks` and `this.bits` property references. The `this.bits` getter derives from `this._peaks`, so it still works correctly.
+
+Update `updated()` to mark all dirty instead of drawing directly:
+
+```typescript
+updated() {
+  this._markAllDirty();
+}
+```
+
+**Note:** When `.peaks` is set, `_markAllDirty()` is called twice: once from the setter, once from `updated()` (triggered by `requestUpdate()`). This is harmless — the Set deduplicates, and only one rAF draw is scheduled. The double-mark ensures new canvas chunks created by Lit's re-render also get drawn.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/dawcore/src/elements/daw-waveform.ts packages/dawcore/src/__tests__/daw-waveform.test.ts
+git commit -m "refactor(dawcore): convert daw-waveform peaks to getter/setter with dirty tracking
+
+Remove bits @property — derived from typed array (Int8Array→8, Int16Array→16).
+Add _dirtyPixels Set, _markAllDirty(), _scheduleDraw() scaffolding.
+updated() marks all dirty instead of drawing directly."
+```
+
+---
+
+### Task 2: Implement rAF-batched dirty drawing
+
+**Files:**
+- Modify: `packages/dawcore/src/elements/daw-waveform.ts`
+- Modify: `packages/dawcore/src/__tests__/daw-waveform.test.ts`
+
+- [ ] **Step 1: Write tests for full redraw via dirty path**
+
+Add to the test file:
+
+```typescript
+  it('calls clearRect on full canvas width when peaks are set', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    document.body.appendChild(el);
+
+    // Wait for Lit render to create canvas elements
+    await new Promise((r) => setTimeout(r, 50));
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+    const ctx = canvas.getContext('2d');
+    const clearSpy = vi.spyOn(ctx, 'clearRect');
+
+    // Set peaks — marks all dirty
+    el.peaks = new Int16Array([0, 100, -50, 200, 0, 150, -100, 300]);
+    flushRaf();
+
+    expect(clearSpy).toHaveBeenCalled();
+    // clearRect should cover the full canvas width (4 peak pairs = 4 pixels)
+    const [, , width] = clearSpy.mock.calls[0];
+    expect(width).toBeGreaterThan(0);
+
+    document.body.removeChild(el);
+  });
+
+  it('skips draw when dirty set is empty', () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    document.body.appendChild(el);
+
+    // Flush any pending draws from mount
+    flushRaf();
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    if (canvas) {
+      const ctx = canvas.getContext('2d');
+      const clearSpy = vi.spyOn(ctx, 'clearRect');
+
+      // No peaks set, no updatePeaks called — dirty set should be empty
+      flushRaf();
+      expect(clearSpy).not.toHaveBeenCalled();
+    }
+
+    document.body.removeChild(el);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: FAIL — `_drawDirty()` is a stub that just clears the set
+
+- [ ] **Step 3: Implement `_drawDirty()` with partial clear**
+
+Replace the `_drawDirty()` stub in `daw-waveform.ts`:
+
+```typescript
+private _drawDirty() {
+  if (this._dirtyPixels.size === 0 || this.length === 0 || this._peaks.length === 0) {
+    this._dirtyPixels.clear();
+    return;
+  }
+
+  const canvases = this.shadowRoot?.querySelectorAll('canvas');
+  if (!canvases || canvases.length === 0) {
+    this._dirtyPixels.clear();
+    return;
+  }
+
+  const step = this.barWidth + this.barGap;
+  const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
+  const halfHeight = this.waveHeight / 2;
+  const bits = this.bits;
+  const waveColor =
+    getComputedStyle(this).getPropertyValue('--daw-wave-color').trim() || '#c49a6c';
+
+  // Group dirty peak indices by chunk
+  const dirtyByChunk = new Map<number, { min: number; max: number }>();
+  for (const peakIdx of this._dirtyPixels) {
+    const chunkIdx = Math.floor(peakIdx / MAX_CANVAS_WIDTH);
+    const existing = dirtyByChunk.get(chunkIdx);
+    if (existing) {
+      existing.min = Math.min(existing.min, peakIdx);
+      existing.max = Math.max(existing.max, peakIdx);
+    } else {
+      dirtyByChunk.set(chunkIdx, { min: peakIdx, max: peakIdx });
+    }
+  }
+
+  for (const canvas of canvases) {
+    const chunkIdx = Number(canvas.dataset.index);
+    const range = dirtyByChunk.get(chunkIdx);
+    if (!range) continue;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) continue;
+
+    const globalOffset = chunkIdx * MAX_CANVAS_WIDTH;
+
+    // Convert dirty peak range to local pixel coordinates
+    const dirtyLocalStart = range.min - globalOffset;
+    const dirtyLocalEnd = range.max - globalOffset;
+
+    // Align to bar boundaries
+    const firstBar = calculateFirstBarPosition(
+      globalOffset + dirtyLocalStart,
+      this.barWidth,
+      step
+    );
+    const clearStart = Math.max(0, firstBar - globalOffset);
+    const clearEnd = dirtyLocalEnd + this.barWidth;
+    const clearWidth = clearEnd - clearStart;
+
+    // Partial clear
+    ctx.resetTransform();
+    ctx.clearRect(
+      clearStart * dpr,
+      0,
+      clearWidth * dpr,
+      canvas.height
+    );
+    ctx.scale(dpr, dpr);
+    ctx.fillStyle = waveColor;
+
+    // Draw only bars in the dirty region
+    const canvasWidth = Math.min(MAX_CANVAS_WIDTH, this.length - globalOffset);
+    const regionEnd = Math.min(globalOffset + clearEnd, globalOffset + canvasWidth);
+
+    for (let bar = Math.max(0, firstBar); bar < regionEnd; bar += step) {
+      const peak = aggregatePeaks(this._peaks, bits, bar, bar + step);
+      if (!peak) continue;
+      const rects = calculateBarRects(
+        bar - globalOffset,
+        this.barWidth,
+        halfHeight,
+        peak.min,
+        peak.max,
+        'normal'
+      );
+      for (const r of rects) {
+        ctx.fillRect(r.x, r.y, r.width, r.height);
+      }
+    }
+  }
+
+  this._dirtyPixels.clear();
+}
+```
+
+Remove the old `_drawVisibleChunks()` method entirely.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/dawcore/src/elements/daw-waveform.ts packages/dawcore/src/__tests__/daw-waveform.test.ts
+git commit -m "feat(dawcore): implement rAF-batched dirty drawing in daw-waveform
+
+_drawDirty() groups dirty peak indices by chunk, does partial clearRect,
+and redraws only bars in the dirty region. Replaces _drawVisibleChunks()."
+```
+
+---
+
+### Task 3: Implement `updatePeaks()` for incremental updates
+
+**Files:**
+- Modify: `packages/dawcore/src/elements/daw-waveform.ts`
+- Modify: `packages/dawcore/src/__tests__/daw-waveform.test.ts`
+
+- [ ] **Step 1: Write tests for updatePeaks**
+
+```typescript
+  it('updatePeaks marks only the specified range dirty', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 200;
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Set initial peaks (10 pairs = 10 pixels)
+    el.peaks = new Int16Array(20);
+    flushRaf(); // flush the full draw
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    const ctx = canvas?.getContext('2d');
+    const clearSpy = vi.spyOn(ctx, 'clearRect');
+
+    // Incremental update: only pixels 8-9 changed
+    el.updatePeaks(8, 10);
+    flushRaf();
+
+    expect(clearSpy).toHaveBeenCalled();
+    // clearRect x should be near pixel 8, NOT 0
+    const [x] = clearSpy.mock.calls[0];
+    expect(x).toBeGreaterThanOrEqual(8);
+
+    document.body.removeChild(el);
+  });
+
+  it('batches multiple updatePeaks into single rAF draw', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 200;
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+
+    el.peaks = new Int16Array(20);
+    flushRaf();
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    const ctx = canvas?.getContext('2d');
+    const clearSpy = vi.spyOn(ctx, 'clearRect');
+
+    // Two incremental updates before rAF fires
+    el.updatePeaks(2, 4);
+    el.updatePeaks(7, 9);
+    flushRaf();
+
+    // Should be one clearRect call covering the merged range (2-9)
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    const [x, , width] = clearSpy.mock.calls[0];
+    // Should cover from pixel 2 to pixel 9
+    expect(x).toBeLessThanOrEqual(2);
+    expect(x + width).toBeGreaterThanOrEqual(9);
+
+    document.body.removeChild(el);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: FAIL — `updatePeaks` is not defined
+
+- [ ] **Step 3: Implement `updatePeaks()`**
+
+Add to `daw-waveform.ts`:
+
+```typescript
+/**
+ * Mark a range of peak indices as dirty for incremental redraw.
+ * The caller must have already updated the underlying peaks array.
+ * Does NOT trigger a Lit re-render — bypasses Lit entirely.
+ */
+updatePeaks(startIndex: number, endIndex: number) {
+  for (let i = startIndex; i < endIndex; i++) {
+    this._dirtyPixels.add(i);
+  }
+  this._scheduleDraw();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/dawcore/src/elements/daw-waveform.ts packages/dawcore/src/__tests__/daw-waveform.test.ts
+git commit -m "feat(dawcore): add updatePeaks() for incremental rendering
+
+Marks a range of peak indices as dirty without triggering Lit re-render.
+Multiple calls batched into single rAF draw."
+```
+
+---
+
+### Task 4: Handle layout property changes (waveHeight, barWidth, barGap)
+
+**Files:**
+- Modify: `packages/dawcore/src/__tests__/daw-waveform.test.ts`
+
+- [ ] **Step 1: Write test for layout change triggering full dirty**
+
+```typescript
+  it('marks all dirty when waveHeight changes', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    el.peaks = new Int16Array([0, 100, -50, 200, 0, 150, -100, 300]);
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+    flushRaf(); // initial draw
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    const ctx = canvas?.getContext('2d');
+    const clearSpy = vi.spyOn(ctx, 'clearRect');
+
+    el.waveHeight = 256;
+    await new Promise((r) => setTimeout(r, 50));
+    flushRaf();
+
+    expect(clearSpy).toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+```
+
+- [ ] **Step 2: Run test — should pass**
+
+Run: `cd packages/dawcore && npx vitest run src/__tests__/daw-waveform.test.ts`
+Expected: PASS — `updated()` already calls `_markAllDirty()` on any Lit property change (including `waveHeight`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/dawcore/src/__tests__/daw-waveform.test.ts
+git commit -m "test(dawcore): verify layout property changes trigger full redraw"
+```
+
+---
+
+### Task 5: Remove `.bits` from daw-editor template and verify build
+
+**Files:**
+- Modify: `packages/dawcore/src/elements/daw-editor.ts`
+
+- [ ] **Step 1: Remove `.bits` binding from daw-editor template**
+
+In `packages/dawcore/src/elements/daw-editor.ts`, find the `daw-waveform` template (around line 749-761) and remove:
+
+```typescript
+.bits=${16}
+```
+
+So the template becomes:
+
+```html
+<daw-waveform
+  style="position: absolute; left: ${clipLeft}px; top: ${chIdx * channelHeight}px;"
+  .peaks=${channelPeaks}
+  .length=${peakData?.length ?? width}
+  .waveHeight=${channelHeight}
+  .barWidth=${this.barWidth}
+  .barGap=${this.barGap}
+  .visibleStart=${this._viewport.visibleStart}
+  .visibleEnd=${this._viewport.visibleEnd}
+  .originX=${clipLeft}
+></daw-waveform>
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd packages/dawcore && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd packages/dawcore && pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 4: Run lint**
+
+Run: `pnpm format && pnpm lint`
+Expected: No errors (warnings only)
+
+- [ ] **Step 5: Build**
+
+Run: `pnpm --filter @dawcore/components build`
+Expected: Clean build
+
+- [ ] **Step 6: Verify daw-editor line count**
+
+Run: `wc -l packages/dawcore/src/elements/daw-editor.ts`
+Expected: <= 779 (removed 1 line)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/dawcore/src/elements/daw-editor.ts
+git commit -m "refactor(dawcore): remove .bits binding from daw-editor template
+
+bits is now derived from the peaks typed array (Int8Array→8, Int16Array→16)."
+```
+
+---
+
+### Task 6: Update CLAUDE.md and existing tests
+
+**Files:**
+- Modify: `packages/dawcore/CLAUDE.md`
+- Modify: `packages/dawcore/src/__tests__/daw-waveform.test.ts` (update default property test if `bits` was checked)
+
+- [ ] **Step 1: Update daw-waveform section in CLAUDE.md**
+
+In the "Visual elements" section of `packages/dawcore/CLAUDE.md`, update the `<daw-waveform>` entry:
+
+```markdown
+- `<daw-waveform>` — Chunked canvas rendering (1000px chunks). Receives peaks as JS properties. Uses dirty pixel tracking for incremental rendering — `updatePeaks(startIndex, endIndex)` marks a range dirty without full redraw. Bits derived from typed array (Int8Array→8, Int16Array→16). Drawing batched via `requestAnimationFrame`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/dawcore/CLAUDE.md
+git commit -m "docs(dawcore): document incremental rendering in CLAUDE.md"
+```

--- a/docs/superpowers/specs/2026-03-20-incremental-canvas-render-design.md
+++ b/docs/superpowers/specs/2026-03-20-incremental-canvas-render-design.md
@@ -1,0 +1,153 @@
+# Incremental Canvas Rendering — Design Spec
+
+**Date:** 2026-03-20
+**Scope:** `@dawcore/components` — `daw-waveform` element only
+**Branch:** `feat/incremental-canvas-render`
+
+## Problem
+
+`daw-waveform` does a full `clearRect()` + redraw of every bar in every visible canvas chunk on any peak update. During recording, new peaks arrive at ~60fps but only 1-2 pixels change per frame. Redrawing thousands of bars 60 times per second is wasteful.
+
+## Solution
+
+Add dirty pixel tracking to `daw-waveform`. A `Set<number>` tracks which peak indices need redrawing. On each animation frame, only the dirty region is cleared and redrawn. Full redraws still happen on zoom, load, and layout changes — they just mark all peaks dirty through the same code path.
+
+Inspired by the mediabunny-worker-decoder pattern: dirty Set + running min/max + partial clearRect.
+
+## Coordinate System
+
+**Peak index** is the unit throughout. Peak index N corresponds to interleaved data at `peaks[N*2]` (min) and `peaks[N*2+1]` (max). When `barWidth=1, barGap=0`, peak index equals pixel column. When `barWidth > 1` or `barGap > 0`, the drawing loop maps peak indices to bar positions via `step = barWidth + barGap`. The dirty set stores peak indices, and the draw loop converts them to canvas pixel coordinates.
+
+## API
+
+### Full replacement (load, zoom, resize)
+
+```typescript
+// Setting .peaks marks all peak indices dirty and triggers redraw.
+// Also calls requestUpdate() to trigger Lit re-render (container sizing, chunk creation).
+waveform.peaks = newInt16Array;
+```
+
+- `bits` derived from array type: `Int8Array` → 8, `Int16Array` → 16
+- No separate `bits` property
+
+### Incremental update (recording append, partial redraw)
+
+```typescript
+// Caller has already mutated/replaced the peaks array.
+// This marks only the specified peak index range as dirty.
+// Does NOT trigger a Lit re-render — bypasses Lit entirely.
+waveform.updatePeaks(startIndex, endIndex);
+```
+
+`updatePeaks(start, end)` does NOT accept peak data — the caller is expected to have already updated the underlying array. The method just marks peak indices `start..end-1` dirty and schedules a rAF draw.
+
+### Container width: `length` stays
+
+The `length` property is retained as a Lit `@property` for container sizing. Per CLAUDE.md pattern #24, clip pixel width can differ from `peaks.length / 2` (audio may be shorter than configured clip duration). The editor sets `length` for the container `<div>` width and chunk calculations. Peak data length (`_peaks.length / 2`) controls how many bars are drawn; `length` controls how wide the container is.
+
+### Remaining Lit properties
+
+- `length: number` — container/clip pixel width (set by editor)
+- `waveHeight: number` — canvas height
+- `barWidth: number` — bar width in pixels
+- `barGap: number` — gap between bars
+- `visibleStart / visibleEnd / originX` — viewport (from ViewportController)
+
+Changes to `waveHeight`, `barWidth`, or `barGap` mark all peaks dirty (layout changed). Viewport changes trigger Lit re-render (add/remove canvas chunks); newly created canvases are blank and need a full draw — `updated()` marks all visible peaks dirty.
+
+## Internal State
+
+```typescript
+// Mutable — NOT a Lit @property (avoids triggering Lit re-renders on updatePeaks)
+private _peaks: Peaks = new Int16Array(0);
+
+// Dirty peak indices needing redraw
+private _dirtyPixels: Set<number> = new Set();
+
+// Whether a rAF draw is already scheduled
+private _drawScheduled = false;
+```
+
+### `.peaks` setter
+
+```typescript
+set peaks(value: Peaks) {
+  this._peaks = value;
+  this._markAllDirty();
+  this.requestUpdate();  // Trigger Lit re-render for container sizing
+}
+get peaks(): Peaks {
+  return this._peaks;
+}
+```
+
+The setter calls `requestUpdate()` so Lit re-runs `render()` (updates container width, creates/destroys canvas chunks). It also marks all peaks dirty so the scheduled rAF redraws everything.
+
+## Drawing Algorithm
+
+When peaks are marked dirty, schedule a single `requestAnimationFrame` if one isn't already pending. The rAF callback:
+
+1. If dirty set is empty → return
+2. Compute bits from `_peaks` type, peak count from `_peaks.length / 2`
+3. Query canvases from Shadow DOM: `shadowRoot.querySelectorAll('canvas')`
+4. Group dirty peak indices by canvas chunk (`Math.floor(index / MAX_CANVAS_WIDTH)`)
+5. Per chunk with dirty peaks:
+   - Get canvas context, apply `ctx.scale(dpr, dpr)` transform
+   - Find min/max dirty peak index within that chunk → convert to local pixel coordinates
+   - `clearRect(minLocalX, 0, dirtyWidth, height)` — partial clear (in scaled coordinates, after `ctx.scale`)
+   - Draw only bars that overlap the dirty region using the existing `aggregatePeaks` + `calculateBarRects` + `fillRect` loop
+   - `ctx.resetTransform()` before `clearRect` to work in physical pixels, then `ctx.scale(dpr, dpr)` for drawing — OR — do both clear and draw in scaled coordinates. Implementation will follow the cleaner pattern.
+6. Clear the dirty set and `_drawScheduled` flag
+
+### Lit `updated()` behavior
+
+`updated()` no longer calls `_drawVisibleChunks()` directly. Instead, it marks all visible peaks dirty and schedules a rAF draw. This prevents double-drawing (once from `updated()` synchronously, once from rAF). All drawing goes through the single rAF path.
+
+Canvas chunks may be created or destroyed during Lit's render. The rAF callback always queries fresh canvases from Shadow DOM, so it naturally sees the current set of canvases — no stale references.
+
+### When Lit render does NOT run
+
+`updatePeaks(startIndex, endIndex)` bypasses Lit entirely — it marks peak indices dirty and schedules a rAF draw without triggering a Lit update. This is the fast path for recording. The caller must ensure `length` is already correct (or set it separately if the clip grew).
+
+## Dirty Marking Rules
+
+| Trigger | Peaks marked dirty |
+|---------|-------------------|
+| `.peaks` setter | All (`0..peakCount-1`) |
+| `updatePeaks(start, end)` | Range `start..end-1` |
+| `waveHeight` change | All |
+| `barWidth` / `barGap` change | All |
+| `updated()` (after Lit re-render) | All visible (ensures new canvas chunks get drawn) |
+
+## Integration with `daw-editor`
+
+**Minimal changes to `daw-editor.ts`.** Remove `.bits` from the template binding (derived from array type). Keep `.length` (needed for container sizing). The editor continues using the full-replacement path (setting `.peaks` via Lit property binding). The incremental `updatePeaks()` API is available for when recording support is added to dawcore.
+
+## Testing
+
+### Unit tests for `daw-waveform`:
+
+1. Full redraw on `.peaks` set — clearRect covers full canvas width
+2. Incremental `updatePeaks(start, end)` — clearRect covers only the dirty region
+3. Multiple `updatePeaks` calls batched into single rAF — one draw covers both ranges
+4. Empty dirty set skips draw — no clearRect called
+5. Bits derived from array type (Int8Array → 8, Int16Array → 16)
+6. Peak count derived from array (`peaks.length / 2`)
+7. `updated()` marks all visible peaks dirty (new canvas chunks drawn)
+8. `barWidth`/`barGap`/`waveHeight` change marks all dirty — full redraw
+
+**Mocking:** `requestAnimationFrame` stubbed (same pattern as `AudioResumeController` tests). Spy on canvas context `clearRect` and `fillRect` to verify partial vs full clears.
+
+## Files Changed
+
+- **Modified:** `packages/dawcore/src/elements/daw-waveform.ts` — dirty tracking, `updatePeaks()`, rAF-batched draw, peaks setter
+- **Modified:** `packages/dawcore/src/__tests__/daw-waveform.test.ts` — new/updated tests for incremental rendering
+- **Modified:** `packages/dawcore/src/elements/daw-editor.ts` — remove `.bits` from `daw-waveform` template binding
+
+## Non-Goals
+
+- OffscreenCanvas / web worker rendering — future optimization
+- Changes to the React browser package — separate rendering pipeline
+- Recording support in dawcore — this PR builds the incremental rendering capability; recording wiring comes later
+- Smart diffing of old vs new peaks — full replacement marks all dirty, incremental path is caller-directed

--- a/docs/superpowers/specs/2026-03-20-incremental-canvas-render-design.md
+++ b/docs/superpowers/specs/2026-03-20-incremental-canvas-render-design.md
@@ -116,6 +116,7 @@ Canvas chunks may be created or destroyed during Lit's render. The rAF callback 
 |---------|-------------------|
 | `.peaks` setter | All (`0..peakCount-1`) |
 | `updatePeaks(start, end)` | Range `start..end-1` |
+| `length` change | All |
 | `waveHeight` change | All |
 | `barWidth` / `barGap` change | All |
 | `updated()` (after Lit re-render) | All visible (ensures new canvas chunks get drawn) |

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -11,6 +11,7 @@
 **Testing gotchas:**
 - `isConnected` is a readonly getter in happy-dom — cannot be set via `Object.assign` on elements. Append the element to `document.body` instead.
 - Mocks for async functions (e.g., `resumeGlobalAudioContext`) must return `Promise.resolve()`, not `undefined`. Calling `.catch()` on `undefined` crashes.
+- `canvas.getContext('2d')` returns `null` in happy-dom. Tests must mock it: `vi.spyOn(canvas, 'getContext').mockReturnValue(mockCtx as any)` where `mockCtx` has `clearRect`, `resetTransform`, `scale`, `fillStyle`, `fillRect` as `vi.fn()`.
 
 **Dev page:** `pnpm dev:page` starts Vite at `http://localhost:5173/dev/index.html`. Uses `website/static/` as publicDir for audio files.
 
@@ -123,7 +124,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **`getVisibleChunkIndices()`** — Shared pure function in `utils/viewport.ts`, re-exported from `viewport-controller.ts`. Used by `daw-waveform._getVisibleChunkIndices()`.
 - **Permissive defaults** — Controller initializes `visibleStart=-Infinity, visibleEnd=Infinity` so all chunks render before scroll container is attached.
 - **`daw-waveform` props** — `visibleStart`, `visibleEnd`, `originX` control which 1000px canvas chunks are rendered. Defaults to all-visible when not set.
-- **File size budget** — `daw-editor.ts` is at exactly 800 lines (the hard max). Any new code in this file requires extracting something else first. `loadFiles` was already extracted to `interactions/file-loader.ts`.
+- **File size budget** — `daw-editor.ts` is at 778 lines (hard max: 800). `loadFiles` extracted to `interactions/file-loader.ts`; `TrackDescriptor`/`ClipDescriptor` extracted to `src/types.ts`.
 
 ## Track Controls
 
@@ -135,6 +136,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 ## File Loader Extraction
 
 - **`interactions/file-loader.ts`** — `loadFiles()` extracted via `FileLoaderHost` interface to keep editor under 800 lines.
+- **`src/types.ts`** — `TrackDescriptor` and `ClipDescriptor` interfaces, shared by `daw-editor.ts` and `file-loader.ts`. Re-exported from `index.ts`.
 - **Non-private fields** — Fields accessed by the loader (`_tracks`, `_engineTracks`, `_peaksData`, `_clipBuffers`, `_audioCache`, `_peakPipeline`, `_resolvedSampleRate`, `_fetchAndDecode`, `_recomputeDuration`, `_ensureEngine`) are non-private (no `private` keyword, `_` prefix convention only).
 
 ## Empty State

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -26,7 +26,7 @@
 - `<daw-track>` — Track data (name, volume, pan, muted, soloed). Dispatches `daw-track-connected` on mount, `daw-track-update` on property change. Track removal detected by editor's MutationObserver (not events — detached elements can't bubble).
 
 **Visual elements (Shadow DOM):**
-- `<daw-waveform>` — Chunked canvas rendering (1000px chunks). Receives peaks as JS properties.
+- `<daw-waveform>` — Chunked canvas rendering (1000px chunks). Receives peaks as JS properties. Uses dirty pixel tracking for incremental rendering — `updatePeaks(startIndex, endIndex)` marks a range dirty without full redraw. Bits derived from typed array (Int8Array→8, Int16Array→16). Drawing batched via `requestAnimationFrame`.
 - `<daw-playhead>` — RAF-animated vertical line via `AnimationController`.
 - `<daw-ruler>` — Temporal time scale with tick marks. Ported from `SmartScale` (temporal mode only, beats & bars deferred). Computes ticks once in `willUpdate()`, reused by both `render()` and `updated()`.
 

--- a/packages/dawcore/src/__tests__/daw-waveform.test.ts
+++ b/packages/dawcore/src/__tests__/daw-waveform.test.ts
@@ -62,4 +62,67 @@ describe('DawWaveformElement', () => {
     expect(el.shadowRoot).toBeTruthy();
     document.body.removeChild(el);
   });
+
+  it('calls clearRect on full canvas width when peaks are set', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    document.body.appendChild(el);
+
+    // Wait for Lit render to create canvas elements
+    await new Promise((r) => setTimeout(r, 50));
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    // happy-dom returns null for getContext('2d') — install a mock context
+    const mockCtx = {
+      clearRect: vi.fn(),
+      resetTransform: vi.fn(),
+      scale: vi.fn(),
+      fillRect: vi.fn(),
+      fillStyle: '',
+    };
+    vi.spyOn(canvas, 'getContext').mockReturnValue(mockCtx as any);
+
+    // Set peaks — marks all dirty
+    el.peaks = new Int16Array([0, 100, -50, 200, 0, 150, -100, 300]);
+    flushRaf();
+
+    expect(mockCtx.clearRect).toHaveBeenCalled();
+    // clearRect should cover the full canvas width (4 peak pairs = 4 pixels)
+    const [, , width] = mockCtx.clearRect.mock.calls[0];
+    expect(width).toBeGreaterThan(0);
+
+    document.body.removeChild(el);
+  });
+
+  it('skips draw when dirty set is empty', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    document.body.appendChild(el);
+
+    // Wait for Lit render to create canvas elements
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Flush any pending draws from mount
+    flushRaf();
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      resetTransform: vi.fn(),
+      scale: vi.fn(),
+      fillRect: vi.fn(),
+      fillStyle: '',
+    };
+    vi.spyOn(canvas!, 'getContext').mockReturnValue(mockCtx as any);
+
+    // No peaks set, no updatePeaks called — dirty set should be empty
+    flushRaf();
+    expect(mockCtx.clearRect).not.toHaveBeenCalled();
+
+    document.body.removeChild(el);
+  });
 });

--- a/packages/dawcore/src/__tests__/daw-waveform.test.ts
+++ b/packages/dawcore/src/__tests__/daw-waveform.test.ts
@@ -166,6 +166,34 @@ describe('DawWaveformElement', () => {
     document.body.removeChild(el);
   });
 
+  it('marks all dirty when waveHeight changes', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 100;
+    el.peaks = new Int16Array([0, 100, -50, 200, 0, 150, -100, 300]);
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+    flushRaf(); // initial draw
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      resetTransform: vi.fn(),
+      scale: vi.fn(),
+      fillStyle: '',
+      fillRect: vi.fn(),
+    };
+    vi.spyOn(canvas!, 'getContext').mockReturnValue(mockCtx as any);
+
+    el.waveHeight = 256;
+    await new Promise((r) => setTimeout(r, 50));
+    flushRaf();
+
+    expect(mockCtx.clearRect).toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+
   it('skips draw when dirty set is empty', async () => {
     const el = document.createElement('daw-waveform') as any;
     el.length = 100;

--- a/packages/dawcore/src/__tests__/daw-waveform.test.ts
+++ b/packages/dawcore/src/__tests__/daw-waveform.test.ts
@@ -96,6 +96,76 @@ describe('DawWaveformElement', () => {
     document.body.removeChild(el);
   });
 
+  it('updatePeaks marks only the specified range dirty', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 200;
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Set initial peaks (10 pairs = 10 pixels)
+    el.peaks = new Int16Array(20);
+    flushRaf(); // flush the full draw
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      resetTransform: vi.fn(),
+      scale: vi.fn(),
+      fillStyle: '',
+      fillRect: vi.fn(),
+    };
+    vi.spyOn(canvas!, 'getContext').mockReturnValue(mockCtx as any);
+
+    // Incremental update: only pixels 8-9 changed
+    el.updatePeaks(8, 10);
+    flushRaf();
+
+    expect(mockCtx.clearRect).toHaveBeenCalled();
+    // clearRect x should be near pixel 8, NOT 0 (dpr=1)
+    const [x] = mockCtx.clearRect.mock.calls[0];
+    expect(x).toBeGreaterThanOrEqual(8);
+
+    document.body.removeChild(el);
+  });
+
+  it('batches multiple updatePeaks into single rAF draw', async () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.length = 200;
+    document.body.appendChild(el);
+    await new Promise((r) => setTimeout(r, 50));
+
+    el.peaks = new Int16Array(20);
+    flushRaf();
+
+    const canvas = el.shadowRoot?.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      resetTransform: vi.fn(),
+      scale: vi.fn(),
+      fillStyle: '',
+      fillRect: vi.fn(),
+    };
+    vi.spyOn(canvas!, 'getContext').mockReturnValue(mockCtx as any);
+
+    // Two incremental updates before rAF fires
+    el.updatePeaks(2, 4);
+    el.updatePeaks(7, 9);
+    flushRaf();
+
+    // Should be one clearRect call covering the merged range
+    expect(mockCtx.clearRect).toHaveBeenCalledTimes(1);
+    const [x, , width] = mockCtx.clearRect.mock.calls[0];
+    // Should cover from pixel 2 to at least pixel 9
+    expect(x).toBeLessThanOrEqual(2);
+    expect(x + width).toBeGreaterThanOrEqual(9);
+
+    document.body.removeChild(el);
+  });
+
   it('skips draw when dirty set is empty', async () => {
     const el = document.createElement('daw-waveform') as any;
     el.length = 100;

--- a/packages/dawcore/src/__tests__/daw-waveform.test.ts
+++ b/packages/dawcore/src/__tests__/daw-waveform.test.ts
@@ -1,7 +1,31 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
+
+let rafCallbacks: Array<(time: number) => void>;
+
+function flushRaf() {
+  const cbs = rafCallbacks.splice(0);
+  cbs.forEach((cb) => cb(performance.now()));
+}
 
 beforeAll(async () => {
   await import('../elements/daw-waveform');
+});
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: (time: number) => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  vi.stubGlobal('devicePixelRatio', 1);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('DawWaveformElement', () => {
@@ -14,8 +38,22 @@ describe('DawWaveformElement', () => {
     expect(el.waveHeight).toBe(128);
     expect(el.barWidth).toBe(1);
     expect(el.barGap).toBe(0);
-    expect(el.bits).toBe(16);
     expect(el.length).toBe(0);
+    expect(el.peaks).toBeInstanceOf(Int16Array);
+    expect(el.peaks.length).toBe(0);
+  });
+
+  it('derives bits=8 from Int8Array peaks', () => {
+    const el = document.createElement('daw-waveform') as any;
+    el.peaks = new Int8Array([0, 10, -5, 20]);
+    expect(el.bits).toBe(8);
+  });
+
+  it('derives bits=16 from Int16Array peaks (default)', () => {
+    const el = document.createElement('daw-waveform') as any;
+    expect(el.bits).toBe(16);
+    el.peaks = new Int16Array([0, 1000, -500, 2000]);
+    expect(el.bits).toBe(16);
   });
 
   it('uses Shadow DOM', () => {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -750,7 +750,6 @@ export class DawEditorElement extends LitElement {
                         style="position: absolute; left: ${clipLeft}px; top: ${chIdx *
                         channelHeight}px;"
                         .peaks=${channelPeaks}
-                        .bits=${16}
                         .length=${peakData?.length ?? width}
                         .waveHeight=${channelHeight}
                         .barWidth=${this.barWidth}

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -66,6 +66,18 @@ export class DawWaveformElement extends LitElement {
     );
   }
 
+  /**
+   * Mark a range of peak indices as dirty for incremental redraw.
+   * The caller must have already updated the underlying peaks array.
+   * Does NOT trigger a Lit re-render — bypasses Lit entirely.
+   */
+  updatePeaks(startIndex: number, endIndex: number) {
+    for (let i = startIndex; i < endIndex; i++) {
+      this._dirtyPixels.add(i);
+    }
+    this._scheduleDraw();
+  }
+
   private _markAllDirty() {
     const peakCount = Math.floor(this._peaks.length / 2);
     for (let i = 0; i < peakCount; i++) {

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -10,12 +10,43 @@ import { getVisibleChunkIndices } from '../utils/viewport';
 
 const MAX_CANVAS_WIDTH = 1000;
 
+/** Layout/data properties that require a full redraw when changed. */
+const LAYOUT_PROPS = new Set(['length', 'waveHeight', 'barWidth', 'barGap']);
+
+/**
+ * Group dirty peak indices by canvas chunk, mapping peak indices to bar pixel
+ * positions for correct chunk assignment when barWidth > 1 or barGap > 0.
+ */
+function groupDirtyByChunk(
+  dirtyPixels: Set<number>,
+  step: number
+): Map<number, { min: number; max: number }> {
+  const dirtyByChunk = new Map<number, { min: number; max: number }>();
+  for (const peakIdx of dirtyPixels) {
+    // Map peak index to its bar's global pixel position
+    const barPixel = Math.floor(peakIdx / step) * step;
+    const chunkIdx = Math.floor(barPixel / MAX_CANVAS_WIDTH);
+    const existing = dirtyByChunk.get(chunkIdx);
+    if (existing) {
+      dirtyByChunk.set(chunkIdx, {
+        min: Math.min(existing.min, peakIdx),
+        max: Math.max(existing.max, peakIdx),
+      });
+    } else {
+      dirtyByChunk.set(chunkIdx, { min: peakIdx, max: peakIdx });
+    }
+  }
+  return dirtyByChunk;
+}
+
 @customElement('daw-waveform')
 export class DawWaveformElement extends LitElement {
   private _peaks: Peaks = new Int16Array(0);
   private _dirtyPixels: Set<number> = new Set();
   private _drawScheduled = false;
   private _rafId = 0;
+  /** Chunk indices that were drawn in the last frame — used to detect new chunks on scroll. */
+  private _drawnChunks: Set<number> = new Set();
 
   set peaks(value: Peaks) {
     this._peaks = value;
@@ -72,7 +103,10 @@ export class DawWaveformElement extends LitElement {
    * Does NOT trigger a Lit re-render — bypasses Lit entirely.
    */
   updatePeaks(startIndex: number, endIndex: number) {
-    for (let i = startIndex; i < endIndex; i++) {
+    const peakCount = Math.floor(this._peaks.length / 2);
+    const clampedStart = Math.max(0, startIndex);
+    const clampedEnd = Math.min(peakCount, endIndex);
+    for (let i = clampedStart; i < clampedEnd; i++) {
       this._dirtyPixels.add(i);
     }
     this._scheduleDraw();
@@ -115,71 +149,73 @@ export class DawWaveformElement extends LitElement {
     const waveColor =
       getComputedStyle(this).getPropertyValue('--daw-wave-color').trim() || '#c49a6c';
 
-    // Group dirty peak indices by chunk
-    const dirtyByChunk = new Map<number, { min: number; max: number }>();
-    for (const peakIdx of this._dirtyPixels) {
-      const chunkIdx = Math.floor(peakIdx / MAX_CANVAS_WIDTH);
-      const existing = dirtyByChunk.get(chunkIdx);
-      if (existing) {
-        existing.min = Math.min(existing.min, peakIdx);
-        existing.max = Math.max(existing.max, peakIdx);
-      } else {
-        dirtyByChunk.set(chunkIdx, { min: peakIdx, max: peakIdx });
-      }
-    }
+    const dirtyByChunk = groupDirtyByChunk(this._dirtyPixels, step);
 
+    this._drawnChunks.clear();
     for (const canvas of canvases) {
       const chunkIdx = Number(canvas.dataset.index);
+      this._drawnChunks.add(chunkIdx);
       const range = dirtyByChunk.get(chunkIdx);
       if (!range) continue;
-
-      const ctx = canvas.getContext('2d');
-      if (!ctx) continue;
-
-      const globalOffset = chunkIdx * MAX_CANVAS_WIDTH;
-
-      // Convert dirty peak range to local pixel coordinates
-      const dirtyLocalStart = range.min - globalOffset;
-      const dirtyLocalEnd = range.max - globalOffset;
-
-      // Align to bar boundaries
-      const firstBar = calculateFirstBarPosition(
-        globalOffset + dirtyLocalStart,
-        this.barWidth,
-        step
-      );
-      const clearStart = Math.max(0, firstBar - globalOffset);
-      const clearEnd = dirtyLocalEnd + this.barWidth;
-      const clearWidth = clearEnd - clearStart;
-
-      // Partial clear
-      ctx.resetTransform();
-      ctx.clearRect(clearStart * dpr, 0, clearWidth * dpr, canvas.height);
-      ctx.scale(dpr, dpr);
-      ctx.fillStyle = waveColor;
-
-      // Draw only bars in the dirty region
-      const canvasWidth = Math.min(MAX_CANVAS_WIDTH, this.length - globalOffset);
-      const regionEnd = Math.min(globalOffset + clearEnd, globalOffset + canvasWidth);
-
-      for (let bar = Math.max(0, firstBar); bar < regionEnd; bar += step) {
-        const peak = aggregatePeaks(this._peaks, bits, bar, bar + step);
-        if (!peak) continue;
-        const rects = calculateBarRects(
-          bar - globalOffset,
-          this.barWidth,
-          halfHeight,
-          peak.min,
-          peak.max,
-          'normal'
-        );
-        for (const r of rects) {
-          ctx.fillRect(r.x, r.y, r.width, r.height);
-        }
-      }
+      this._drawChunk(canvas, chunkIdx, range, step, dpr, halfHeight, bits, waveColor);
     }
 
     this._dirtyPixels.clear();
+  }
+
+  private _drawChunk(
+    canvas: HTMLCanvasElement,
+    chunkIdx: number,
+    range: { min: number; max: number },
+    step: number,
+    dpr: number,
+    halfHeight: number,
+    bits: Bits,
+    waveColor: string
+  ) {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const globalOffset = chunkIdx * MAX_CANVAS_WIDTH;
+    const dirtyLocalStart = range.min - globalOffset;
+    const dirtyLocalEnd = range.max - globalOffset;
+
+    const firstBar = calculateFirstBarPosition(globalOffset + dirtyLocalStart, this.barWidth, step);
+    const clearStart = Math.max(0, firstBar - globalOffset);
+    const clearEnd = dirtyLocalEnd + this.barWidth;
+    const clearWidth = clearEnd - clearStart;
+
+    ctx.resetTransform();
+    ctx.clearRect(clearStart * dpr, 0, clearWidth * dpr, canvas.height);
+    ctx.scale(dpr, dpr);
+    ctx.fillStyle = waveColor;
+
+    const canvasWidth = Math.min(MAX_CANVAS_WIDTH, this.length - globalOffset);
+    const regionEnd = Math.min(globalOffset + clearEnd, globalOffset + canvasWidth);
+
+    for (let bar = Math.max(0, firstBar); bar < regionEnd; bar += step) {
+      const peak = aggregatePeaks(this._peaks, bits, bar, bar + step);
+      if (!peak) continue;
+      const rects = calculateBarRects(
+        bar - globalOffset,
+        this.barWidth,
+        halfHeight,
+        peak.min,
+        peak.max,
+        'normal'
+      );
+      for (const r of rects) {
+        ctx.fillRect(r.x, r.y, r.width, r.height);
+      }
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Reschedule draw if dirty pixels survived a disconnect/reconnect cycle
+    if (this._dirtyPixels.size > 0) {
+      this._scheduleDraw();
+    }
   }
 
   disconnectedCallback() {
@@ -188,7 +224,7 @@ export class DawWaveformElement extends LitElement {
       cancelAnimationFrame(this._rafId);
       this._drawScheduled = false;
     }
-    this._dirtyPixels.clear();
+    // Keep _dirtyPixels — connectedCallback will reschedule if reconnected
   }
 
   render() {
@@ -213,8 +249,39 @@ export class DawWaveformElement extends LitElement {
     `;
   }
 
-  updated() {
-    this._markAllDirty();
+  /** Mark peaks dirty only for chunks that weren't drawn in the previous frame. */
+  private _markNewChunksDirty() {
+    const currentIndices = this._getVisibleChunkIndices();
+    const peakCount = Math.floor(this._peaks.length / 2);
+    for (const chunkIdx of currentIndices) {
+      if (!this._drawnChunks.has(chunkIdx)) {
+        const start = chunkIdx * MAX_CANVAS_WIDTH;
+        const end = Math.min(start + MAX_CANVAS_WIDTH, peakCount);
+        for (let i = start; i < end; i++) {
+          this._dirtyPixels.add(i);
+        }
+      }
+    }
+    if (this._dirtyPixels.size > 0) {
+      this._scheduleDraw();
+    }
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
+    // Layout/data changes require full redraw of all peaks
+    const needsFullDirty = [...changedProperties.keys()].some((key) => LAYOUT_PROPS.has(key));
+    if (needsFullDirty) {
+      this._markAllDirty();
+      return;
+    }
+    // Viewport-only changes: only draw newly visible chunks, skip already-drawn ones
+    if (
+      changedProperties.has('visibleStart') ||
+      changedProperties.has('visibleEnd') ||
+      changedProperties.has('originX')
+    ) {
+      this._markNewChunksDirty();
+    }
   }
 }
 

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -85,6 +85,88 @@ export class DawWaveformElement extends LitElement {
   }
 
   private _drawDirty() {
+    if (this._dirtyPixels.size === 0 || this.length === 0 || this._peaks.length === 0) {
+      this._dirtyPixels.clear();
+      return;
+    }
+
+    const canvases = this.shadowRoot?.querySelectorAll('canvas');
+    if (!canvases || canvases.length === 0) {
+      this._dirtyPixels.clear();
+      return;
+    }
+
+    const step = this.barWidth + this.barGap;
+    const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
+    const halfHeight = this.waveHeight / 2;
+    const bits = this.bits;
+    const waveColor =
+      getComputedStyle(this).getPropertyValue('--daw-wave-color').trim() || '#c49a6c';
+
+    // Group dirty peak indices by chunk
+    const dirtyByChunk = new Map<number, { min: number; max: number }>();
+    for (const peakIdx of this._dirtyPixels) {
+      const chunkIdx = Math.floor(peakIdx / MAX_CANVAS_WIDTH);
+      const existing = dirtyByChunk.get(chunkIdx);
+      if (existing) {
+        existing.min = Math.min(existing.min, peakIdx);
+        existing.max = Math.max(existing.max, peakIdx);
+      } else {
+        dirtyByChunk.set(chunkIdx, { min: peakIdx, max: peakIdx });
+      }
+    }
+
+    for (const canvas of canvases) {
+      const chunkIdx = Number(canvas.dataset.index);
+      const range = dirtyByChunk.get(chunkIdx);
+      if (!range) continue;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) continue;
+
+      const globalOffset = chunkIdx * MAX_CANVAS_WIDTH;
+
+      // Convert dirty peak range to local pixel coordinates
+      const dirtyLocalStart = range.min - globalOffset;
+      const dirtyLocalEnd = range.max - globalOffset;
+
+      // Align to bar boundaries
+      const firstBar = calculateFirstBarPosition(
+        globalOffset + dirtyLocalStart,
+        this.barWidth,
+        step
+      );
+      const clearStart = Math.max(0, firstBar - globalOffset);
+      const clearEnd = dirtyLocalEnd + this.barWidth;
+      const clearWidth = clearEnd - clearStart;
+
+      // Partial clear
+      ctx.resetTransform();
+      ctx.clearRect(clearStart * dpr, 0, clearWidth * dpr, canvas.height);
+      ctx.scale(dpr, dpr);
+      ctx.fillStyle = waveColor;
+
+      // Draw only bars in the dirty region
+      const canvasWidth = Math.min(MAX_CANVAS_WIDTH, this.length - globalOffset);
+      const regionEnd = Math.min(globalOffset + clearEnd, globalOffset + canvasWidth);
+
+      for (let bar = Math.max(0, firstBar); bar < regionEnd; bar += step) {
+        const peak = aggregatePeaks(this._peaks, bits, bar, bar + step);
+        if (!peak) continue;
+        const rects = calculateBarRects(
+          bar - globalOffset,
+          this.barWidth,
+          halfHeight,
+          peak.min,
+          peak.max,
+          'normal'
+        );
+        for (const r of rects) {
+          ctx.fillRect(r.x, r.y, r.width, r.height);
+        }
+      }
+    }
+
     this._dirtyPixels.clear();
   }
 
@@ -123,52 +205,6 @@ export class DawWaveformElement extends LitElement {
     this._markAllDirty();
   }
 
-  private _drawVisibleChunks() {
-    if (this.length === 0 || this._peaks.length === 0) return;
-
-    const canvases = this.shadowRoot?.querySelectorAll('canvas');
-    if (!canvases) return;
-
-    const step = this.barWidth + this.barGap;
-    const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
-    const halfHeight = this.waveHeight / 2;
-
-    const waveColor =
-      getComputedStyle(this).getPropertyValue('--daw-wave-color').trim() || '#c49a6c';
-
-    for (const canvas of canvases) {
-      const idx = Number(canvas.dataset.index);
-      const ctx = canvas.getContext('2d');
-      if (!ctx) continue;
-
-      const canvasWidth = Math.min(MAX_CANVAS_WIDTH, this.length - idx * MAX_CANVAS_WIDTH);
-
-      ctx.resetTransform();
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.scale(dpr, dpr);
-      ctx.fillStyle = waveColor;
-
-      const globalOffset = idx * MAX_CANVAS_WIDTH;
-      const canvasEnd = globalOffset + canvasWidth;
-      const firstBar = calculateFirstBarPosition(globalOffset, this.barWidth, step);
-
-      for (let bar = Math.max(0, firstBar); bar < canvasEnd; bar += step) {
-        const peak = aggregatePeaks(this._peaks, this.bits, bar, bar + step);
-        if (!peak) continue;
-        const rects = calculateBarRects(
-          bar - globalOffset,
-          this.barWidth,
-          halfHeight,
-          peak.min,
-          peak.max,
-          'normal'
-        );
-        for (const r of rects) {
-          ctx.fillRect(r.x, r.y, r.width, r.height);
-        }
-      }
-    }
-  }
 }
 
 declare global {

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -216,7 +216,6 @@ export class DawWaveformElement extends LitElement {
   updated() {
     this._markAllDirty();
   }
-
 }
 
 declare global {

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -12,8 +12,25 @@ const MAX_CANVAS_WIDTH = 1000;
 
 @customElement('daw-waveform')
 export class DawWaveformElement extends LitElement {
-  @property({ type: Object, attribute: false }) peaks: Peaks = new Int16Array(0);
-  @property({ type: Number, attribute: false }) bits: Bits = 16;
+  private _peaks: Peaks = new Int16Array(0);
+  private _dirtyPixels: Set<number> = new Set();
+  private _drawScheduled = false;
+  private _rafId = 0;
+
+  set peaks(value: Peaks) {
+    this._peaks = value;
+    this._markAllDirty();
+    this.requestUpdate();
+  }
+
+  get peaks(): Peaks {
+    return this._peaks;
+  }
+
+  get bits(): Bits {
+    return this._peaks instanceof Int8Array ? 8 : 16;
+  }
+
   @property({ type: Number, attribute: false }) length = 0;
   @property({ type: Number, attribute: false }) waveHeight = 128;
   @property({ type: Number, attribute: false }) barWidth = 1;
@@ -49,6 +66,37 @@ export class DawWaveformElement extends LitElement {
     );
   }
 
+  private _markAllDirty() {
+    const peakCount = Math.floor(this._peaks.length / 2);
+    for (let i = 0; i < peakCount; i++) {
+      this._dirtyPixels.add(i);
+    }
+    this._scheduleDraw();
+  }
+
+  private _scheduleDraw() {
+    if (!this._drawScheduled) {
+      this._drawScheduled = true;
+      this._rafId = requestAnimationFrame(() => {
+        this._drawScheduled = false;
+        this._drawDirty();
+      });
+    }
+  }
+
+  private _drawDirty() {
+    this._dirtyPixels.clear();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._drawScheduled) {
+      cancelAnimationFrame(this._rafId);
+      this._drawScheduled = false;
+    }
+    this._dirtyPixels.clear();
+  }
+
   render() {
     const indices = this._getVisibleChunkIndices();
     const dpr = typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1;
@@ -72,11 +120,11 @@ export class DawWaveformElement extends LitElement {
   }
 
   updated() {
-    this._drawVisibleChunks();
+    this._markAllDirty();
   }
 
   private _drawVisibleChunks() {
-    if (this.length === 0 || this.peaks.length === 0) return;
+    if (this.length === 0 || this._peaks.length === 0) return;
 
     const canvases = this.shadowRoot?.querySelectorAll('canvas');
     if (!canvases) return;
@@ -105,7 +153,7 @@ export class DawWaveformElement extends LitElement {
       const firstBar = calculateFirstBarPosition(globalOffset, this.barWidth, step);
 
       for (let bar = Math.max(0, firstBar); bar < canvasEnd; bar += step) {
-        const peak = aggregatePeaks(this.peaks, this.bits, bar, bar + step);
+        const peak = aggregatePeaks(this._peaks, this.bits, bar, bar + step);
         if (!peak) continue;
         const rects = calculateBarRects(
           bar - globalOffset,

--- a/packages/dawcore/src/elements/daw-waveform.ts
+++ b/packages/dawcore/src/elements/daw-waveform.ts
@@ -1,11 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { Peaks, Bits } from '@waveform-playlist/core';
-import {
-  aggregatePeaks,
-  calculateBarRects,
-  calculateFirstBarPosition,
-} from '../utils/peak-rendering';
+import { aggregatePeaks, calculateBarRects } from '../utils/peak-rendering';
 import { getVisibleChunkIndices } from '../utils/viewport';
 
 const MAX_CANVAS_WIDTH = 1000;
@@ -14,8 +10,9 @@ const MAX_CANVAS_WIDTH = 1000;
 const LAYOUT_PROPS = new Set(['length', 'waveHeight', 'barWidth', 'barGap']);
 
 /**
- * Group dirty peak indices by canvas chunk, mapping peak indices to bar pixel
- * positions for correct chunk assignment when barWidth > 1 or barGap > 0.
+ * Group dirty peak indices by canvas chunk. Returns bar-pixel-aligned
+ * min/max positions per chunk for correct clearRect coordinates,
+ * including when barWidth > 1 or barGap > 0.
  */
 function groupDirtyByChunk(
   dirtyPixels: Set<number>,
@@ -29,11 +26,11 @@ function groupDirtyByChunk(
     const existing = dirtyByChunk.get(chunkIdx);
     if (existing) {
       dirtyByChunk.set(chunkIdx, {
-        min: Math.min(existing.min, peakIdx),
-        max: Math.max(existing.max, peakIdx),
+        min: Math.min(existing.min, barPixel),
+        max: Math.max(existing.max, barPixel),
       });
     } else {
-      dirtyByChunk.set(chunkIdx, { min: peakIdx, max: peakIdx });
+      dirtyByChunk.set(chunkIdx, { min: barPixel, max: barPixel });
     }
   }
   return dirtyByChunk;
@@ -45,7 +42,7 @@ export class DawWaveformElement extends LitElement {
   private _dirtyPixels: Set<number> = new Set();
   private _drawScheduled = false;
   private _rafId = 0;
-  /** Chunk indices that were drawn in the last frame — used to detect new chunks on scroll. */
+  /** Chunk indices visible in the last draw pass — used to detect new chunks on scroll. */
   private _drawnChunks: Set<number> = new Set();
 
   set peaks(value: Peaks) {
@@ -138,7 +135,8 @@ export class DawWaveformElement extends LitElement {
 
     const canvases = this.shadowRoot?.querySelectorAll('canvas');
     if (!canvases || canvases.length === 0) {
-      this._dirtyPixels.clear();
+      // Don't clear _dirtyPixels — canvases may appear after Lit renders.
+      // connectedCallback or updated() will reschedule the draw.
       return;
     }
 
@@ -177,13 +175,11 @@ export class DawWaveformElement extends LitElement {
     if (!ctx) return;
 
     const globalOffset = chunkIdx * MAX_CANVAS_WIDTH;
-    const dirtyLocalStart = range.min - globalOffset;
-    const dirtyLocalEnd = range.max - globalOffset;
-
-    const firstBar = calculateFirstBarPosition(globalOffset + dirtyLocalStart, this.barWidth, step);
-    const clearStart = Math.max(0, firstBar - globalOffset);
-    const clearEnd = dirtyLocalEnd + this.barWidth;
+    // range.min/max are bar-pixel-aligned global positions from groupDirtyByChunk
+    const clearStart = Math.max(0, range.min - globalOffset);
+    const clearEnd = range.max - globalOffset + this.barWidth;
     const clearWidth = clearEnd - clearStart;
+    const firstBar = range.min;
 
     ctx.resetTransform();
     ctx.clearRect(clearStart * dpr, 0, clearWidth * dpr, canvas.height);


### PR DESCRIPTION
## Summary
- Adds dirty pixel tracking to `<daw-waveform>` — only changed peak regions are cleared and redrawn instead of full canvas redraws on every update
- New `updatePeaks(startIndex, endIndex)` API for incremental updates (e.g., recording appends) that bypasses Lit re-render entirely
- `bits` property now derived from typed array (`Int8Array` → 8, `Int16Array` → 16) — removed as a separate property
- Drawing batched via `requestAnimationFrame` with proper `disconnectedCallback` cleanup
- Full redraws (zoom, load, layout changes) use the same dirty path — mark all pixels dirty

## Key changes
- `daw-waveform.ts`: `peaks` converted from `@property` to getter/setter with `_dirtyPixels` Set, `_markAllDirty()`, `_scheduleDraw()`, `_drawDirty()` (partial clearRect per chunk)
- `daw-editor.ts`: removed `.bits` template binding (derived from array type)
- 10 unit tests covering full redraw, incremental update, batching, empty skip, bits derivation, layout changes

## Test plan
- [ ] 10 unit tests in `daw-waveform.test.ts` — full redraw, partial dirty, batching, empty skip, bits derivation, layout triggers
- [ ] 129 total tests pass across dawcore package
- [ ] Manual: load dev page, verify waveforms render correctly (full replacement path)
- [ ] Manual: verify no visual regressions on zoom/scroll