### PR TITLE
docs: mark CI pipeline as done in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Multi-track audio editor roadmap for waveform-playlist.
 
 ### Testing & CI
 
-- [ ] **CI/CD pipeline** — Automated builds, tests, publishing
+- [ ] **CD pipeline** — Automated npm publishing (currently manual via `pnpm publish`)
 
 ### Playback UX
 


### PR DESCRIPTION
## Summary

- Mark CI pipeline item as done — builds, lint, and unit tests (React 18 + 19) already run on PRs via `.github/workflows/ci.yml`
- Split out CD (automated npm publishing) as a separate TODO item since that's still manual

## Test plan

- [ ] No code changes — docs only


🤖 Generated with [Claude Code](https://claude.com/claude-code)