### PR TITLE
test(midi): suppress expected console.error in error handling tests

### DIFF
--- a/packages/midi/src/__tests__/useMidiTracks.test.ts
+++ b/packages/midi/src/__tests__/useMidiTracks.test.ts
@@ -264,6 +264,10 @@ describe('useMidiTracks', () => {
   });
 
   describe('error handling', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
     it('sets error on fetch failure', async () => {
       mockFetch.mockResolvedValue({
         ok: false,


### PR DESCRIPTION
## Summary

Mock `console.error` in the error handling test block to suppress expected error logging from the hook. The tests verify that `useMidiTracks` sets `error` state on fetch failures and invalid configs — the `console.error` output is expected behavior, not a test failure, but it creates noisy stderr in CI.

## Test plan

- [ ] 22 midi tests passing
- [ ] No stderr noise in CI output


🤖 Generated with [Claude Code](https://claude.com/claude-code)