### PR TITLE
feat: extract keyboard shortcuts to core, configurable dawcore shortcuts

### DIFF
--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -255,7 +255,7 @@ const sourceEnd = Math.min(waveformData.length, Math.ceil(targetEnd * ratio));
 
 - `new KeyboardEvent()` has `target: null` in jsdom — use `Object.defineProperty(event, 'target', { value: document.body })` when calling handlers directly (not via `dispatchEvent`)
 - jsdom doesn't implement `isContentEditable` (returns `undefined` as of jsdom 28). Polyfill with `Object.defineProperty(el, 'isContentEditable', { value: true })` in tests
-- `handleKeyboardEvent` is exported as a pure function from `useKeyboardShortcuts.ts` for direct unit testing without React rendering infrastructure
+- `handleKeyboardEvent` is a pure function in `@waveform-playlist/core` (re-exported from `useKeyboardShortcuts.ts` for backwards compatibility). Unit tests import from core directly.
 
 ## Click-to-Seek During Auto-Scroll
 

--- a/packages/browser/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/browser/src/hooks/useKeyboardShortcuts.ts
@@ -1,59 +1,14 @@
 import { useEffect, useCallback } from 'react';
+import { handleKeyboardEvent } from '@waveform-playlist/core';
+import type { KeyboardShortcut } from '@waveform-playlist/core';
 
-export interface KeyboardShortcut {
-  key: string;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-  metaKey?: boolean;
-  altKey?: boolean;
-  action: () => void;
-  description?: string;
-  preventDefault?: boolean;
-}
+// Re-export from core for backwards compatibility
+export type { KeyboardShortcut } from '@waveform-playlist/core';
+export { handleKeyboardEvent, getShortcutLabel } from '@waveform-playlist/core';
 
 export interface UseKeyboardShortcutsOptions {
   shortcuts: KeyboardShortcut[];
   enabled?: boolean;
-}
-
-/**
- * Handle a keyboard event against a list of shortcuts.
- * Extracted from the hook for testability — pure function, no React dependency.
- */
-export function handleKeyboardEvent(
-  event: KeyboardEvent,
-  shortcuts: KeyboardShortcut[],
-  enabled: boolean
-): void {
-  if (!enabled) return;
-
-  // Ignore key repeat events — holding a key fires keydown repeatedly.
-  // Without this guard, holding Space rapidly toggles play/pause.
-  if (event.repeat) return;
-
-  const target = event.target as HTMLElement;
-  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-    return;
-  }
-
-  const matchingShortcut = shortcuts.find((shortcut) => {
-    const keyMatch =
-      event.key.toLowerCase() === shortcut.key.toLowerCase() || event.key === shortcut.key;
-
-    const ctrlMatch = shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey;
-    const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
-    const metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
-    const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
-
-    return keyMatch && ctrlMatch && shiftMatch && metaMatch && altMatch;
-  });
-
-  if (matchingShortcut) {
-    if (matchingShortcut.preventDefault !== false) {
-      event.preventDefault();
-    }
-    matchingShortcut.action();
-  }
 }
 
 /**
@@ -98,37 +53,4 @@ export const useKeyboardShortcuts = (options: UseKeyboardShortcutsOptions): void
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown, enabled]);
-};
-
-/**
- * Get a human-readable string representation of a keyboard shortcut
- *
- * @param shortcut - The keyboard shortcut
- * @returns Human-readable string (e.g., "Cmd+Shift+S")
- */
-export const getShortcutLabel = (shortcut: KeyboardShortcut): string => {
-  const parts: string[] = [];
-
-  // Use Cmd on Mac, Ctrl on other platforms
-  const isMac = typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
-
-  if (shortcut.metaKey) {
-    parts.push(isMac ? 'Cmd' : 'Ctrl');
-  }
-
-  if (shortcut.ctrlKey && !shortcut.metaKey) {
-    parts.push('Ctrl');
-  }
-
-  if (shortcut.altKey) {
-    parts.push(isMac ? 'Option' : 'Alt');
-  }
-
-  if (shortcut.shiftKey) {
-    parts.push('Shift');
-  }
-
-  parts.push(shortcut.key.toUpperCase());
-
-  return parts.join('+');
 };

--- a/packages/core/src/__tests__/keyboard.test.ts
+++ b/packages/core/src/__tests__/keyboard.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleKeyboardEvent, getShortcutLabel } from '../keyboard';
+import type { KeyboardShortcut } from '../keyboard';
+
+function makeKeyboardEvent(
+  key: string,
+  overrides: Partial<KeyboardEventInit & { repeat: boolean }> = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    ...overrides,
+  });
+  Object.defineProperty(event, 'target', { value: document.body });
+  return event;
+}
+
+describe('handleKeyboardEvent', () => {
+  let action: ReturnType<typeof vi.fn>;
+  let shortcuts: KeyboardShortcut[];
+
+  beforeEach(() => {
+    action = vi.fn();
+    shortcuts = [{ key: ' ', action, description: 'Play/Pause', preventDefault: true }];
+  });
+
+  it('calls action on matching keydown', () => {
+    handleKeyboardEvent(makeKeyboardEvent(' '), shortcuts, true);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call action when disabled', () => {
+    handleKeyboardEvent(makeKeyboardEvent(' '), shortcuts, false);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not call action on key repeat', () => {
+    handleKeyboardEvent(makeKeyboardEvent(' ', { repeat: true }), shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not call action for non-matching key', () => {
+    handleKeyboardEvent(makeKeyboardEvent('a'), shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('matches keys case-insensitively', () => {
+    const sAction = vi.fn();
+    const sShortcuts: KeyboardShortcut[] = [{ key: 's', action: sAction, description: 'Split' }];
+    handleKeyboardEvent(makeKeyboardEvent('S'), sShortcuts, true);
+    expect(sAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call action when target is an input element', () => {
+    const input = document.createElement('input');
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
+    Object.defineProperty(event, 'target', { value: input });
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not call action when target is a textarea element', () => {
+    const textarea = document.createElement('textarea');
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
+    Object.defineProperty(event, 'target', { value: textarea });
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not call action when target is contentEditable', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
+    Object.defineProperty(event, 'target', { value: div });
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('calls preventDefault when shortcut.preventDefault is true', () => {
+    const event = makeKeyboardEvent(' ');
+    const spy = vi.spyOn(event, 'preventDefault');
+    handleKeyboardEvent(event, shortcuts, true);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not call preventDefault when shortcut.preventDefault is false', () => {
+    const noPrevent: KeyboardShortcut[] = [
+      { key: ' ', action, description: 'test', preventDefault: false },
+    ];
+    const event = makeKeyboardEvent(' ');
+    const spy = vi.spyOn(event, 'preventDefault');
+    handleKeyboardEvent(event, noPrevent, true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  describe('modifier key matching', () => {
+    it('matches ctrlKey when specified', () => {
+      const ctrlShortcuts: KeyboardShortcut[] = [
+        { key: 'z', action, ctrlKey: true, description: 'Undo' },
+      ];
+      handleKeyboardEvent(makeKeyboardEvent('z', { ctrlKey: true }), ctrlShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+
+      handleKeyboardEvent(makeKeyboardEvent('z', { ctrlKey: false }), ctrlShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1); // Still 1 — not called again
+    });
+
+    it('matches shiftKey when specified', () => {
+      const shiftShortcuts: KeyboardShortcut[] = [
+        { key: 's', action, shiftKey: true, description: 'Split at selection' },
+      ];
+      handleKeyboardEvent(makeKeyboardEvent('S', { shiftKey: true }), shiftShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+
+      handleKeyboardEvent(makeKeyboardEvent('s', { shiftKey: false }), shiftShortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores modifier keys when not specified in shortcut', () => {
+      handleKeyboardEvent(makeKeyboardEvent(' ', { ctrlKey: true }), shortcuts, true);
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('multiple shortcuts', () => {
+    it('calls the correct action for each key', () => {
+      const playAction = vi.fn();
+      const stopAction = vi.fn();
+      const multi: KeyboardShortcut[] = [
+        { key: ' ', action: playAction, description: 'Play' },
+        { key: 'Escape', action: stopAction, description: 'Stop' },
+      ];
+
+      handleKeyboardEvent(makeKeyboardEvent(' '), multi, true);
+      expect(playAction).toHaveBeenCalledTimes(1);
+      expect(stopAction).not.toHaveBeenCalled();
+
+      handleKeyboardEvent(makeKeyboardEvent('Escape'), multi, true);
+      expect(stopAction).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('getShortcutLabel', () => {
+  it('returns uppercase key for simple shortcut', () => {
+    expect(getShortcutLabel({ key: 's', action: () => {} })).toBe('S');
+  });
+
+  it('includes Ctrl for ctrlKey shortcut', () => {
+    expect(getShortcutLabel({ key: 'z', ctrlKey: true, action: () => {} })).toBe('Ctrl+Z');
+  });
+
+  it('includes Shift for shiftKey shortcut', () => {
+    expect(getShortcutLabel({ key: 's', shiftKey: true, action: () => {} })).toBe('Shift+S');
+  });
+
+  it('combines multiple modifiers', () => {
+    const label = getShortcutLabel({
+      key: 's',
+      ctrlKey: true,
+      shiftKey: true,
+      action: () => {},
+    });
+    expect(label).toBe('Ctrl+Shift+S');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './utils';
 export * from './clipTimeHelpers';
 export * from './fades';
+export * from './keyboard';

--- a/packages/core/src/keyboard.ts
+++ b/packages/core/src/keyboard.ts
@@ -1,0 +1,88 @@
+/**
+ * Framework-agnostic keyboard shortcut handling.
+ * Used by both React (useKeyboardShortcuts) and Web Components (daw-editor).
+ */
+
+export interface KeyboardShortcut {
+  key: string;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  action: () => void;
+  description?: string;
+  preventDefault?: boolean;
+}
+
+/**
+ * Handle a keyboard event against a list of shortcuts.
+ * Pure function, no framework dependency.
+ */
+export function handleKeyboardEvent(
+  event: KeyboardEvent,
+  shortcuts: KeyboardShortcut[],
+  enabled: boolean
+): void {
+  if (!enabled) return;
+
+  // Ignore key repeat events — holding a key fires keydown repeatedly.
+  // Without this guard, holding Space rapidly toggles play/pause.
+  if (event.repeat) return;
+
+  const target = event.target as HTMLElement;
+  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+    return;
+  }
+
+  const matchingShortcut = shortcuts.find((shortcut) => {
+    const keyMatch =
+      event.key.toLowerCase() === shortcut.key.toLowerCase() || event.key === shortcut.key;
+
+    const ctrlMatch = shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey;
+    const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
+    const metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
+    const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
+
+    return keyMatch && ctrlMatch && shiftMatch && metaMatch && altMatch;
+  });
+
+  if (matchingShortcut) {
+    if (matchingShortcut.preventDefault !== false) {
+      event.preventDefault();
+    }
+    matchingShortcut.action();
+  }
+}
+
+/**
+ * Get a human-readable string representation of a keyboard shortcut.
+ *
+ * @param shortcut - The keyboard shortcut
+ * @returns Human-readable string (e.g., "Cmd+Shift+S")
+ */
+export const getShortcutLabel = (shortcut: KeyboardShortcut): string => {
+  const parts: string[] = [];
+
+  // Use Cmd on Mac, Ctrl on other platforms
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
+
+  if (shortcut.metaKey) {
+    parts.push(isMac ? 'Cmd' : 'Ctrl');
+  }
+
+  if (shortcut.ctrlKey && !shortcut.metaKey) {
+    parts.push('Ctrl');
+  }
+
+  if (shortcut.altKey) {
+    parts.push(isMac ? 'Option' : 'Alt');
+  }
+
+  if (shortcut.shiftKey) {
+    parts.push('Shift');
+  }
+
+  parts.push(shortcut.key.toUpperCase());
+
+  return parts.join('+');
+};

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -17,7 +17,7 @@
 
 ## Dev Page Dependencies
 
-- **`pnpm dev:page` resolves peer packages from `dist/`** — No Vite source aliases. After changing `@waveform-playlist/engine` or `@waveform-playlist/playout` source, run `pnpm build` in those packages before testing on the dev page.
+- **`pnpm dev:page` resolves peer packages from source** — `dev/vite.config.ts` has `resolve.alias` for core, engine, and playout pointing to `src/index.ts`. Changes are picked up immediately without rebuilding.
 - **Incremental track removal** — `engine.removeTrack(trackId)` uses `adapter.removeTrack()` when available (disposes single track, preserves playback). Falls back to `adapter.setTracks()` (full rebuild, stops Transport).
 
 ## Element Types
@@ -126,7 +126,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **Trim peak re-extraction** — During trim drag, call `host.reextractClipPeaks()` to synchronously re-slice peaks from cached WaveformData at the new offset/duration. When peaks are available, set waveforms to `left:0` (peaks cover full new bounds). Fall back to `-deltaPx` shift only when cache unavailable.
 - **Statechange syncs `_engineTracks`** — When `tracksVersion` changes, rebuild `_engineTracks` Map from engine state. This is how `moveClip`/`trimClip`/`splitClip` trigger Lit re-renders.
 - **`DRAG_THRESHOLD`** — Shared constant in `interactions/constants.ts` (3px, click vs drag). Boundary width (8px) is CSS-only in `styles/theme.ts` (CSS can't import JS constants).
-- **Keyboard shortcut modifier guard** — `_onKeyDown` must check `e.ctrlKey || e.metaKey || e.altKey` before handling `S` key. Without this, Ctrl+S (save) triggers split.
+- **Keyboard shortcuts via core** — `<daw-editor>` uses `handleKeyboardEvent` from `@waveform-playlist/core`. Listener on `document` (not the element — users won't know to focus it). Configurable via `editor.shortcuts` JS property; defaults: Space (play/pause), Escape (stop), 0 (rewind), S (split, when `interactive-clips`).
+- **Split pre-flight check** — `splitAtPlayhead` calls `canSplitAtTime` before stopping playback. Without this, pressing S with no track selected interrupts audio for a no-op.
 - **`engine.constrainTrimDelta()`** — Wraps the engine's `constrainBoundaryTrim` pure function. Call during trim drag for per-frame collision detection (timeline bounds, audio bounds, neighbor overlap, min duration). Don't manually clamp — use the engine's constraints so visual preview matches what's applied on drop.
 
 ## Typed Events

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -45,7 +45,7 @@
 
   <script type="module" src="/src/index.ts"></script>
 
-  <daw-editor id="editor" samples-per-pixel="1024" wave-height="80" timescale file-drop clip-headers interactive-clips>
+  <daw-editor id="editor" samples-per-pixel="1024" wave-height="80" timescale file-drop clip-headers interactive-clips keyboard-shortcuts>
     <!-- Kick: two clips with a gap -->
     <daw-track name="Kick">
       <daw-clip src="/media/audio/AlbertKader_Ubiquitous/01_Kick.opus"

--- a/packages/dawcore/dev/vite.config.ts
+++ b/packages/dawcore/dev/vite.config.ts
@@ -4,9 +4,19 @@ import path from 'node:path';
 const packageDir = path.resolve(import.meta.dirname, '..');
 const repoRoot = path.resolve(packageDir, '../..');
 
+// Resolve workspace peer dependencies from source (not dist/) so dev page
+// picks up changes without rebuilding. Matches the Docusaurus webpack alias
+// pattern in website/docusaurus.config.ts.
 export default defineConfig({
   root: packageDir,
   publicDir: path.resolve(repoRoot, 'website/static'),
+  resolve: {
+    alias: {
+      '@waveform-playlist/core': path.resolve(repoRoot, 'packages/core/src/index.ts'),
+      '@waveform-playlist/engine': path.resolve(repoRoot, 'packages/engine/src/index.ts'),
+      '@waveform-playlist/playout': path.resolve(repoRoot, 'packages/playout/src/index.ts'),
+    },
+  },
   server: {
     port: 5173,
     open: false,

--- a/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { splitAtPlayhead } from '../interactions/split-handler';
-import type { SplitHost } from '../interactions/split-handler';
+import { splitAtPlayhead, splitAtPlayheadSafe } from '../interactions/split-handler';
+import type { SplitHost, SplitDuringPlaybackHost } from '../interactions/split-handler';
 import type { AudioClip, ClipTrack } from '@waveform-playlist/core';
 
 // ---------------------------------------------------------------------------
@@ -311,5 +311,101 @@ describe('splitAtPlayhead', () => {
       expect(result).toBe(false);
       expect(host.events).toHaveLength(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitAtPlayheadSafe — stop/resume during playback
+// ---------------------------------------------------------------------------
+
+describe('splitAtPlayheadSafe', () => {
+  function createPlaybackHost(
+    overrides: Partial<SplitDuringPlaybackHost> = {}
+  ): SplitDuringPlaybackHost & { events: Event[] } {
+    const events: Event[] = [];
+    return {
+      effectiveSampleRate: 48000,
+      currentTime: 0.5,
+      isPlaying: false,
+      engine: null,
+      stop: vi.fn(),
+      play: vi.fn(),
+      dispatchEvent: vi.fn((event: Event) => {
+        events.push(event);
+        return true;
+      }),
+      events,
+      ...overrides,
+    };
+  }
+
+  it('stops playback before split and resumes after success', () => {
+    const clip = makeClip('clip-1', 0, 96000);
+    const track = makeTrack('track-1', [clip]);
+
+    const leftClip = makeClip('clip-left', 0, 24000);
+    const rightClip = makeClip('clip-right', 24000, 72000);
+    const trackAfter = makeTrack('track-1', [leftClip, rightClip]);
+
+    const engine = {
+      getState: vi
+        .fn()
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
+      splitClip: vi.fn(),
+    };
+
+    const host = createPlaybackHost({
+      engine,
+      currentTime: 0.5,
+      isPlaying: true,
+    });
+
+    const result = splitAtPlayheadSafe(host);
+
+    expect(result).toBe(true);
+    expect(host.stop).toHaveBeenCalledTimes(1);
+    expect(host.play).toHaveBeenCalledWith(0.5);
+  });
+
+  it('does not stop or resume when not playing', () => {
+    const clip = makeClip('clip-1', 0, 96000);
+    const track = makeTrack('track-1', [clip]);
+
+    const leftClip = makeClip('clip-left', 0, 24000);
+    const rightClip = makeClip('clip-right', 24000, 72000);
+    const trackAfter = makeTrack('track-1', [leftClip, rightClip]);
+
+    const engine = {
+      getState: vi
+        .fn()
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
+      splitClip: vi.fn(),
+    };
+
+    const host = createPlaybackHost({
+      engine,
+      currentTime: 0.5,
+      isPlaying: false,
+    });
+
+    splitAtPlayheadSafe(host);
+
+    expect(host.stop).not.toHaveBeenCalled();
+    expect(host.play).not.toHaveBeenCalled();
+  });
+
+  it('does not resume when split fails', () => {
+    const host = createPlaybackHost({
+      engine: null,
+      isPlaying: true,
+    });
+
+    const result = splitAtPlayheadSafe(host);
+
+    expect(result).toBe(false);
+    expect(host.stop).toHaveBeenCalledTimes(1);
+    expect(host.play).not.toHaveBeenCalled();
   });
 });

--- a/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { splitAtPlayhead, splitAtPlayheadSafe } from '../interactions/split-handler';
-import type { SplitHost, SplitDuringPlaybackHost } from '../interactions/split-handler';
+import { splitAtPlayhead } from '../interactions/split-handler';
+import type { SplitHost } from '../interactions/split-handler';
 import type { AudioClip, ClipTrack } from '@waveform-playlist/core';
 
 // ---------------------------------------------------------------------------
@@ -43,7 +43,10 @@ function createMockHost(overrides: Partial<SplitHost> = {}): SplitHost & { event
   const host: SplitHost & { events: CustomEvent[] } = {
     effectiveSampleRate: 48000,
     currentTime: 0,
+    isPlaying: false,
     engine: null,
+    stop: vi.fn(),
+    play: vi.fn(),
     dispatchEvent: vi.fn((event: Event) => {
       events.push(event as CustomEvent);
       return true;
@@ -315,13 +318,11 @@ describe('splitAtPlayhead', () => {
 });
 
 // ---------------------------------------------------------------------------
-// splitAtPlayheadSafe — stop/resume during playback
+// splitAtPlayhead — stop/resume during playback
 // ---------------------------------------------------------------------------
 
-describe('splitAtPlayheadSafe', () => {
-  function createPlaybackHost(
-    overrides: Partial<SplitDuringPlaybackHost> = {}
-  ): SplitDuringPlaybackHost & { events: Event[] } {
+describe('splitAtPlayhead', () => {
+  function createPlaybackHost(overrides: Partial<SplitHost> = {}): SplitHost & { events: Event[] } {
     const events: Event[] = [];
     return {
       effectiveSampleRate: 48000,
@@ -361,7 +362,7 @@ describe('splitAtPlayheadSafe', () => {
       isPlaying: true,
     });
 
-    const result = splitAtPlayheadSafe(host);
+    const result = splitAtPlayhead(host);
 
     expect(result).toBe(true);
     expect(host.stop).toHaveBeenCalledTimes(1);
@@ -390,7 +391,7 @@ describe('splitAtPlayheadSafe', () => {
       isPlaying: false,
     });
 
-    splitAtPlayheadSafe(host);
+    splitAtPlayhead(host);
 
     expect(host.stop).not.toHaveBeenCalled();
     expect(host.play).not.toHaveBeenCalled();
@@ -402,7 +403,7 @@ describe('splitAtPlayheadSafe', () => {
       isPlaying: true,
     });
 
-    const result = splitAtPlayheadSafe(host);
+    const result = splitAtPlayhead(host);
 
     expect(result).toBe(false);
     expect(host.stop).toHaveBeenCalledTimes(1);

--- a/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
@@ -387,11 +387,13 @@ describe('splitAtPlayhead', () => {
     const rightClip = makeClip('clip-right', 24000, 72000);
     const trackAfter = makeTrack('track-1', [leftClip, rightClip]);
 
+    const stateBefore = { selectedTrackId: 'track-1', tracks: [track] };
     const engine = {
       getState: vi
         .fn()
-        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
-        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
+        .mockReturnValueOnce(stateBefore) // canSplitAtTime
+        .mockReturnValueOnce(stateBefore) // performSplit before
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }), // after
       splitClip: vi.fn(),
     };
 
@@ -401,8 +403,9 @@ describe('splitAtPlayhead', () => {
       isPlaying: false,
     });
 
-    splitAtPlayhead(host);
+    const result = splitAtPlayhead(host);
 
+    expect(result).toBe(true);
     expect(host.stop).not.toHaveBeenCalled();
     expect(host.play).not.toHaveBeenCalled();
   });
@@ -456,5 +459,34 @@ describe('splitAtPlayhead', () => {
     expect(result).toBe(false);
     expect(host.stop).not.toHaveBeenCalled();
     expect(host.play).not.toHaveBeenCalled();
+  });
+
+  it('resumes playback even when split fails (engine no-op)', () => {
+    const clip = makeClip('clip-1', 0, 96000);
+    const track = makeTrack('track-1', [clip]);
+
+    // canSplitAtTime passes, but engine no-ops (state unchanged after splitClip)
+    const state = { selectedTrackId: 'track-1', tracks: [track] };
+    const engine = {
+      getState: vi
+        .fn()
+        .mockReturnValueOnce(state) // canSplitAtTime
+        .mockReturnValueOnce(state) // performSplit before
+        .mockReturnValueOnce(state), // after — unchanged, no-op
+      splitClip: vi.fn(),
+    };
+
+    const host = createPlaybackHost({
+      engine,
+      currentTime: 0.5,
+      isPlaying: true,
+    });
+
+    const result = splitAtPlayhead(host);
+
+    expect(result).toBe(false);
+    expect(host.stop).toHaveBeenCalledTimes(1);
+    // Must resume even though split was a no-op
+    expect(host.play).toHaveBeenCalledWith(0.5);
   });
 });

--- a/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-clip-interactions.test.ts
@@ -176,7 +176,8 @@ describe('splitAtPlayhead', () => {
       const engine = {
         getState: vi
           .fn()
-          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] })
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] }) // canSplitAtTime
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] }) // performSplit before
           .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
         splitClip: vi.fn(),
       };
@@ -218,7 +219,8 @@ describe('splitAtPlayhead', () => {
       const engine = {
         getState: vi
           .fn()
-          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] })
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] }) // canSplitAtTime
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackBefore] }) // performSplit before
           .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
         splitClip: vi.fn(),
       };
@@ -247,7 +249,8 @@ describe('splitAtPlayhead', () => {
       const engine = {
         getState: vi
           .fn()
-          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] }) // canSplitAtTime
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] }) // performSplit before
           .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
         splitClip: vi.fn(),
       };
@@ -273,7 +276,8 @@ describe('splitAtPlayhead', () => {
       const engine = {
         getState: vi
           .fn()
-          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] }) // canSplitAtTime
+          .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] }) // performSplit before
           .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
         splitClip: vi.fn(),
       };
@@ -300,7 +304,11 @@ describe('splitAtPlayhead', () => {
       const stateSnapshot = { selectedTrackId: 'track-1', tracks: [track] };
 
       const engine = {
-        getState: vi.fn().mockReturnValueOnce(stateSnapshot).mockReturnValueOnce(stateSnapshot),
+        getState: vi
+          .fn()
+          .mockReturnValueOnce(stateSnapshot) // canSplitAtTime
+          .mockReturnValueOnce(stateSnapshot) // performSplit before
+          .mockReturnValueOnce(stateSnapshot), // after (unchanged = no-op)
         splitClip: vi.fn(),
       };
       const host = createMockHost({
@@ -348,11 +356,13 @@ describe('splitAtPlayhead', () => {
     const rightClip = makeClip('clip-right', 24000, 72000);
     const trackAfter = makeTrack('track-1', [leftClip, rightClip]);
 
+    const stateBefore = { selectedTrackId: 'track-1', tracks: [track] };
     const engine = {
       getState: vi
         .fn()
-        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [track] })
-        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }),
+        .mockReturnValueOnce(stateBefore) // canSplitAtTime check
+        .mockReturnValueOnce(stateBefore) // performSplit before
+        .mockReturnValueOnce({ selectedTrackId: 'track-1', tracks: [trackAfter] }), // after
       splitClip: vi.fn(),
     };
 
@@ -397,7 +407,7 @@ describe('splitAtPlayhead', () => {
     expect(host.play).not.toHaveBeenCalled();
   });
 
-  it('does not resume when split fails', () => {
+  it('does not stop or resume when split would be a no-op (no engine)', () => {
     const host = createPlaybackHost({
       engine: null,
       isPlaying: true,
@@ -406,7 +416,45 @@ describe('splitAtPlayhead', () => {
     const result = splitAtPlayhead(host);
 
     expect(result).toBe(false);
-    expect(host.stop).toHaveBeenCalledTimes(1);
+    expect(host.stop).not.toHaveBeenCalled();
+    expect(host.play).not.toHaveBeenCalled();
+  });
+
+  it('does not stop or resume when no track is selected', () => {
+    const engine = {
+      getState: vi.fn().mockReturnValue({ selectedTrackId: null, tracks: [] }),
+      splitClip: vi.fn(),
+    };
+    const host = createPlaybackHost({
+      engine,
+      isPlaying: true,
+      currentTime: 1.0,
+    });
+
+    const result = splitAtPlayhead(host);
+
+    expect(result).toBe(false);
+    expect(host.stop).not.toHaveBeenCalled();
+    expect(host.play).not.toHaveBeenCalled();
+  });
+
+  it('does not stop or resume when playhead is not over a clip', () => {
+    const clip = makeClip('clip-1', 0, 48000);
+    const track = makeTrack('track-1', [clip]);
+    const engine = {
+      getState: vi.fn().mockReturnValue({ selectedTrackId: 'track-1', tracks: [track] }),
+      splitClip: vi.fn(),
+    };
+    const host = createPlaybackHost({
+      engine,
+      isPlaying: true,
+      currentTime: 100.0, // way past the clip
+    });
+
+    const result = splitAtPlayhead(host);
+
+    expect(result).toBe(false);
+    expect(host.stop).not.toHaveBeenCalled();
     expect(host.play).not.toHaveBeenCalled();
   });
 });

--- a/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
@@ -77,10 +77,10 @@ describe('Selection', () => {
 });
 
 describe('seekTo', () => {
-  it('updates currentTime', () => {
+  it('updates currentTime when not playing', () => {
     const el = document.createElement('daw-editor') as any;
-    // Provide a mock engine so seekTo doesn't bail
     el._engine = { seek: vi.fn() };
+    el._isPlaying = false;
     el.seekTo(5.0);
     expect(el._currentTime).toBe(5.0);
   });
@@ -95,14 +95,17 @@ describe('seekTo', () => {
     spy.mockRestore();
   });
 
-  it('does not call _stopPlayhead when playing', () => {
+  it('stops and restarts playback when playing (Tone.js reschedule)', () => {
     const el = document.createElement('daw-editor') as any;
-    el._engine = { seek: vi.fn() };
+    el._engine = { seek: vi.fn(), stop: vi.fn(), play: vi.fn(), init: vi.fn().mockResolvedValue(undefined) };
     el._isPlaying = true;
-    const spy = vi.spyOn(el, '_stopPlayhead').mockImplementation(() => {});
+    const stopSpy = vi.spyOn(el, 'stop');
+    const playSpy = vi.spyOn(el, 'play');
     el.seekTo(3.0);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+    expect(stopSpy).toHaveBeenCalled();
+    expect(playSpy).toHaveBeenCalledWith(3.0);
+    stopSpy.mockRestore();
+    playSpy.mockRestore();
   });
 });
 

--- a/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
@@ -76,6 +76,92 @@ describe('Selection', () => {
   });
 });
 
+describe('seekTo', () => {
+  it('updates currentTime', () => {
+    const el = document.createElement('daw-editor') as any;
+    // Provide a mock engine so seekTo doesn't bail
+    el._engine = { seek: vi.fn() };
+    el.seekTo(5.0);
+    expect(el._currentTime).toBe(5.0);
+  });
+
+  it('calls _stopPlayhead when not playing', () => {
+    const el = document.createElement('daw-editor') as any;
+    el._engine = { seek: vi.fn() };
+    el._isPlaying = false;
+    const spy = vi.spyOn(el, '_stopPlayhead').mockImplementation(() => {});
+    el.seekTo(0);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('does not call _stopPlayhead when playing', () => {
+    const el = document.createElement('daw-editor') as any;
+    el._engine = { seek: vi.fn() };
+    el._isPlaying = true;
+    const spy = vi.spyOn(el, '_stopPlayhead').mockImplementation(() => {});
+    el.seekTo(3.0);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('Track control selects track', () => {
+  it('selects track when daw-track-control event is dispatched', () => {
+    const el = document.createElement('daw-editor') as any;
+    document.body.appendChild(el);
+    // Set up minimal state for the handler
+    el._tracks = new Map([['track-1', { volume: 1, pan: 0, muted: false, soloed: false }]]);
+    el._engine = {
+      selectTrack: vi.fn(),
+      setTrackVolume: vi.fn(),
+    };
+
+    const events: CustomEvent[] = [];
+    el.addEventListener('daw-track-select', (e: CustomEvent) => events.push(e));
+
+    el.dispatchEvent(
+      new CustomEvent('daw-track-control', {
+        bubbles: true,
+        detail: { trackId: 'track-1', prop: 'volume', value: 0.5 },
+      })
+    );
+
+    expect(el._selectedTrackId).toBe('track-1');
+    expect(el._engine.selectTrack).toHaveBeenCalledWith('track-1');
+    expect(events).toHaveLength(1);
+    expect(events[0].detail.trackId).toBe('track-1');
+
+    document.body.removeChild(el);
+  });
+
+  it('does not re-select already selected track', () => {
+    const el = document.createElement('daw-editor') as any;
+    document.body.appendChild(el);
+    el._tracks = new Map([['track-1', { volume: 1, pan: 0, muted: false, soloed: false }]]);
+    el._engine = {
+      selectTrack: vi.fn(),
+      setTrackVolume: vi.fn(),
+    };
+    el._selectedTrackId = 'track-1';
+
+    const events: CustomEvent[] = [];
+    el.addEventListener('daw-track-select', (e: CustomEvent) => events.push(e));
+
+    el.dispatchEvent(
+      new CustomEvent('daw-track-control', {
+        bubbles: true,
+        detail: { trackId: 'track-1', prop: 'volume', value: 0.5 },
+      })
+    );
+
+    expect(el._engine.selectTrack).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+
+    document.body.removeChild(el);
+  });
+});
+
 describe('effectiveSampleRate', () => {
   it('returns initial sampleRate hint when no audio decoded', () => {
     const el = document.createElement('daw-editor') as any;

--- a/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-interactions.test.ts
@@ -97,7 +97,12 @@ describe('seekTo', () => {
 
   it('stops and restarts playback when playing (Tone.js reschedule)', () => {
     const el = document.createElement('daw-editor') as any;
-    el._engine = { seek: vi.fn(), stop: vi.fn(), play: vi.fn(), init: vi.fn().mockResolvedValue(undefined) };
+    el._engine = {
+      seek: vi.fn(),
+      stop: vi.fn(),
+      play: vi.fn(),
+      init: vi.fn().mockResolvedValue(undefined),
+    };
     el._isPlaying = true;
     const stopSpy = vi.spyOn(el, 'stop');
     const playSpy = vi.spyOn(el, 'play');

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -637,12 +637,23 @@ export class DawEditorElement extends LitElement {
 
   /** Split the clip under the playhead on the selected track. */
   splitAtPlayhead(): boolean {
-    return performSplitAtPlayhead({
+    const wasPlaying = this._isPlaying;
+    const time = this._currentTime;
+    // Stop before split to avoid duplicate audio from Transport rescheduling
+    if (wasPlaying) {
+      this.stop();
+    }
+    const result = performSplitAtPlayhead({
       effectiveSampleRate: this.effectiveSampleRate,
-      currentTime: this._currentTime,
+      currentTime: time,
       engine: this._engine,
       dispatchEvent: (e: Event) => this.dispatchEvent(e),
     });
+    // Resume playback from the same position
+    if (wasPlaying && result) {
+      this.play(time);
+    }
+    return result;
   }
 
   /** Get the active shortcuts — user-provided or defaults. */

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -667,8 +667,17 @@ export class DawEditorElement extends LitElement {
       isPlaying: this._isPlaying,
       engine: this._engine,
       dispatchEvent: (e: Event) => this.dispatchEvent(e),
-      stop: () => this.stop(),
-      play: (time: number) => this.play(time),
+      stop: () => {
+        this._engine?.stop();
+        this._stopPlayhead();
+      },
+      // Call engine.play directly (synchronous) — not the async editor play()
+      // which yields to microtask queue via await engine.init(). Engine is
+      // already initialized at split time; the async gap causes audio desync.
+      play: (time: number) => {
+        this._engine?.play(time);
+        this._startPlayhead();
+      },
     });
   }
 

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -25,7 +25,7 @@ import type {
 } from '../events';
 import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
 import { addRecordedClip } from '../interactions/recording-clip';
-import { splitAtPlayheadSafe } from '../interactions/split-handler';
+import { splitAtPlayhead as performSplitAtPlayhead } from '../interactions/split-handler';
 import { handleKeyboardEvent } from '@waveform-playlist/core';
 import type { KeyboardShortcut } from '@waveform-playlist/core';
 import { syncPeaksForChangedClips } from '../interactions/clip-peak-sync';
@@ -637,7 +637,7 @@ export class DawEditorElement extends LitElement {
 
   /** Split the clip under the playhead on the selected track. */
   splitAtPlayhead(): boolean {
-    return splitAtPlayheadSafe({
+    return performSplitAtPlayhead({
       effectiveSampleRate: this.effectiveSampleRate,
       currentTime: this._currentTime,
       isPlaying: this._isPlaying,

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -183,10 +183,7 @@ export class DawEditorElement extends LitElement {
   // --- Lifecycle ---
   connectedCallback() {
     super.connectedCallback();
-    if (!this.hasAttribute('tabindex')) {
-      this.setAttribute('tabindex', '0');
-    }
-    this.addEventListener('keydown', this._onKeyDown);
+    document.addEventListener('keydown', this._onKeyDown);
     this.addEventListener('daw-track-connected', this._onTrackConnected as EventListener);
     this.addEventListener('daw-track-update', this._onTrackUpdate as EventListener);
     this.addEventListener('daw-track-control', this._onTrackControl as EventListener);
@@ -213,7 +210,7 @@ export class DawEditorElement extends LitElement {
   }
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener('keydown', this._onKeyDown);
+    document.removeEventListener('keydown', this._onKeyDown);
     this.removeEventListener('daw-track-connected', this._onTrackConnected as EventListener);
     this.removeEventListener('daw-track-update', this._onTrackUpdate as EventListener);
     this.removeEventListener('daw-track-control', this._onTrackControl as EventListener);

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -686,6 +686,9 @@ export class DawEditorElement extends LitElement {
     if (this.interactiveClips) {
       defaults.push({
         key: 's',
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
         action: () => this.splitAtPlayhead(),
         description: 'Split at playhead',
       });

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -319,6 +319,20 @@ export class DawEditorElement extends LitElement {
   private _onTrackControl = (e: CustomEvent) => {
     const { trackId, prop, value } = e.detail ?? {};
     if (!trackId || !prop || !DawEditorElement._CONTROL_PROPS.has(prop)) return;
+    // Select the track when interacting with its controls
+    if (this._selectedTrackId !== trackId) {
+      this._setSelectedTrackId(trackId);
+      if (this._engine) {
+        this._engine.selectTrack(trackId);
+      }
+      this.dispatchEvent(
+        new CustomEvent('daw-track-select', {
+          bubbles: true,
+          composed: true,
+          detail: { trackId },
+        })
+      );
+    }
     const oldDescriptor = this._tracks.get(trackId);
     if (oldDescriptor) {
       const descriptor = { ...oldDescriptor, [prop]: value };

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -25,7 +25,7 @@ import type {
 } from '../events';
 import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
 import { addRecordedClip } from '../interactions/recording-clip';
-import { splitAtPlayhead as performSplitAtPlayhead } from '../interactions/split-handler';
+import { splitAtPlayheadSafe } from '../interactions/split-handler';
 import { handleKeyboardEvent } from '@waveform-playlist/core';
 import type { KeyboardShortcut } from '@waveform-playlist/core';
 import { syncPeaksForChangedClips } from '../interactions/clip-peak-sync';
@@ -637,23 +637,15 @@ export class DawEditorElement extends LitElement {
 
   /** Split the clip under the playhead on the selected track. */
   splitAtPlayhead(): boolean {
-    const wasPlaying = this._isPlaying;
-    const time = this._currentTime;
-    // Stop before split to avoid duplicate audio from Transport rescheduling
-    if (wasPlaying) {
-      this.stop();
-    }
-    const result = performSplitAtPlayhead({
+    return splitAtPlayheadSafe({
       effectiveSampleRate: this.effectiveSampleRate,
-      currentTime: time,
+      currentTime: this._currentTime,
+      isPlaying: this._isPlaying,
       engine: this._engine,
       dispatchEvent: (e: Event) => this.dispatchEvent(e),
+      stop: () => this.stop(),
+      play: (time: number) => this.play(time),
     });
-    // Resume playback from the same position
-    if (wasPlaying && result) {
-      this.play(time);
-    }
-    return result;
   }
 
   /** Get the active shortcuts — user-provided or defaults. */

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -648,9 +648,13 @@ export class DawEditorElement extends LitElement {
       console.warn('[dawcore] seekTo: engine not ready, call ignored');
       return;
     }
-    this._engine.seek(time);
-    this._currentTime = time;
-    if (!this._isPlaying) {
+    if (this._isPlaying) {
+      // Tone.js needs stop+play to reschedule audio sources at new position
+      this.stop();
+      this.play(time);
+    } else {
+      this._engine.seek(time);
+      this._currentTime = time;
       this._stopPlayhead();
     }
   }

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -42,10 +42,10 @@ export class DawEditorElement extends LitElement {
   @property({ type: Boolean, attribute: 'clip-headers' }) clipHeaders = false;
   @property({ type: Number, attribute: 'clip-header-height' }) clipHeaderHeight = 20;
   @property({ type: Boolean, attribute: 'interactive-clips' }) interactiveClips = false;
-  /** Configurable keyboard shortcuts. Set via JS property (not HTML attribute).
-   *  When `interactive-clips` is set, a default split shortcut (S key) is included
-   *  unless overridden. */
-  shortcuts: KeyboardShortcut[] = [];
+  /** Enable default keyboard shortcuts (Space, Escape, 0, and S when interactive-clips). */
+  @property({ type: Boolean, attribute: 'keyboard-shortcuts' }) keyboardShortcuts = false;
+  /** Custom keyboard shortcuts. Set via JS property. Overrides defaults when non-null. */
+  shortcuts: KeyboardShortcut[] | null = null;
   /** Initial sample rate hint. Overridden by decoded audio buffer's actual rate. */
   @property({ type: Number, attribute: 'sample-rate' }) sampleRate = 48000;
   /** Resolved sample rate — falls back to sampleRate property until first audio decode. */
@@ -644,7 +644,10 @@ export class DawEditorElement extends LitElement {
     }
   }
   seekTo(time: number) {
-    if (!this._engine) return;
+    if (!this._engine) {
+      console.warn('[dawcore] seekTo: engine not ready, call ignored');
+      return;
+    }
     this._engine.seek(time);
     this._currentTime = time;
     if (!this._isPlaying) {
@@ -665,9 +668,12 @@ export class DawEditorElement extends LitElement {
     });
   }
 
-  /** Get the active shortcuts — user-provided or defaults. */
+  /** Get the active shortcuts — custom overrides defaults when non-null. */
   private _getActiveShortcuts(): KeyboardShortcut[] {
-    if (this.shortcuts.length > 0) return this.shortcuts;
+    // Custom shortcuts override everything (including empty array = no shortcuts)
+    if (this.shortcuts !== null) return this.shortcuts;
+    // Defaults only when keyboard-shortcuts attribute is set
+    if (!this.keyboardShortcuts) return [];
     const defaults: KeyboardShortcut[] = [
       { key: ' ', action: () => this.togglePlayPause(), description: 'Play/Pause' },
       { key: 'Escape', action: () => this.stop(), description: 'Stop' },
@@ -686,7 +692,18 @@ export class DawEditorElement extends LitElement {
   private _onKeyDown = (e: KeyboardEvent) => {
     const shortcuts = this._getActiveShortcuts();
     if (shortcuts.length === 0) return;
-    handleKeyboardEvent(e, shortcuts, true);
+    try {
+      handleKeyboardEvent(e, shortcuts, true);
+    } catch (err) {
+      console.warn('[dawcore] Keyboard shortcut failed: ' + String(err));
+      this.dispatchEvent(
+        new CustomEvent('daw-error', {
+          bubbles: true,
+          composed: true,
+          detail: { operation: 'keyboard-shortcut', error: err },
+        })
+      );
+    }
   };
 
   // --- Recording ---

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -624,6 +624,14 @@ export class DawEditorElement extends LitElement {
     this._stopPlayhead();
     this.dispatchEvent(new CustomEvent('daw-stop', { bubbles: true, composed: true }));
   }
+  /** Toggle between play and pause. */
+  togglePlayPause() {
+    if (this._isPlaying) {
+      this.pause();
+    } else {
+      this.play();
+    }
+  }
   seekTo(time: number) {
     if (!this._engine) return;
     this._engine.seek(time);
@@ -640,12 +648,21 @@ export class DawEditorElement extends LitElement {
     });
   }
 
-  /** Get the active shortcuts — user-provided or defaults when interactive-clips is set. */
+  /** Get the active shortcuts — user-provided or defaults. */
   private _getActiveShortcuts(): KeyboardShortcut[] {
     if (this.shortcuts.length > 0) return this.shortcuts;
-    if (!this.interactiveClips) return [];
-    // Default: split at playhead on S key
-    return [{ key: 's', action: () => this.splitAtPlayhead(), description: 'Split at playhead' }];
+    const defaults: KeyboardShortcut[] = [
+      { key: ' ', action: () => this.togglePlayPause(), description: 'Play/Pause' },
+      { key: 'Escape', action: () => this.stop(), description: 'Stop' },
+    ];
+    if (this.interactiveClips) {
+      defaults.push({
+        key: 's',
+        action: () => this.splitAtPlayhead(),
+        description: 'Split at playhead',
+      });
+    }
+    return defaults;
   }
 
   private _onKeyDown = (e: KeyboardEvent) => {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -633,6 +633,9 @@ export class DawEditorElement extends LitElement {
     if (!this._engine) return;
     this._engine.seek(time);
     this._currentTime = time;
+    if (!this._isPlaying) {
+      this._stopPlayhead();
+    }
   }
 
   /** Split the clip under the playhead on the selected track. */

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -26,6 +26,8 @@ import type {
 import { loadFiles as loadFilesImpl } from '../interactions/file-loader';
 import { addRecordedClip } from '../interactions/recording-clip';
 import { splitAtPlayhead as performSplitAtPlayhead } from '../interactions/split-handler';
+import { handleKeyboardEvent } from '@waveform-playlist/core';
+import type { KeyboardShortcut } from '@waveform-playlist/core';
 import { syncPeaksForChangedClips } from '../interactions/clip-peak-sync';
 
 @customElement('daw-editor')
@@ -40,6 +42,10 @@ export class DawEditorElement extends LitElement {
   @property({ type: Boolean, attribute: 'clip-headers' }) clipHeaders = false;
   @property({ type: Number, attribute: 'clip-header-height' }) clipHeaderHeight = 20;
   @property({ type: Boolean, attribute: 'interactive-clips' }) interactiveClips = false;
+  /** Configurable keyboard shortcuts. Set via JS property (not HTML attribute).
+   *  When `interactive-clips` is set, a default split shortcut (S key) is included
+   *  unless overridden. */
+  shortcuts: KeyboardShortcut[] = [];
   /** Initial sample rate hint. Overridden by decoded audio buffer's actual rate. */
   @property({ type: Number, attribute: 'sample-rate' }) sampleRate = 48000;
   /** Resolved sample rate — falls back to sampleRate property until first audio decode. */
@@ -634,18 +640,18 @@ export class DawEditorElement extends LitElement {
     });
   }
 
+  /** Get the active shortcuts — user-provided or defaults when interactive-clips is set. */
+  private _getActiveShortcuts(): KeyboardShortcut[] {
+    if (this.shortcuts.length > 0) return this.shortcuts;
+    if (!this.interactiveClips) return [];
+    // Default: split at playhead on S key
+    return [{ key: 's', action: () => this.splitAtPlayhead(), description: 'Split at playhead' }];
+  }
+
   private _onKeyDown = (e: KeyboardEvent) => {
-    if (!this.interactiveClips) return;
-    if (e.key === 's' || e.key === 'S') {
-      // Don't intercept Ctrl+S/Cmd+S (save) or other modifier combos
-      if (e.ctrlKey || e.metaKey || e.altKey) return;
-      // Don't split when user is typing in a form element
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      if ((e.target as HTMLElement)?.isContentEditable) return;
-      e.preventDefault();
-      this.splitAtPlayhead();
-    }
+    const shortcuts = this._getActiveShortcuts();
+    if (shortcuts.length === 0) return;
+    handleKeyboardEvent(e, shortcuts, true);
   };
 
   // --- Recording ---

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -654,6 +654,7 @@ export class DawEditorElement extends LitElement {
     const defaults: KeyboardShortcut[] = [
       { key: ' ', action: () => this.togglePlayPause(), description: 'Play/Pause' },
       { key: 'Escape', action: () => this.stop(), description: 'Stop' },
+      { key: '0', action: () => this.seekTo(0), description: 'Rewind to start' },
     ];
     if (this.interactiveClips) {
       defaults.push({

--- a/packages/dawcore/src/interactions/split-handler.ts
+++ b/packages/dawcore/src/interactions/split-handler.ts
@@ -45,9 +45,16 @@ export function splitAtPlayhead(host: SplitHost): boolean {
     host.stop();
   }
 
-  const result = performSplit(host, time);
+  let result: boolean;
+  try {
+    result = performSplit(host, time);
+  } catch (err) {
+    console.warn('[dawcore] splitAtPlayhead failed: ' + String(err));
+    result = false;
+  }
 
-  if (wasPlaying && result) {
+  // Always resume if was playing — even on failed split, don't leave audio stopped
+  if (wasPlaying) {
     host.play(time);
   }
 

--- a/packages/dawcore/src/interactions/split-handler.ts
+++ b/packages/dawcore/src/interactions/split-handler.ts
@@ -15,8 +15,11 @@ export interface SplitEngineContract {
 export interface SplitHost {
   readonly effectiveSampleRate: number;
   readonly currentTime: number;
+  readonly isPlaying: boolean;
   readonly engine: SplitEngineContract | null;
   dispatchEvent(event: Event): boolean;
+  stop(): void;
+  play(time: number): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -24,12 +27,36 @@ export interface SplitHost {
 // ---------------------------------------------------------------------------
 
 /**
- * Splits the clip under the playhead on the selected track.
+ * Split the clip under the playhead on the selected track.
+ * Stops playback before split and resumes after to avoid duplicate audio
+ * from Transport rescheduling during playback.
  *
  * Returns true if the split occurred and dispatched a daw-clip-split event.
  * Returns false for any guard failure or engine no-op.
  */
 export function splitAtPlayhead(host: SplitHost): boolean {
+  const wasPlaying = host.isPlaying;
+  const time = host.currentTime;
+
+  if (wasPlaying) {
+    host.stop();
+  }
+
+  const result = performSplit(host, time);
+
+  if (wasPlaying && result) {
+    host.play(time);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+/** Core split logic — finds clip at position, calls engine, diffs state for new IDs. */
+function performSplit(host: SplitHost, time: number): boolean {
   const { engine } = host;
   if (!engine) return false;
 
@@ -41,7 +68,7 @@ export function splitAtPlayhead(host: SplitHost): boolean {
   const track = tracks.find((t) => t.id === selectedTrackId);
   if (!track) return false;
 
-  const atSample = Math.round(host.currentTime * host.effectiveSampleRate);
+  const atSample = Math.round(time * host.effectiveSampleRate);
 
   const clip = findClipAtSample(track.clips, atSample);
   if (!clip) return false;
@@ -91,42 +118,6 @@ export function splitAtPlayhead(host: SplitHost): boolean {
 
   return true;
 }
-
-// ---------------------------------------------------------------------------
-// Split with playback management
-// ---------------------------------------------------------------------------
-
-export interface SplitDuringPlaybackHost extends SplitHost {
-  readonly isPlaying: boolean;
-  stop(): void;
-  play(time: number): void;
-}
-
-/**
- * Split at playhead with stop→split→resume to avoid duplicate audio.
- * During playback, replaceTrackClips creates new sources alongside old ones.
- * Stopping first ensures clean Transport state.
- */
-export function splitAtPlayheadSafe(host: SplitDuringPlaybackHost): boolean {
-  const wasPlaying = host.isPlaying;
-  const time = host.currentTime;
-
-  if (wasPlaying) {
-    host.stop();
-  }
-
-  const result = splitAtPlayhead(host);
-
-  if (wasPlaying && result) {
-    host.play(time);
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Finds a clip that strictly contains the given sample position.

--- a/packages/dawcore/src/interactions/split-handler.ts
+++ b/packages/dawcore/src/interactions/split-handler.ts
@@ -38,6 +38,9 @@ export function splitAtPlayhead(host: SplitHost): boolean {
   const wasPlaying = host.isPlaying;
   const time = host.currentTime;
 
+  // Check guards before stopping playback — don't interrupt audio for a no-op
+  if (!canSplitAtTime(host, time)) return false;
+
   if (wasPlaying) {
     host.stop();
   }
@@ -54,6 +57,21 @@ export function splitAtPlayhead(host: SplitHost): boolean {
 // ---------------------------------------------------------------------------
 // Internal
 // ---------------------------------------------------------------------------
+
+/** Pre-flight check — can a split happen at this time without touching playback? */
+function canSplitAtTime(host: SplitHost, time: number): boolean {
+  const { engine } = host;
+  if (!engine) return false;
+
+  const state = engine.getState();
+  if (!state.selectedTrackId) return false;
+
+  const track = state.tracks.find((t) => t.id === state.selectedTrackId);
+  if (!track) return false;
+
+  const atSample = Math.round(time * host.effectiveSampleRate);
+  return !!findClipAtSample(track.clips, atSample);
+}
 
 /** Core split logic — finds clip at position, calls engine, diffs state for new IDs. */
 function performSplit(host: SplitHost, time: number): boolean {

--- a/packages/dawcore/src/interactions/split-handler.ts
+++ b/packages/dawcore/src/interactions/split-handler.ts
@@ -93,6 +93,38 @@ export function splitAtPlayhead(host: SplitHost): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Split with playback management
+// ---------------------------------------------------------------------------
+
+export interface SplitDuringPlaybackHost extends SplitHost {
+  readonly isPlaying: boolean;
+  stop(): void;
+  play(time: number): void;
+}
+
+/**
+ * Split at playhead with stop→split→resume to avoid duplicate audio.
+ * During playback, replaceTrackClips creates new sources alongside old ones.
+ * Stopping first ensures clean Transport state.
+ */
+export function splitAtPlayheadSafe(host: SplitDuringPlaybackHost): boolean {
+  const wasPlaying = host.isPlaying;
+  const time = host.currentTime;
+
+  if (wasPlaying) {
+    host.stop();
+  }
+
+  const result = splitAtPlayhead(host);
+
+  if (wasPlaying && result) {
+    host.play(time);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Move `KeyboardShortcut` type, `handleKeyboardEvent()`, and `getShortcutLabel()` from `@waveform-playlist/browser` to `@waveform-playlist/core`
- Replace hardcoded `_onKeyDown` in `<daw-editor>` with configurable `shortcuts` property
- Browser package re-exports from core for backwards compatibility

## Details

**Core (`@waveform-playlist/core`):**
- New `keyboard.ts` with `KeyboardShortcut` interface, `handleKeyboardEvent()` pure function, `getShortcutLabel()` helper
- 18 unit tests covering matching, modifiers, input guards, key repeat, preventDefault

**Browser (`@waveform-playlist/browser`):**
- `useKeyboardShortcuts` now imports from core instead of defining its own
- Re-exports `KeyboardShortcut`, `handleKeyboardEvent`, `getShortcutLabel` for backwards compat

**Dawcore (`@dawcore/components`):**
- `<daw-editor>` accepts `shortcuts` JS property (`KeyboardShortcut[]`)
- Default: when `interactive-clips` is set and no custom shortcuts provided, includes split on `S`
- Replaces hardcoded modifier checks with core's `handleKeyboardEvent` (handles modifiers, repeat, input guards, case-insensitive matching)

```js
const editor = document.getElementById('editor');
editor.shortcuts = [
  { key: 's', action: () => editor.splitAtPlayhead(), description: 'Split' },
  { key: ' ', action: () => editor.togglePlayPause(), description: 'Play/Pause' },
  { key: 'Escape', action: () => editor.stop(), description: 'Stop' },
];
```

## Test plan

- [x] 18 core keyboard tests (matching, modifiers, input guards, key repeat, preventDefault, getShortcutLabel)
- [x] Core typecheck passes
- [x] Browser typecheck passes (re-exports work)
- [x] Dawcore typecheck passes
- [x] Full build clean
- [ ] Manual: S key still splits in dawcore dev page
- [ ] Manual: Ctrl+S passes through to browser
- [ ] Manual: Custom shortcuts override defaults