### PR TITLE
docs: update for v10.3.0 recording improvements

### DIFF
--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -551,7 +551,7 @@ interface MidiTrackConfig {
   color?: string;
   startTime?: number;              // Clip position in seconds (default 0)
   duration?: number;               // Override clip duration in seconds
-  sampleRate?: number;             // For sample-based positioning (default 44100)
+  sampleRate?: number;             // For sample-based positioning (defaults to AudioContext.sampleRate)
   flatten?: boolean;               // Merge all MIDI tracks into one (default false)
 }
 
@@ -608,7 +608,7 @@ import type { EngineState, PlayoutAdapter, EngineEvents, PlaylistEngineOptions }
 
 interface PlaylistEngineOptions {
   adapter?: PlayoutAdapter;
-  sampleRate?: number;          // Default: 44100
+  sampleRate?: number;          // Default: 44100 (use AudioContext.sampleRate for hardware rate)
   samplesPerPixel?: number;     // Default: 1000
   zoomLevels?: number[];        // Default: [256, 512, 1024, 2048, 4096, 8192]
 }

--- a/website/docs/guides/engine.md
+++ b/website/docs/guides/engine.md
@@ -27,9 +27,9 @@ The engine's only peer dependency is `@waveform-playlist/core` (data model types
 import { PlaylistEngine } from '@waveform-playlist/engine';
 import { createTrack, createClipFromSeconds } from '@waveform-playlist/core';
 
-// 1. Create an engine
+// 1. Create an engine (use AudioContext.sampleRate for the hardware rate)
 const engine = new PlaylistEngine({
-  sampleRate: 44100,
+  sampleRate: 48000, // Match your AudioContext.sampleRate
   samplesPerPixel: 1000,
 });
 
@@ -78,7 +78,7 @@ const engine = new PlaylistEngine(options?: PlaylistEngineOptions);
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `adapter` | `PlayoutAdapter` | `null` | Audio playback backend |
-| `sampleRate` | `number` | `44100` | Audio sample rate |
+| `sampleRate` | `number` | `44100` | Audio sample rate (use `AudioContext.sampleRate` for hardware rate) |
 | `samplesPerPixel` | `number` | `1000` | Initial zoom level |
 | `zoomLevels` | `number[]` | `[256, 512, 1024, 2048, 4096, 8192]` | Available zoom steps (samples per pixel) |
 
@@ -192,7 +192,7 @@ engine.pause(): void;
 // Stop and reset to beginning
 engine.stop(): void;
 
-// Seek to a time position (clamped to duration)
+// Seek to a time position (any non-negative value — plays silence beyond audio)
 engine.seek(time: number): void;
 ```
 
@@ -386,8 +386,8 @@ const newScrollLeft = calculateZoomScrollPosition(
   oldSpp, newSpp, scrollLeft, containerWidth, sampleRate
 );
 
-// Clamp seek position
-const time = clampSeekPosition(requestedTime, duration);
+// Clamp negative seek position to 0
+const time = Math.max(0, requestedTime);
 ```
 
 ### Viewport Operations
@@ -477,7 +477,7 @@ A plain DOM UI that reacts to engine state — no framework required:
   import { PlaylistEngine } from '@waveform-playlist/engine';
   import { createTrack, createClipFromSeconds } from '@waveform-playlist/core';
 
-  const engine = new PlaylistEngine({ sampleRate: 44100 });
+  const engine = new PlaylistEngine({ sampleRate: 48000 });
 
   // Update DOM on every state change
   engine.on('statechange', (state) => {
@@ -508,7 +508,7 @@ A minimal Svelte store that subscribes to engine state:
   import { writable } from 'svelte/store';
   import { PlaylistEngine } from '@waveform-playlist/engine';
 
-  const engine = new PlaylistEngine({ sampleRate: 44100 });
+  const engine = new PlaylistEngine({ sampleRate: 48000 });
 
   const state = writable(engine.getState());
 

--- a/website/docs/guides/midi.md
+++ b/website/docs/guides/midi.md
@@ -56,7 +56,7 @@ interface MidiTrackConfig {
   color?: string;
   startTime?: number;         // Clip position in seconds (default: 0)
   duration?: number;          // Override clip duration in seconds
-  sampleRate?: number;        // For sample-based positioning (default: 44100)
+  sampleRate?: number;        // For sample-based positioning (defaults to AudioContext.sampleRate)
   flatten?: boolean;          // Merge all MIDI tracks into one (default: false)
 }
 ```

--- a/website/docs/guides/recording.md
+++ b/website/docs/guides/recording.md
@@ -174,6 +174,21 @@ function RecordingControls() {
 }
 ```
 
+### Mic Disconnect Detection
+
+`useRecording` automatically detects when the microphone is unplugged or permission is revoked during recording. When the `MediaStreamTrack` 'ended' event fires, the hook calls `stopRecording()` and sets an `error` state:
+
+```tsx
+const { error } = useRecording(stream);
+
+// error.message === 'Microphone disconnected during recording'
+{error && <p style={{ color: 'red' }}>{error.message}</p>}
+```
+
+:::tip Sample Rate Mismatch
+The mic's native sample rate (from `MediaStreamTrack.getSettings().sampleRate`) may differ from the `AudioContext.sampleRate`. The browser automatically resamples at the `MediaStreamAudioSourceNode` boundary. To avoid resampling, match input and output sample rates in your system audio settings (e.g., macOS Audio MIDI Setup).
+:::
+
 ## Accessing Recorded Audio Data
 
 After recording stops, the `audioBuffer` from `useRecording` contains the full recorded audio as a Web Audio API [AudioBuffer](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer). You can also await the return value of `stopRecording()` to get the buffer directly.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -20,11 +20,11 @@ waveform-playlist is a React component library for building browser-based audio 
 
 - `@waveform-playlist/browser` — Main package: React components, hooks, effects
 - `@waveform-playlist/core` — Data model: ClipTrack, AudioClip, sample-based math
-- `@waveform-playlist/engine` — Framework-agnostic timeline engine: PlaylistEngine class, pure clip/timeline operations, event emitter. Owns selection, loop, zoom, volume, selectedTrackId, and clip mutation state.
+- `@waveform-playlist/engine` — Framework-agnostic timeline engine: PlaylistEngine class, pure clip/timeline operations, event emitter. Owns selection, loop, zoom, volume, selectedTrackId, and clip mutation state. Seek/play beyond audio duration is supported (silence where there's no audio).
 - `@waveform-playlist/playout` — Audio playback: Tone.js adapter (implements PlayoutAdapter from engine), global AudioContext
 - `@waveform-playlist/ui-components` — Styled primitives, theming, virtual scrolling contexts, playhead components, PlaylistErrorBoundary, BeatsAndBarsProvider
 - `@waveform-playlist/annotations` — Annotation parsing, rendering, keyboard controls
-- `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter, integrated recording hook
+- `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter, integrated recording hook, mic-unplug detection
 - `@waveform-playlist/worklets` — Shared AudioWorklet processors: `meter-processor` (sample-accurate peak/RMS metering) and `recording-processor` (multi-channel audio capture). Auto-installed with recording package.
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
 - `@waveform-playlist/media-element-playout` — HTMLAudioElement playback with pitch-preserving speed control, optional Web Audio routing for fades and Tone.js effect bridging


### PR DESCRIPTION
## Summary

Updates documentation to reflect v10.3.0 changes:

- **Engine guide**: seek/play no longer clamp to duration, removed stale `clampSeekPosition` reference, updated sampleRate examples from 44100 to 48000 with AudioContext note
- **Recording guide**: new section for mic-unplug detection, sample rate mismatch tip
- **MIDI guide + llm-reference**: sampleRate defaults to `AudioContext.sampleRate`, not hardcoded 44100
- **llms.txt**: mention mic-unplug detection and unclamped seek/play

## Test plan

- [ ] `pnpm --filter website build` passes (no broken links)
- [ ] Docs render correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)