### PR TITLE
refactor: read sampleRate from context, not props

### DIFF
--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -192,6 +192,10 @@ const rebuildChain = useCallback(() => {
 - `useExportWav`: calls `getGlobalAudioContext().sampleRate` directly.
 - **Never** fall back to 44100 or derive from `tracks[0].clips[0]?.sampleRate` — that fails in recording-only workflows.
 
+## sampleRate From Context (Not Props)
+
+Internal hooks (`useClipDragHandlers`, `useClipSplitting`, `useAnnotationKeyboardControls`) read `sampleRate` from `usePlaylistData()` — do NOT add it as a parameter. `useAnnotationDragHandlers` accepts optional `sampleRate` (defaults to `getGlobalAudioContext().sampleRate`) because it's used in both WaveformPlaylist and MediaElement contexts. `SnapToGridModifier` and `calculateBoundaryTrim` are not hooks — they still receive `sampleRate` as a parameter from callers that have context access.
+
 ## Aligned Peak Resampling (waveformDataLoader.ts)
 
 **Decision:** When slicing WaveformData before resampling to a different scale, source slice indices must align to the resampling ratio.

--- a/packages/browser/src/components/ClipInteractionProvider.tsx
+++ b/packages/browser/src/components/ClipInteractionProvider.tsx
@@ -91,7 +91,6 @@ export const ClipInteractionProvider: React.FC<ClipInteractionProviderProps> = (
     tracks,
     onTracksChange: onTracksChange ?? NOOP_TRACKS_CHANGE,
     samplesPerPixel,
-    sampleRate,
     engineRef: playoutRef,
     isDraggingRef,
     snapSamplePosition,

--- a/packages/browser/src/components/KeyboardShortcuts.tsx
+++ b/packages/browser/src/components/KeyboardShortcuts.tsx
@@ -35,7 +35,7 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
   additionalShortcuts = [],
 }) => {
   // Clip splitting setup
-  const { tracks, samplesPerPixel, sampleRate, playoutRef, duration } = usePlaylistData();
+  const { tracks, samplesPerPixel, playoutRef, duration } = usePlaylistData();
   const {
     annotations: annotationList,
     linkEndpoints,
@@ -46,7 +46,6 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
 
   const { splitClipAtPlayhead } = useClipSplitting({
     tracks,
-    sampleRate,
     samplesPerPixel,
     engineRef: playoutRef,
   });
@@ -83,8 +82,6 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
     linkEndpoints,
     continuousPlay,
     scrollContainerRef,
-    samplesPerPixel,
-    sampleRate,
     onPlay: play,
     enabled: annotations && annotationList.length > 0,
   });

--- a/packages/browser/src/components/MediaElementPlaylist.tsx
+++ b/packages/browser/src/components/MediaElementPlaylist.tsx
@@ -175,7 +175,6 @@ export const MediaElementPlaylist: React.FC<MediaElementPlaylistProps> = ({
     annotations,
     onAnnotationsChange: handleAnnotationUpdate,
     samplesPerPixel,
-    sampleRate,
     duration,
     linkEndpoints: linkEndpointsProp,
   });

--- a/packages/browser/src/hooks/useAnnotationDragHandlers.ts
+++ b/packages/browser/src/hooks/useAnnotationDragHandlers.ts
@@ -5,6 +5,7 @@ import type {
   DragEndEvent as DragEndCallback,
 } from '@dnd-kit/abstract';
 import type { AnnotationData } from '@waveform-playlist/core';
+import { getGlobalAudioContext } from '@waveform-playlist/playout';
 
 const LINK_THRESHOLD = 0.01; // Consider edges "linked" if within 10ms
 
@@ -12,7 +13,8 @@ interface UseAnnotationDragHandlersOptions {
   annotations: AnnotationData[];
   onAnnotationsChange: (annotations: AnnotationData[]) => void;
   samplesPerPixel: number;
-  sampleRate: number;
+  /** Sample rate for pixel-to-time conversion. Defaults to AudioContext.sampleRate. */
+  sampleRate?: number;
   duration: number;
   linkEndpoints: boolean;
 }
@@ -50,7 +52,7 @@ export function useAnnotationDragHandlers({
   annotations,
   onAnnotationsChange,
   samplesPerPixel,
-  sampleRate,
+  sampleRate = getGlobalAudioContext().sampleRate,
   duration,
   linkEndpoints,
 }: UseAnnotationDragHandlersOptions) {

--- a/packages/browser/src/hooks/useAnnotationDragHandlers.ts
+++ b/packages/browser/src/hooks/useAnnotationDragHandlers.ts
@@ -31,7 +31,6 @@ interface UseAnnotationDragHandlersOptions {
  *   annotations,
  *   onAnnotationsChange: setAnnotations,
  *   samplesPerPixel,
- *   sampleRate,
  *   duration,
  *   linkEndpoints,
  * });

--- a/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
+++ b/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useEffect } from 'react';
 import type { AnnotationData } from '@waveform-playlist/core';
+import { usePlaylistData } from '../WaveformPlaylistContext';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 
 const LINK_THRESHOLD = 0.01; // Consider edges "linked" if within 10ms
@@ -67,10 +68,14 @@ export function useAnnotationKeyboardControls({
   continuousPlay = false,
   enabled = true,
   scrollContainerRef,
-  samplesPerPixel,
-  sampleRate,
+  samplesPerPixel: samplesPerPixelProp,
+  sampleRate: sampleRateProp,
   onPlay,
 }: UseAnnotationKeyboardControlsOptions) {
+  const contextData = usePlaylistData();
+  const samplesPerPixel = samplesPerPixelProp ?? contextData.samplesPerPixel;
+  const sampleRate = sampleRateProp ?? contextData.sampleRate;
+
   const activeIndex = useMemo(() => {
     if (!activeAnnotationId) return -1;
     return annotations.findIndex((a) => a.id === activeAnnotationId);

--- a/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
+++ b/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
@@ -19,10 +19,6 @@ interface UseAnnotationKeyboardControlsOptions {
   enabled?: boolean;
   /** Optional: scroll container ref for auto-scrolling to annotation */
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
-  /** Optional: samples per pixel for scroll position calculation */
-  samplesPerPixel?: number;
-  /** Optional: sample rate for scroll position calculation */
-  sampleRate?: number;
   /** Optional: callback to start playback at a time with optional duration */
   onPlay?: (startTime: number, duration?: number) => void;
 }
@@ -68,13 +64,9 @@ export function useAnnotationKeyboardControls({
   continuousPlay = false,
   enabled = true,
   scrollContainerRef,
-  samplesPerPixel: samplesPerPixelProp,
-  sampleRate: sampleRateProp,
   onPlay,
 }: UseAnnotationKeyboardControlsOptions) {
-  const contextData = usePlaylistData();
-  const samplesPerPixel = samplesPerPixelProp ?? contextData.samplesPerPixel;
-  const sampleRate = sampleRateProp ?? contextData.sampleRate;
+  const { samplesPerPixel, sampleRate } = usePlaylistData();
 
   const activeIndex = useMemo(() => {
     if (!activeAnnotationId) return -1;

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -7,12 +7,12 @@ import type {
 import type { ClipTrack } from '@waveform-playlist/core';
 import type { PlaylistEngine } from '@waveform-playlist/engine';
 import { calculateBoundaryTrim } from '../utils/boundaryTrim';
+import { usePlaylistData } from '../WaveformPlaylistContext';
 
 interface UseClipDragHandlersOptions {
   tracks: ClipTrack[];
   onTracksChange: (tracks: ClipTrack[]) => void;
   samplesPerPixel: number;
-  sampleRate: number;
   engineRef: React.RefObject<PlaylistEngine | null>;
   /** Ref toggled during boundary trim drags. When true, the provider's loadAudio
    *  skips engine rebuilds so engine keeps original clip positions. On drag end,
@@ -44,7 +44,6 @@ interface UseClipDragHandlersOptions {
  *   tracks,
  *   onTracksChange: setTracks,
  *   samplesPerPixel,
- *   sampleRate,
  *   engineRef: playoutRef,
  *   isDraggingRef,
  * });
@@ -65,11 +64,11 @@ export function useClipDragHandlers({
   tracks,
   onTracksChange,
   samplesPerPixel,
-  sampleRate,
   engineRef,
   isDraggingRef,
   snapSamplePosition,
 }: UseClipDragHandlersOptions) {
+  const { sampleRate } = usePlaylistData();
   // Store snap function in ref so onDragMove doesn't need it as a dependency
   const snapSamplePositionRef = React.useRef(snapSamplePosition);
   snapSamplePositionRef.current = snapSamplePosition;

--- a/packages/browser/src/hooks/useClipSplitting.ts
+++ b/packages/browser/src/hooks/useClipSplitting.ts
@@ -2,11 +2,14 @@ import React, { useCallback } from 'react';
 import type { ClipTrack } from '@waveform-playlist/core';
 import { calculateSplitPoint, canSplitAt } from '@waveform-playlist/engine';
 import type { PlaylistEngine } from '@waveform-playlist/engine';
-import { usePlaybackAnimation, usePlaylistState } from '../WaveformPlaylistContext';
+import {
+  usePlaybackAnimation,
+  usePlaylistData,
+  usePlaylistState,
+} from '../WaveformPlaylistContext';
 
 export interface UseClipSplittingOptions {
   tracks: ClipTrack[];
-  sampleRate: number;
   samplesPerPixel: number;
   engineRef: React.RefObject<PlaylistEngine | null>;
 }
@@ -30,7 +33,6 @@ export interface UseClipSplittingResult {
  * ```tsx
  * const { splitClipAtPlayhead } = useClipSplitting({
  *   tracks,
- *   sampleRate,
  *   samplesPerPixel,
  *   engineRef: playoutRef,
  * });
@@ -44,7 +46,8 @@ export interface UseClipSplittingResult {
  * ```
  */
 export const useClipSplitting = (options: UseClipSplittingOptions): UseClipSplittingResult => {
-  const { tracks, sampleRate, engineRef } = options;
+  const { tracks, engineRef } = options;
+  const { sampleRate } = usePlaylistData();
   const { currentTimeRef } = usePlaybackAnimation();
   const { selectedTrackId } = usePlaylistState();
 
@@ -90,7 +93,7 @@ export const useClipSplitting = (options: UseClipSplittingOptions): UseClipSplit
       engine.splitClip(track.id, clip.id, snappedSplitSample);
       return true;
     },
-    [tracks, options, sampleRate, engineRef]
+    [tracks, options, engineRef, sampleRate]
   );
 
   /**

--- a/packages/midi/CLAUDE.md
+++ b/packages/midi/CLAUDE.md
@@ -45,7 +45,7 @@ The `loadedTracksMap` stores `ClipTrack[]` per config index (not single `ClipTra
 
 ### MIDI Has No Native Sample Rate
 
-MIDI is event-based, not sample-based. The `sampleRate` config option is **required** on `MidiTrackConfig` — pass `AudioContext.sampleRate` (or `getGlobalAudioContext().sampleRate` from playout). Used for sample-based timeline positioning in `createClipFromSeconds()`. The actual audio synthesis sample rate is determined by the `AudioContext` in the playout layer.
+MIDI is event-based, not sample-based. `sampleRate` is **required** on `UseMidiTracksOptions` (second arg to `useMidiTracks()`) — pass `getGlobalAudioContext().sampleRate` from playout. Used for sample-based timeline positioning in `createClipFromSeconds()`. The actual audio synthesis sample rate is determined by the `AudioContext` in the playout layer. Never hardcode a default (e.g., 48000) — the real AudioContext rate varies by hardware.
 
 ## @tonejs/midi Gotchas
 

--- a/packages/midi/CLAUDE.md
+++ b/packages/midi/CLAUDE.md
@@ -93,10 +93,10 @@ MIDI velocity is a 0-127 integer. `@tonejs/midi` normalizes to 0-1 float, but ro
 ```typescript
 // ✅ Stable reference
 const configs: MidiTrackConfig[] = [{ midiNotes: notes, name: 'Test' }];
-const { result } = renderHook(() => useMidiTracks(configs));
+const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
 // ❌ New reference each render — infinite effect loop
-const { result } = renderHook(() => useMidiTracks([{ midiNotes: notes }]));
+const { result } = renderHook(() => useMidiTracks([{ midiNotes: notes }], { sampleRate: 48000 }));
 ```
 
 ### Flatten Is Visual-Only (Planned)

--- a/packages/midi/src/__tests__/useMidiTracks.test.ts
+++ b/packages/midi/src/__tests__/useMidiTracks.test.ts
@@ -89,7 +89,6 @@ describe('useMidiTracks', () => {
           muted: true,
           soloed: true,
           color: '#ff0000',
-          sampleRate: 48000,
         },
       ];
 
@@ -118,7 +117,6 @@ describe('useMidiTracks', () => {
           name: 'Positioned',
           startTime: 5.0,
           duration: 10.0,
-          sampleRate: 48000,
         },
       ];
 

--- a/packages/midi/src/__tests__/useMidiTracks.test.ts
+++ b/packages/midi/src/__tests__/useMidiTracks.test.ts
@@ -59,9 +59,9 @@ describe('useMidiTracks', () => {
       ];
 
       // Stable config reference to avoid useEffect infinite loop
-      const configs: MidiTrackConfig[] = [{ midiNotes: notes, name: 'Test', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ midiNotes: notes, name: 'Test' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -93,7 +93,7 @@ describe('useMidiTracks', () => {
         },
       ];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -122,7 +122,7 @@ describe('useMidiTracks', () => {
         },
       ];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -155,9 +155,9 @@ describe('useMidiTracks', () => {
         arrayBuffer: () => Promise.resolve(midiBuffer),
       });
 
-      const configs: MidiTrackConfig[] = [{ src: '/test.mid', name: 'Song', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/test.mid', name: 'Song' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -191,9 +191,9 @@ describe('useMidiTracks', () => {
         arrayBuffer: () => Promise.resolve(midiBuffer),
       });
 
-      const configs: MidiTrackConfig[] = [{ src: '/multi.mid', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/multi.mid' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -223,9 +223,9 @@ describe('useMidiTracks', () => {
         arrayBuffer: () => Promise.resolve(midiBuffer),
       });
 
-      const configs: MidiTrackConfig[] = [{ src: '/multi.mid', flatten: true, sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/multi.mid', flatten: true }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -240,9 +240,9 @@ describe('useMidiTracks', () => {
     it('starts in loading state', () => {
       mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
 
-      const configs: MidiTrackConfig[] = [{ src: '/test.mid', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/test.mid' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       expect(result.current.loading).toBe(true);
       expect(result.current.loadedCount).toBe(0);
@@ -252,7 +252,7 @@ describe('useMidiTracks', () => {
     it('handles empty configs', async () => {
       const configs: MidiTrackConfig[] = [];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -275,9 +275,9 @@ describe('useMidiTracks', () => {
         statusText: 'Not Found',
       });
 
-      const configs: MidiTrackConfig[] = [{ src: '/missing.mid', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/missing.mid' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -288,9 +288,9 @@ describe('useMidiTracks', () => {
     });
 
     it('sets error when neither src nor midiNotes provided', async () => {
-      const configs: MidiTrackConfig[] = [{ name: 'Invalid', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ name: 'Invalid' }];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -308,9 +308,9 @@ describe('useMidiTracks', () => {
         return new Promise(() => {}); // never resolves
       });
 
-      const configs: MidiTrackConfig[] = [{ src: '/test.mid', sampleRate: 48000 }];
+      const configs: MidiTrackConfig[] = [{ src: '/test.mid' }];
 
-      const { unmount } = renderHook(() => useMidiTracks(configs));
+      const { unmount } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       // Wait for fetch to be called
       await waitFor(() => {
@@ -333,11 +333,11 @@ describe('useMidiTracks', () => {
       ];
 
       const configs: MidiTrackConfig[] = [
-        { midiNotes: notes1, name: 'Track 1', sampleRate: 48000 },
-        { midiNotes: notes2, name: 'Track 2', sampleRate: 48000 },
+        { midiNotes: notes1, name: 'Track 1' },
+        { midiNotes: notes2, name: 'Track 2' },
       ];
 
-      const { result } = renderHook(() => useMidiTracks(configs));
+      const { result } = renderHook(() => useMidiTracks(configs, { sampleRate: 48000 }));
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);

--- a/packages/midi/src/index.ts
+++ b/packages/midi/src/index.ts
@@ -1,4 +1,4 @@
 export { parseMidiFile, parseMidiUrl } from './parseMidiFile';
 export type { ParsedMidi, ParsedMidiTrack, ParseMidiOptions } from './parseMidiFile';
 export { useMidiTracks } from './useMidiTracks';
-export type { MidiTrackConfig, UseMidiTracksReturn } from './useMidiTracks';
+export type { MidiTrackConfig, UseMidiTracksOptions, UseMidiTracksReturn } from './useMidiTracks';

--- a/packages/midi/src/useMidiTracks.ts
+++ b/packages/midi/src/useMidiTracks.ts
@@ -53,8 +53,7 @@ export interface UseMidiTracksReturn {
 }
 
 export interface UseMidiTracksOptions {
-  /** Default sample rate for all configs. Pass AudioContext.sampleRate.
-   *  Per-config sampleRate overrides this value. */
+  /** Sample rate for sample-based timeline positioning. Pass AudioContext.sampleRate. */
   sampleRate: number;
 }
 

--- a/packages/midi/src/useMidiTracks.ts
+++ b/packages/midi/src/useMidiTracks.ts
@@ -35,8 +35,6 @@ export interface MidiTrackConfig {
   startTime?: number;
   /** Override clip duration in seconds (default: derived from last note) */
   duration?: number;
-  /** Sample rate for sample-based positioning — pass AudioContext.sampleRate */
-  sampleRate: number;
   /** Merge all MIDI tracks from the file into one ClipTrack (default false) */
   flatten?: boolean;
 }
@@ -54,6 +52,12 @@ export interface UseMidiTracksReturn {
   totalCount: number;
 }
 
+export interface UseMidiTracksOptions {
+  /** Default sample rate for all configs. Pass AudioContext.sampleRate.
+   *  Per-config sampleRate overrides this value. */
+  sampleRate: number;
+}
+
 /**
  * Hook to load MIDI files and convert to ClipTrack format with midiNotes.
  *
@@ -63,17 +67,22 @@ export interface UseMidiTracksReturn {
  *
  * @example
  * ```typescript
- * const { tracks, loading, error } = useMidiTracks([
- *   { src: '/music/song.mid', name: 'Piano' },
- * ]);
+ * const { tracks, loading, error } = useMidiTracks(
+ *   [{ src: '/music/song.mid', name: 'Piano' }],
+ *   { sampleRate: audioContext.sampleRate }
+ * );
  *
  * // Pre-parsed notes (no fetch)
- * const { tracks } = useMidiTracks([
- *   { midiNotes: myNotes, name: 'Synth Lead', duration: 30 },
- * ]);
+ * const { tracks } = useMidiTracks(
+ *   [{ midiNotes: myNotes, name: 'Synth Lead', duration: 30 }],
+ *   { sampleRate: 48000 }
+ * );
  * ```
  */
-export function useMidiTracks(configs: MidiTrackConfig[]): UseMidiTracksReturn {
+export function useMidiTracks(
+  configs: MidiTrackConfig[],
+  options: UseMidiTracksOptions
+): UseMidiTracksReturn {
   const [tracks, setTracks] = useState<ClipTrack[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -103,7 +112,7 @@ export function useMidiTracks(configs: MidiTrackConfig[]): UseMidiTracksReturn {
       midiChannel?: number,
       midiProgram?: number
     ): ClipTrack => {
-      const sampleRate = config.sampleRate;
+      const sampleRate = options.sampleRate;
       const clipDuration = config.duration ?? noteDuration;
 
       const clip = createClipFromSeconds({
@@ -210,7 +219,7 @@ export function useMidiTracks(configs: MidiTrackConfig[]): UseMidiTracksReturn {
       cancelled = true;
       abortController.abort();
     };
-  }, [configs]);
+  }, [configs, options.sampleRate]);
 
   return { tracks, loading, error, loadedCount, totalCount };
 }

--- a/website/docs/api/hooks.md
+++ b/website/docs/api/hooks.md
@@ -742,7 +742,6 @@ interface UseClipDragHandlersOptions {
   tracks: ClipTrack[];
   onTracksChange: (tracks: ClipTrack[]) => void;
   samplesPerPixel: number;
-  sampleRate: number;
   engineRef: RefObject<PlaylistEngine | null>;
   /** Ref toggled during boundary trim drags. Obtain from usePlaylistData(). */
   isDraggingRef: MutableRefObject<boolean>;
@@ -758,14 +757,13 @@ import { ClipCollisionModifier, noDropAnimationPlugins, useDragSensors } from '@
 
 function EditablePlaylist() {
   const [tracks, setTracks] = useState<ClipTrack[]>(initialTracks);
-  const { samplesPerPixel, sampleRate, playoutRef, isDraggingRef } = usePlaylistData();
+  const { samplesPerPixel, playoutRef, isDraggingRef } = usePlaylistData();
   const sensors = useDragSensors();
 
   const { onDragStart, onDragMove, onDragEnd } = useClipDragHandlers({
     tracks,
     onTracksChange: setTracks,
     samplesPerPixel,
-    sampleRate,
     engineRef: playoutRef,
     isDraggingRef,
   });
@@ -814,7 +812,6 @@ function useClipSplitting(options: UseClipSplittingOptions): UseClipSplittingRes
 ```typescript
 interface UseClipSplittingOptions {
   tracks: ClipTrack[];
-  sampleRate: number;
   samplesPerPixel: number;
   engineRef: RefObject<PlaylistEngine | null>;
 }
@@ -833,11 +830,10 @@ interface UseClipSplittingResult {
 
 ```tsx
 function SplitButton() {
-  const { tracks, sampleRate, samplesPerPixel, playoutRef } = usePlaylistData();
+  const { tracks, samplesPerPixel, playoutRef } = usePlaylistData();
 
   const { splitClipAtPlayhead } = useClipSplitting({
     tracks,
-    sampleRate,
     samplesPerPixel,
     engineRef: playoutRef,
   });

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -449,7 +449,6 @@ interface UseClipDragHandlersOptions {
   tracks: ClipTrack[];
   onTracksChange: (tracks: ClipTrack[]) => void;
   samplesPerPixel: number;
-  sampleRate: number;
   engineRef: RefObject<PlaylistEngine | null>;
   /** Ref toggled during boundary trim drags. Obtain from usePlaylistData(). */
   isDraggingRef: MutableRefObject<boolean>;
@@ -516,7 +515,6 @@ function useClipSplitting(options: UseClipSplittingOptions): UseClipSplittingRes
 
 interface UseClipSplittingOptions {
   tracks: ClipTrack[];
-  sampleRate: number;
   samplesPerPixel: number;
   engineRef: RefObject<PlaylistEngine | null>;
 }
@@ -538,7 +536,7 @@ Load and parse MIDI files into `ClipTrack[]` with `midiNotes` for piano roll vis
 ### useMidiTracks
 
 ```typescript
-function useMidiTracks(configs: MidiTrackConfig[]): UseMidiTracksReturn;
+function useMidiTracks(configs: MidiTrackConfig[], options: UseMidiTracksOptions): UseMidiTracksReturn;
 
 interface MidiTrackConfig {
   src?: string;                    // URL to .mid file
@@ -551,8 +549,11 @@ interface MidiTrackConfig {
   color?: string;
   startTime?: number;              // Clip position in seconds (default 0)
   duration?: number;               // Override clip duration in seconds
-  sampleRate: number;              // Required — pass AudioContext.sampleRate
   flatten?: boolean;               // Merge all MIDI tracks into one (default false)
+}
+
+interface UseMidiTracksOptions {
+  sampleRate: number;              // Required — pass AudioContext.sampleRate
 }
 
 interface UseMidiTracksReturn {

--- a/website/docs/guides/annotations.md
+++ b/website/docs/guides/annotations.md
@@ -151,9 +151,9 @@ const { onDragStart, onDragMove, onDragEnd } = useAnnotationDragHandlers({
   annotations,           // AnnotationData[]
   onAnnotationsChange,   // (annotations) => void
   samplesPerPixel,       // number
-  sampleRate,            // number
   duration,              // number (total duration in seconds)
   linkEndpoints,         // boolean
+  sampleRate,            // number (optional — defaults to getGlobalAudioContext().sampleRate)
 });
 ```
 

--- a/website/docs/guides/custom-drag-setup.md
+++ b/website/docs/guides/custom-drag-setup.md
@@ -42,7 +42,7 @@ The minimal setup for interactive clips with collision detection:
 
 ```tsx
 function PlaylistWithDrag({ tracks, onTracksChange }) {
-  const { samplesPerPixel, sampleRate, playoutRef, isDraggingRef } = usePlaylistData();
+  const { samplesPerPixel, playoutRef, isDraggingRef } = usePlaylistData();
   const { setSelectedTrackId } = usePlaylistControls();
 
   // Configure drag sensors (pointer activation with 1px distance threshold)
@@ -57,7 +57,6 @@ function PlaylistWithDrag({ tracks, onTracksChange }) {
     tracks,
     onTracksChange,
     samplesPerPixel,
-    sampleRate,
     engineRef: playoutRef,
     isDraggingRef,
   });
@@ -118,6 +117,7 @@ import { useBeatsAndBars } from '@waveform-playlist/ui-components';
 function PlaylistWithBeatsSnap({ tracks, onTracksChange }) {
   const { samplesPerPixel, sampleRate, playoutRef, isDraggingRef } = usePlaylistData();
   const beatsAndBars = useBeatsAndBars();
+
   const { bpm, timeSignature, snapTo } = beatsAndBars;
 
   // Snap function for boundary trims (snaps absolute sample position to grid)
@@ -137,7 +137,6 @@ function PlaylistWithBeatsSnap({ tracks, onTracksChange }) {
     tracks,
     onTracksChange,
     samplesPerPixel,
-    sampleRate,
     engineRef: playoutRef,
     isDraggingRef,
     snapSamplePosition, // Snaps boundary trims to grid
@@ -317,7 +316,6 @@ This uses delay-based activation for touch events (distinguishes drag from scrol
 | `tracks` | `ClipTrack[]` | Yes | Current tracks state |
 | `onTracksChange` | `(tracks: ClipTrack[]) => void` | Yes | Callback when tracks change |
 | `samplesPerPixel` | `number` | Yes | Current zoom level |
-| `sampleRate` | `number` | Yes | Audio sample rate |
 | `engineRef` | `RefObject<PlaylistEngine>` | Yes | Engine ref from `usePlaylistData().playoutRef` |
 | `isDraggingRef` | `MutableRefObject<boolean>` | Yes | Drag state ref from `usePlaylistData().isDraggingRef` |
 | `snapSamplePosition` | `(sample: number) => number` | No | Snap function for boundary trims |

--- a/website/docs/guides/midi.md
+++ b/website/docs/guides/midi.md
@@ -24,9 +24,10 @@ import { useMidiTracks } from '@waveform-playlist/midi';
 import { WaveformPlaylistProvider, Waveform, PlayButton, StopButton } from '@waveform-playlist/browser';
 
 function MidiPlayer() {
-  const { tracks, loading, error } = useMidiTracks([
-    { src: '/music/song.mid' },
-  ]);
+  const { tracks, loading, error } = useMidiTracks(
+    [{ src: '/music/song.mid' }],
+    { sampleRate: 48000 },
+  );
 
   if (loading) return <div>Loading MIDI...</div>;
   if (error) return <div>Error: {error}</div>;
@@ -56,8 +57,11 @@ interface MidiTrackConfig {
   color?: string;
   startTime?: number;         // Clip position in seconds (default: 0)
   duration?: number;          // Override clip duration in seconds
-  sampleRate: number;          // Required — pass AudioContext.sampleRate
   flatten?: boolean;          // Merge all MIDI tracks into one (default: false)
+}
+
+interface UseMidiTracksOptions {
+  sampleRate: number;         // Required — pass AudioContext.sampleRate
 }
 ```
 
@@ -66,16 +70,19 @@ interface MidiTrackConfig {
 If you already have note data (e.g., from a custom parser or algorithm), skip the fetch step:
 
 ```tsx
-const { tracks } = useMidiTracks([
-  {
-    midiNotes: [
-      { midi: 60, name: 'C4', time: 0, duration: 0.5, velocity: 0.8 },
-      { midi: 64, name: 'E4', time: 0.5, duration: 0.5, velocity: 0.7 },
-    ],
-    name: 'Melody',
-    duration: 4,
-  },
-]);
+const { tracks } = useMidiTracks(
+  [
+    {
+      midiNotes: [
+        { midi: 60, name: 'C4', time: 0, duration: 0.5, velocity: 0.8 },
+        { midi: 64, name: 'E4', time: 0.5, duration: 0.5, velocity: 0.7 },
+      ],
+      name: 'Melody',
+      duration: 4,
+    },
+  ],
+  { sampleRate: 48000 },
+);
 ```
 
 ### Flatten Mode
@@ -83,9 +90,10 @@ const { tracks } = useMidiTracks([
 By default, each MIDI channel becomes a separate track. Use `flatten: true` to merge all channels into one visual track:
 
 ```tsx
-const { tracks } = useMidiTracks([
-  { src: '/music/song.mid', flatten: true },
-]);
+const { tracks } = useMidiTracks(
+  [{ src: '/music/song.mid', flatten: true }],
+  { sampleRate: 48000 },
+);
 ```
 
 ## SoundFont Playback
@@ -119,9 +127,10 @@ import { useMidiTracks } from '@waveform-playlist/midi';
 import { useAudioTracks, WaveformPlaylistProvider, Waveform } from '@waveform-playlist/browser';
 
 function MixedPlayer() {
-  const { tracks: midiTracks, loading: midiLoading } = useMidiTracks([
-    { src: '/music/song.mid' },
-  ]);
+  const { tracks: midiTracks, loading: midiLoading } = useMidiTracks(
+    [{ src: '/music/song.mid' }],
+    { sampleRate: 48000 },
+  );
 
   const { tracks: audioTracks, loading: audioLoading } = useAudioTracks([
     { src: '/audio/vocals.mp3', name: 'Vocals' },

--- a/website/src/components/examples/AnnotationsExample.tsx
+++ b/website/src/components/examples/AnnotationsExample.tsx
@@ -332,7 +332,7 @@ const AnnotationsAppContent: React.FC<AnnotationsAppContentProps> = ({
   defaultAnnotationDuration = 3.0,
   minAnnotationDuration = 0.5,
 }) => {
-  const { samplesPerPixel, sampleRate, duration, controls } = usePlaylistData();
+  const { samplesPerPixel, duration, controls } = usePlaylistData();
   const { annotations, linkEndpoints, activeAnnotationId } = usePlaylistState();
   const { setAnnotations, play } = usePlaylistControls();
   const { currentTime } = usePlaybackAnimation();
@@ -345,7 +345,6 @@ const AnnotationsAppContent: React.FC<AnnotationsAppContentProps> = ({
     annotations,
     onAnnotationsChange: setAnnotations,
     samplesPerPixel,
-    sampleRate,
     duration,
     linkEndpoints,
   });

--- a/website/src/components/examples/MidiExample.tsx
+++ b/website/src/components/examples/MidiExample.tsx
@@ -276,19 +276,18 @@ export function MidiExample() {
   } = useSoundFontCache(soundFontUrl);
 
   // Build configs: base (unless hidden) + user-added
-  const ctxSampleRate = typeof AudioContext !== 'undefined'
-    ? getGlobalAudioContext().sampleRate : 48000;
-
   const midiConfigs = React.useMemo(() => {
     const configs: MidiTrackConfig[] = [];
     if (!baseHidden) {
-      configs.push({ src: BASE_MIDI_SRC, sampleRate: ctxSampleRate });
+      configs.push({ src: BASE_MIDI_SRC });
     }
-    configs.push(...userMidiConfigs.map((c) => ({ ...c, sampleRate: c.sampleRate ?? ctxSampleRate })));
+    configs.push(...userMidiConfigs);
     return configs;
-  }, [baseHidden, userMidiConfigs, ctxSampleRate]);
+  }, [baseHidden, userMidiConfigs]);
 
-  const { tracks: allTracks, loading, error, loadedCount, totalCount } = useMidiTracks(midiConfigs);
+  const { tracks: allTracks, loading, error, loadedCount, totalCount } = useMidiTracks(midiConfigs, {
+    sampleRate: getGlobalAudioContext().sampleRate,
+  });
 
   // Merge MIDI + audio tracks and filter out removed ones
   const filteredTracks = React.useMemo(

--- a/website/src/components/examples/MobileAnnotationsExample.tsx
+++ b/website/src/components/examples/MobileAnnotationsExample.tsx
@@ -259,7 +259,7 @@ interface MobileAnnotationsContentProps {
 }
 
 const MobileAnnotationsContent: React.FC<MobileAnnotationsContentProps> = ({ tracks }) => {
-  const { samplesPerPixel, sampleRate, duration, controls } = usePlaylistData();
+  const { samplesPerPixel, duration, controls } = usePlaylistData();
   const { annotations, linkEndpoints, activeAnnotationId, continuousPlay } = usePlaylistState();
   const { setAnnotations, setActiveAnnotationId, play } = usePlaylistControls();
   const { currentTime } = usePlaybackAnimation();
@@ -271,7 +271,6 @@ const MobileAnnotationsContent: React.FC<MobileAnnotationsContentProps> = ({ tra
     annotations,
     onAnnotationsChange: setAnnotations,
     samplesPerPixel,
-    sampleRate,
     duration,
     linkEndpoints,
   });

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -88,7 +88,7 @@ Both providers use React Context with 4 split contexts for performance.
 
 ### MIDI Hooks (from `@waveform-playlist/midi`)
 
-- `useMidiTracks(configs)` — Load .mid files into ClipTrack[] with midiNotes for piano roll rendering. One config can produce multiple tracks (one per MIDI channel). Supports pre-parsed notes via `midiNotes` prop.
+- `useMidiTracks(configs, options)` — Load .mid files into ClipTrack[] with midiNotes for piano roll rendering. `options: { sampleRate: number }`. One config can produce multiple tracks (one per MIDI channel). Supports pre-parsed notes via `midiNotes` prop.
 - `parseMidiFile(data, options?)` — Pure function: ArrayBuffer → ParsedMidi with tracks, notes, tempo, time signature. No React dependency.
 - `parseMidiUrl(url, options?, signal?)` — Fetch + parse convenience wrapper with AbortSignal support.
 


### PR DESCRIPTION
## Summary

- **Browser hooks** (`useClipDragHandlers`, `useClipSplitting`, `useAnnotationKeyboardControls`) now read `sampleRate` from `usePlaylistData()` internally — callers no longer thread it through
- **`useAnnotationDragHandlers`** makes `sampleRate` optional, defaulting to `getGlobalAudioContext().sampleRate`
- **`useMidiTracks`** moves `sampleRate` from per-config (`MidiTrackConfig`) to a hook-level `UseMidiTracksOptions` parameter — pass it once instead of on every config
- Website examples updated to use the simpler APIs

## Test plan

- [ ] `cd packages/browser && npx vitest run` — 194 tests pass
- [ ] `cd packages/midi && npx vitest run` — 22 tests pass
- [ ] `pnpm build` and `pnpm -w lint` clean
- [ ] Verify annotations example drag works (sampleRate defaults correctly)
- [ ] Verify MIDI example loads tracks (sampleRate passed at hook level)