### PR TITLE
feat(engine): add undo/redo stack with transactions

### DIFF
--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -129,6 +129,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 - **Keyboard shortcuts via core** — `<daw-editor>` uses `handleKeyboardEvent` from `@waveform-playlist/core`. Listener on `document` (not the element — users won't know to focus it). Configurable via `editor.shortcuts` JS property; defaults: Space (play/pause), Escape (stop), 0 (rewind), S (split, when `interactive-clips`).
 - **Split pre-flight check** — `splitAtPlayhead` calls `canSplitAtTime` before stopping playback. Without this, pressing S with no track selected interrupts audio for a no-op.
 - **`engine.constrainTrimDelta()`** — Wraps the engine's `constrainBoundaryTrim` pure function. Call during trim drag for per-frame collision detection (timeline bounds, audio bounds, neighbor overlap, min duration). Don't manually clamp — use the engine's constraints so visual preview matches what's applied on drop.
+- **Drag transactions for undo** — `beginTransaction()` at drag start (`_beginDrag`), `commitTransaction()` in `finally` of `onPointerUp`. Groups all per-frame `moveClip`/`trimClip` calls into one undo step. Without this, a 1-second drag creates 60 individual undo steps.
+- **Undo/redo keyboard shortcuts** — Cmd/Ctrl+Z (undo), Cmd/Ctrl+Shift+Z (redo) in default shortcuts when `keyboard-shortcuts` attribute is set. Both Ctrl and Meta variants registered as separate entries since `handleKeyboardEvent` treats undefined modifiers as "match any".
 
 ## Typed Events
 

--- a/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
+++ b/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
@@ -21,6 +21,7 @@ function createMockEngine(): ClipEngineContract {
     constrainTrimDelta: vi.fn().mockImplementation((_t, _c, _b, d) => d),
     beginTransaction: vi.fn(),
     commitTransaction: vi.fn(),
+    abortTransaction: vi.fn(),
   };
 }
 

--- a/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
+++ b/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
@@ -8,7 +8,7 @@ import type { ClipEngineContract, ClipPointerHost } from '../interactions/clip-p
 
 function createMockEngine(): ClipEngineContract {
   return {
-    moveClip: vi.fn(),
+    moveClip: vi.fn().mockImplementation((_t: string, _c: string, d: number) => d),
     trimClip: vi.fn(),
     updateTrack: vi.fn(),
     getClipBounds: vi.fn().mockReturnValue({

--- a/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
+++ b/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
@@ -19,6 +19,8 @@ function createMockEngine(): ClipEngineContract {
     }),
     // Default: pass through unconstrained (tests can override)
     constrainTrimDelta: vi.fn().mockImplementation((_t, _c, _b, d) => d),
+    beginTransaction: vi.fn(),
+    commitTransaction: vi.fn(),
   };
 }
 

--- a/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
+++ b/packages/dawcore/src/__tests__/clip-pointer-handler.test.ts
@@ -676,4 +676,44 @@ describe('ClipPointerHandler', () => {
       expect(trimEvent.composed).toBe(true);
     });
   });
+
+  describe('undo transactions', () => {
+    it('calls beginTransaction on drag start', () => {
+      const el = makeClipEl('clip-1', 'track-1');
+      handler.tryHandle(el, pointerEvent('pointerdown', { clientX: 100 }));
+
+      expect(engine.beginTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls commitTransaction after successful drag', () => {
+      const el = makeClipEl('clip-1', 'track-1');
+      handler.tryHandle(el, pointerEvent('pointerdown', { clientX: 100 }));
+      handler.onPointerMove(pointerEvent('pointermove', { clientX: 150 }));
+      handler.onPointerUp(pointerEvent('pointerup', { clientX: 150 }));
+
+      expect(engine.commitTransaction).toHaveBeenCalledTimes(1);
+      expect(engine.abortTransaction).not.toHaveBeenCalled();
+    });
+
+    it('calls abortTransaction on click (no drag)', () => {
+      const el = makeClipEl('clip-1', 'track-1');
+      handler.tryHandle(el, pointerEvent('pointerdown', { clientX: 100 }));
+      handler.onPointerUp(pointerEvent('pointerup', { clientX: 100 }));
+
+      expect(engine.abortTransaction).toHaveBeenCalledTimes(1);
+      expect(engine.commitTransaction).not.toHaveBeenCalled();
+    });
+
+    it('calls abortTransaction when drag has zero net delta', () => {
+      const el = makeClipEl('clip-1', 'track-1');
+      handler.tryHandle(el, pointerEvent('pointerdown', { clientX: 100 }));
+      // Drag right then back to start — over threshold but net zero
+      handler.onPointerMove(pointerEvent('pointermove', { clientX: 104 }));
+      handler.onPointerMove(pointerEvent('pointermove', { clientX: 100 }));
+      handler.onPointerUp(pointerEvent('pointerup', { clientX: 100 }));
+
+      expect(engine.abortTransaction).toHaveBeenCalledTimes(1);
+      expect(engine.commitTransaction).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -661,13 +661,19 @@ export class DawEditorElement extends LitElement {
 
   /** Undo the last structural edit. */
   undo(): void {
-    if (!this._engine) return;
+    if (!this._engine) {
+      console.warn('[dawcore] undo: engine not ready, call ignored');
+      return;
+    }
     this._engine.undo();
   }
 
   /** Redo the last undone edit. */
   redo(): void {
-    if (!this._engine) return;
+    if (!this._engine) {
+      console.warn('[dawcore] redo: engine not ready, call ignored');
+      return;
+    }
     this._engine.redo();
   }
 

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -659,6 +659,28 @@ export class DawEditorElement extends LitElement {
     }
   }
 
+  /** Undo the last structural edit. */
+  undo(): void {
+    if (!this._engine) return;
+    this._engine.undo();
+  }
+
+  /** Redo the last undone edit. */
+  redo(): void {
+    if (!this._engine) return;
+    this._engine.redo();
+  }
+
+  /** Whether undo is available. */
+  get canUndo(): boolean {
+    return this._engine?.canUndo ?? false;
+  }
+
+  /** Whether redo is available. */
+  get canRedo(): boolean {
+    return this._engine?.canRedo ?? false;
+  }
+
   /** Split the clip under the playhead on the selected track. */
   splitAtPlayhead(): boolean {
     return performSplitAtPlayhead({
@@ -691,6 +713,22 @@ export class DawEditorElement extends LitElement {
       { key: ' ', action: () => this.togglePlayPause(), description: 'Play/Pause' },
       { key: 'Escape', action: () => this.stop(), description: 'Stop' },
       { key: '0', action: () => this.seekTo(0), description: 'Rewind to start' },
+      { key: 'z', ctrlKey: true, shiftKey: false, action: () => this.undo(), description: 'Undo' },
+      {
+        key: 'z',
+        ctrlKey: true,
+        shiftKey: true,
+        action: () => this.redo(),
+        description: 'Redo',
+      },
+      { key: 'z', metaKey: true, shiftKey: false, action: () => this.undo(), description: 'Undo' },
+      {
+        key: 'z',
+        metaKey: true,
+        shiftKey: true,
+        action: () => this.redo(),
+        description: 'Redo',
+      },
     ];
     if (this.interactiveClips) {
       defaults.push({

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -32,6 +32,8 @@ export interface ClipEngineContract {
   beginTransaction(): void;
   /** Commit the transaction — pushes one undo step for all grouped mutations. */
   commitTransaction(): void;
+  /** Abort the transaction — restores pre-transaction state without pushing to undo. */
+  abortTransaction(): void;
 }
 
 /** Peak data returned by reextractClipPeaks for imperative waveform updates. */

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -309,8 +309,13 @@ export class ClipPointerHandler {
         }
       }
     } finally {
-      // Commit transaction — one undo step for the entire drag gesture
-      this._host.engine?.commitTransaction();
+      // Commit transaction if mutations occurred, abort if click/no-op.
+      // Abort does NOT push to undo stack or clear redo stack.
+      if (this._isDragging && this._cumulativeDeltaSamples !== 0) {
+        this._host.engine?.commitTransaction();
+      } else {
+        this._host.engine?.abortTransaction();
+      }
       this._reset();
     }
   }

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -28,6 +28,10 @@ export interface ClipEngineContract {
     boundary: 'left' | 'right',
     deltaSamples: number
   ): number;
+  /** Begin a transaction — groups mutations into one undo step. */
+  beginTransaction(): void;
+  /** Commit the transaction — pushes one undo step for all grouped mutations. */
+  commitTransaction(): void;
 }
 
 /** Peak data returned by reextractClipPeaks for imperative waveform updates. */
@@ -135,6 +139,9 @@ export class ClipPointerHandler {
     this._isDragging = false;
     this._lastDeltaPx = 0;
     this._cumulativeDeltaSamples = 0;
+
+    // Group all drag mutations into one undo step
+    this._host.engine?.beginTransaction();
 
     // For trim: snapshot the clip container's current position/width
     if (mode === 'trim-left' || mode === 'trim-right') {
@@ -302,6 +309,8 @@ export class ClipPointerHandler {
         }
       }
     } finally {
+      // Commit transaction — one undo step for the entire drag gesture
+      this._host.engine?.commitTransaction();
       this._reset();
     }
   }

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -143,7 +143,13 @@ export class ClipPointerHandler {
     this._cumulativeDeltaSamples = 0;
 
     // Group all drag mutations into one undo step
-    this._host.engine?.beginTransaction();
+    if (this._host.engine) {
+      this._host.engine.beginTransaction();
+    } else {
+      console.warn(
+        '[dawcore] beginDrag: engine unavailable, drag mutations will not be grouped for undo'
+      );
+    }
 
     // For trim: snapshot the clip container's current position/width
     if (mode === 'trim-left' || mode === 'trim-right') {

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -10,7 +10,7 @@ export interface ClipBounds {
 
 /** Narrow engine contract for clip move/trim interactions. */
 export interface ClipEngineContract {
-  moveClip(trackId: string, clipId: string, deltaSamples: number, skipAdapter?: boolean): void;
+  moveClip(trackId: string, clipId: string, deltaSamples: number, skipAdapter?: boolean): number;
   trimClip(
     trackId: string,
     clipId: string,
@@ -201,8 +201,9 @@ export class ClipPointerHandler {
       const incrementalDeltaPx = totalDeltaPx - this._lastDeltaPx;
       this._lastDeltaPx = totalDeltaPx;
       const incrementalDeltaSamples = Math.round(incrementalDeltaPx * this._host.samplesPerPixel);
-      this._cumulativeDeltaSamples += incrementalDeltaSamples;
-      engine.moveClip(this._trackId, this._clipId, incrementalDeltaSamples, true);
+      // Track constrained delta (not raw) so undo transactions are accurate
+      const applied = engine.moveClip(this._trackId, this._clipId, incrementalDeltaSamples, true);
+      this._cumulativeDeltaSamples += applied;
     } else {
       // Trim: constrain delta using engine's full collision/bounds logic,
       // then track for visual feedback. Engine called once at pointerup.

--- a/packages/engine/CLAUDE.md
+++ b/packages/engine/CLAUDE.md
@@ -40,6 +40,10 @@
 - **`setTracks()` clears history** — old snapshots reference a different track set.
 - **Transactions** — `beginTransaction()` captures one snapshot; mutations during the transaction don't push individual undo steps. `commitTransaction()` pushes the pre-transaction snapshot. `abortTransaction()` restores it without pushing.
 - **`canUndo`/`canRedo`** — exposed as getters and in `EngineState` for UI binding.
+- **`moveClip` returns constrained delta** — Returns the actually-applied delta (number), not void. Callers (e.g., dawcore clip handler) track this instead of raw pixel delta to avoid no-op undo entries when dragging against boundaries.
+- **`_restoreTracks` uses incremental adapter updates** — Diffs old vs new tracks by reference. When track count is unchanged, calls `_updateTrackOnAdapter` per changed track (avoids full playout rebuild that interrupts playback). Falls back to `adapter.setTracks()` when tracks were added/removed.
+- **`_transactionMutated` flag** — Set in `_pushUndoSnapshot` when inside a transaction. `abortTransaction` skips `_restoreTracks` when no mutations occurred, preventing a full adapter rebuild on click (no-op abort).
+- **`undoLimit`** — Constructor option via `PlaylistEngineOptions`, `readonly` field. Default 100.
 - **Console warn diagnostics** — `moveClip`, `trimClip`, `splitClip` log `console.warn('[waveform-playlist/engine] methodName: ...')` on invalid track/clip IDs. Tests exercising these paths must mock `console.warn`.
 - **`tracksVersion` counter** — Monotonic counter in `EngineState` that increments only on track mutations (setTracks, addTrack, removeTrack, moveClip, trimClip, splitClip). Does NOT increment on selection/zoom/volume/loop changes. Used by the provider to detect track-specific statechange events and skip `loadAudio` rebuilds.
 - **Testing animation-frame code** — `_startTimeUpdateLoop` uses `requestAnimationFrame`, unavailable in Node.js. Use `vi.stubGlobal('requestAnimationFrame', vi.fn((cb) => { rafCallbacks.push(cb); return rafCallbacks.length; }))` and `vi.unstubAllGlobals()` in cleanup. Fire ticks manually via `rafCallbacks[rafCallbacks.length - 1](performance.now())`.

--- a/packages/engine/CLAUDE.md
+++ b/packages/engine/CLAUDE.md
@@ -32,6 +32,14 @@
 - **Loop activation uses `< loopEnd` check** — `play()` activates Transport loop when starting before `loopEnd` (not `>= loopStart && < loopEnd` like before). Starting before the loop region still activates looping — Transport plays through to `loopEnd`, then wraps to `loopStart`. Starting at or past `loopEnd` plays to the end without looping (click-past-loop behavior). `setLoopEnabled()`/`setLoopRegion()` during playback use `_isBeforeLoopEnd()` — same `< loopEnd` check against live adapter position. Selection/annotation playback (with `endTime`) always disables loop.
 - **`play()` state rollback on adapter throw** — `play()` saves `prevCurrentTime` and `prevPlayStartPosition` before mutations. If `adapter.play()` throws, state is restored so the engine isn't left with a moved playhead but no audio.
 - `engine.dispose()` wraps `adapter.dispose()` in try-catch to guarantee `_listeners.clear()` always runs. Explicit `engine.off()` is unnecessary when the engine itself is being disposed.
+
+## Undo/Redo
+
+- **Snapshot-based stack** — `_undoStack` stores frozen `ClipTrack[]` copies before each undoable mutation. No per-operation inverse logic. `undoLimit` defaults to 100.
+- **Undoable operations:** `moveClip`, `trimClip`, `splitClip`, `addTrack`, `removeTrack`, `updateTrack` (when track arg provided). **Not undoable:** `setSelection`, `setZoomLevel`, `setMasterVolume`, `setLoopEnabled`, `setLoopRegion`, `selectTrack`.
+- **`setTracks()` clears history** — old snapshots reference a different track set.
+- **Transactions** — `beginTransaction()` captures one snapshot; mutations during the transaction don't push individual undo steps. `commitTransaction()` pushes the pre-transaction snapshot. `abortTransaction()` restores it without pushing.
+- **`canUndo`/`canRedo`** — exposed as getters and in `EngineState` for UI binding.
 - **Console warn diagnostics** — `moveClip`, `trimClip`, `splitClip` log `console.warn('[waveform-playlist/engine] methodName: ...')` on invalid track/clip IDs. Tests exercising these paths must mock `console.warn`.
 - **`tracksVersion` counter** — Monotonic counter in `EngineState` that increments only on track mutations (setTracks, addTrack, removeTrack, moveClip, trimClip, splitClip). Does NOT increment on selection/zoom/volume/loop changes. Used by the provider to detect track-specific statechange events and skip `loadAudio` rebuilds.
 - **Testing animation-frame code** — `_startTimeUpdateLoop` uses `requestAnimationFrame`, unavailable in Node.js. Use `vi.stubGlobal('requestAnimationFrame', vi.fn((cb) => { rafCallbacks.push(cb); return rafCallbacks.length; }))` and `vi.unstubAllGlobals()` in cleanup. Fire ticks manually via `rafCallbacks[rafCallbacks.length - 1](performance.now())`.

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -103,12 +103,21 @@ export class PlaylistEngine {
   }
 
   beginTransaction(): void {
+    if (this._inTransaction) {
+      console.warn(
+        '[waveform-playlist/engine] beginTransaction: already in a transaction, ' +
+          'previous snapshot will be overwritten'
+      );
+    }
     this._transactionSnapshot = this._snapshotTracks();
     this._inTransaction = true;
   }
 
   commitTransaction(): void {
-    if (!this._inTransaction || this._transactionSnapshot === null) return;
+    if (!this._inTransaction || this._transactionSnapshot === null) {
+      console.warn('[waveform-playlist/engine] commitTransaction: no active transaction to commit');
+      return;
+    }
     this._undoStack.push(this._transactionSnapshot);
     if (this._undoStack.length > this.undoLimit) {
       this._undoStack.shift();
@@ -119,7 +128,10 @@ export class PlaylistEngine {
   }
 
   abortTransaction(): void {
-    if (!this._inTransaction || this._transactionSnapshot === null) return;
+    if (!this._inTransaction || this._transactionSnapshot === null) {
+      console.warn('[waveform-playlist/engine] abortTransaction: no active transaction to abort');
+      return;
+    }
     const snapshot = this._transactionSnapshot;
     this._transactionSnapshot = null;
     this._inTransaction = false;

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -50,12 +50,13 @@ export class PlaylistEngine {
   private _inTransaction = false;
   private _transactionSnapshot: ClipTrack[] | null = null;
   private _transactionMutated = false;
-  undoLimit = 100;
+  readonly undoLimit: number;
 
   constructor(options: PlaylistEngineOptions = {}) {
     this._sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE;
     this._zoomLevels = [...(options.zoomLevels ?? DEFAULT_ZOOM_LEVELS)];
     this._adapter = options.adapter ?? null;
+    this.undoLimit = options.undoLimit ?? 100;
 
     if (this._zoomLevels.length === 0) {
       throw new Error('PlaylistEngine: zoomLevels must not be empty');
@@ -306,11 +307,12 @@ export class PlaylistEngine {
   // Clip Editing (delegates to operations/)
   // ---------------------------------------------------------------------------
 
-  moveClip(trackId: string, clipId: string, deltaSamples: number, skipAdapter = false): void {
+  /** Move a clip by deltaSamples. Returns the constrained delta actually applied (0 if no-op). */
+  moveClip(trackId: string, clipId: string, deltaSamples: number, skipAdapter = false): number {
     const track = this._tracks.find((t) => t.id === trackId);
     if (!track) {
       console.warn(`[waveform-playlist/engine] moveClip: track "${trackId}" not found`);
-      return;
+      return 0;
     }
 
     const clipIndex = track.clips.findIndex((c: AudioClip) => c.id === clipId);
@@ -318,7 +320,7 @@ export class PlaylistEngine {
       console.warn(
         `[waveform-playlist/engine] moveClip: clip "${clipId}" not found in track "${trackId}"`
       );
-      return;
+      return 0;
     }
 
     const clip = track.clips[clipIndex];
@@ -327,7 +329,7 @@ export class PlaylistEngine {
 
     const constrainedDelta = constrainClipDrag(clip, deltaSamples, sortedClips, sortedIndex);
 
-    if (constrainedDelta === 0) return;
+    if (constrainedDelta === 0) return 0;
 
     this._pushUndoSnapshot();
 
@@ -349,6 +351,7 @@ export class PlaylistEngine {
       this._updateTrackOnAdapter(trackId);
     }
     this._emitStateChange();
+    return constrainedDelta;
   }
 
   splitClip(trackId: string, clipId: string, atSample: number): void {
@@ -689,9 +692,20 @@ export class PlaylistEngine {
   }
 
   private _restoreTracks(snapshot: ClipTrack[]): void {
+    const oldTracks = this._tracks;
     this._tracks = snapshot;
     this._tracksVersion++;
-    this._adapter?.setTracks(this._tracks);
+    // Use incremental adapter updates when track count is unchanged —
+    // avoids full playout rebuild that interrupts playback during undo/redo.
+    if (this._adapter && oldTracks.length === snapshot.length) {
+      for (let i = 0; i < snapshot.length; i++) {
+        if (oldTracks[i] !== snapshot[i]) {
+          this._updateTrackOnAdapter(snapshot[i].id);
+        }
+      }
+    } else {
+      this._adapter?.setTracks(this._tracks);
+    }
     this._emitStateChange();
   }
 

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -49,6 +49,7 @@ export class PlaylistEngine {
   private _redoStack: ClipTrack[][] = [];
   private _inTransaction = false;
   private _transactionSnapshot: ClipTrack[] | null = null;
+  private _transactionMutated = false;
   undoLimit = 100;
 
   constructor(options: PlaylistEngineOptions = {}) {
@@ -111,6 +112,7 @@ export class PlaylistEngine {
     }
     this._transactionSnapshot = this._snapshotTracks();
     this._inTransaction = true;
+    this._transactionMutated = false;
   }
 
   commitTransaction(): void {
@@ -133,16 +135,21 @@ export class PlaylistEngine {
       return;
     }
     const snapshot = this._transactionSnapshot;
+    const mutated = this._transactionMutated;
     this._transactionSnapshot = null;
     this._inTransaction = false;
-    this._restoreTracks(snapshot);
+    this._transactionMutated = false;
+    // Only restore if mutations occurred — avoids full adapter rebuild on click
+    if (mutated) {
+      this._restoreTracks(snapshot);
+    }
   }
 
   // ---------------------------------------------------------------------------
   // State snapshot
   // ---------------------------------------------------------------------------
 
-  getState(): EngineState & { canUndo: boolean; canRedo: boolean } {
+  getState(): EngineState {
     return {
       tracks: this._tracks.map((t) => ({ ...t, clips: [...t.clips] })),
       tracksVersion: this._tracksVersion,
@@ -666,11 +673,14 @@ export class PlaylistEngine {
   // ---------------------------------------------------------------------------
 
   private _snapshotTracks(): ClipTrack[] {
-    return this._tracks.map((t) => ({ ...t, clips: [...t.clips] }));
+    return this._tracks.map((t) => ({ ...t, clips: t.clips.map((c) => ({ ...c })) }));
   }
 
   private _pushUndoSnapshot(): void {
-    if (this._inTransaction) return;
+    if (this._inTransaction) {
+      this._transactionMutated = true;
+      return;
+    }
     this._undoStack.push(this._snapshotTracks());
     if (this._undoStack.length > this.undoLimit) {
       this._undoStack.shift();

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -45,6 +45,12 @@ export class PlaylistEngine {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   private _listeners: Map<string, Set<Function>> = new Map();
 
+  private _undoStack: ClipTrack[][] = [];
+  private _redoStack: ClipTrack[][] = [];
+  private _inTransaction = false;
+  private _transactionSnapshot: ClipTrack[] | null = null;
+  undoLimit = 100;
+
   constructor(options: PlaylistEngineOptions = {}) {
     this._sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE;
     this._zoomLevels = [...(options.zoomLevels ?? DEFAULT_ZOOM_LEVELS)];
@@ -66,10 +72,65 @@ export class PlaylistEngine {
   }
 
   // ---------------------------------------------------------------------------
+  // Undo/Redo
+  // ---------------------------------------------------------------------------
+
+  get canUndo(): boolean {
+    return this._undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this._redoStack.length > 0;
+  }
+
+  undo(): void {
+    if (this._undoStack.length === 0) return;
+    const snapshot = this._undoStack.pop()!;
+    this._redoStack.push(this._snapshotTracks());
+    this._restoreTracks(snapshot);
+  }
+
+  redo(): void {
+    if (this._redoStack.length === 0) return;
+    const snapshot = this._redoStack.pop()!;
+    this._undoStack.push(this._snapshotTracks());
+    this._restoreTracks(snapshot);
+  }
+
+  clearHistory(): void {
+    this._undoStack = [];
+    this._redoStack = [];
+  }
+
+  beginTransaction(): void {
+    this._transactionSnapshot = this._snapshotTracks();
+    this._inTransaction = true;
+  }
+
+  commitTransaction(): void {
+    if (!this._inTransaction || this._transactionSnapshot === null) return;
+    this._undoStack.push(this._transactionSnapshot);
+    if (this._undoStack.length > this.undoLimit) {
+      this._undoStack.shift();
+    }
+    this._redoStack = [];
+    this._transactionSnapshot = null;
+    this._inTransaction = false;
+  }
+
+  abortTransaction(): void {
+    if (!this._inTransaction || this._transactionSnapshot === null) return;
+    const snapshot = this._transactionSnapshot;
+    this._transactionSnapshot = null;
+    this._inTransaction = false;
+    this._restoreTracks(snapshot);
+  }
+
+  // ---------------------------------------------------------------------------
   // State snapshot
   // ---------------------------------------------------------------------------
 
-  getState(): EngineState {
+  getState(): EngineState & { canUndo: boolean; canRedo: boolean } {
     return {
       tracks: this._tracks.map((t) => ({ ...t, clips: [...t.clips] })),
       tracksVersion: this._tracksVersion,
@@ -88,6 +149,8 @@ export class PlaylistEngine {
       loopStart: this._loopStart,
       loopEnd: this._loopEnd,
       isLoopEnabled: this._isLoopEnabled,
+      canUndo: this.canUndo,
+      canRedo: this.canRedo,
     };
   }
 
@@ -96,6 +159,7 @@ export class PlaylistEngine {
   // ---------------------------------------------------------------------------
 
   setTracks(tracks: ClipTrack[]): void {
+    this.clearHistory();
     this._tracks = [...tracks];
     this._tracksVersion++;
     this._adapter?.setTracks(this._tracks);
@@ -103,6 +167,7 @@ export class PlaylistEngine {
   }
 
   addTrack(track: ClipTrack): void {
+    this._pushUndoSnapshot();
     this._tracks = [...this._tracks, track];
     this._tracksVersion++;
     if (this._adapter?.addTrack) {
@@ -115,6 +180,7 @@ export class PlaylistEngine {
 
   removeTrack(trackId: string): void {
     if (!this._tracks.some((t) => t.id === trackId)) return;
+    this._pushUndoSnapshot();
     this._tracks = this._tracks.filter((t) => t.id !== trackId);
     this._tracksVersion++;
     if (this._selectedTrackId === trackId) {
@@ -133,6 +199,7 @@ export class PlaylistEngine {
     const resolved = track ?? this._tracks.find((t) => t.id === trackId);
     if (!resolved) return;
     if (track) {
+      this._pushUndoSnapshot();
       this._tracks = this._tracks.map((t) => (t.id === trackId ? track : t));
       this._tracksVersion++;
     }
@@ -243,6 +310,8 @@ export class PlaylistEngine {
 
     if (constrainedDelta === 0) return;
 
+    this._pushUndoSnapshot();
+
     this._tracks = this._tracks.map((t) => {
       if (t.id !== trackId) return t;
       const newClips = t.clips.map((c: AudioClip, i: number) =>
@@ -288,6 +357,8 @@ export class PlaylistEngine {
       );
       return;
     }
+
+    this._pushUndoSnapshot();
 
     const { left, right } = splitClipOp(clip, atSample);
 
@@ -339,6 +410,8 @@ export class PlaylistEngine {
     );
 
     if (constrained === 0) return;
+
+    this._pushUndoSnapshot();
 
     this._tracks = this._tracks.map((t) => {
       if (t.id !== trackId) return t;
@@ -579,6 +652,26 @@ export class PlaylistEngine {
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  private _snapshotTracks(): ClipTrack[] {
+    return this._tracks.map((t) => ({ ...t, clips: [...t.clips] }));
+  }
+
+  private _pushUndoSnapshot(): void {
+    if (this._inTransaction) return;
+    this._undoStack.push(this._snapshotTracks());
+    if (this._undoStack.length > this.undoLimit) {
+      this._undoStack.shift();
+    }
+    this._redoStack = [];
+  }
+
+  private _restoreTracks(snapshot: ClipTrack[]): void {
+    this._tracks = snapshot;
+    this._tracksVersion++;
+    this._adapter?.setTracks(this._tracks);
+    this._emitStateChange();
+  }
 
   private _emit(event: string, ...args: unknown[]): void {
     const listeners = this._listeners.get(event);

--- a/packages/engine/src/__tests__/undo.test.ts
+++ b/packages/engine/src/__tests__/undo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PlaylistEngine } from '../PlaylistEngine';
 import { createClip, createTrack } from '@waveform-playlist/core';
 
@@ -252,6 +252,98 @@ describe('PlaylistEngine — Undo/Redo', () => {
       // Only one undo step, not two
       engine.undo();
       expect(engine.canUndo).toBe(false);
+    });
+  });
+
+  describe('addTrack/removeTrack undo', () => {
+    it('undo after addTrack removes the track', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+      expect(engine.getState().tracks).toHaveLength(1);
+
+      const newTrack = makeTrack([makeClip(0, 24000)]);
+      engine.addTrack(newTrack);
+      expect(engine.getState().tracks).toHaveLength(2);
+
+      engine.undo();
+      expect(engine.getState().tracks).toHaveLength(1);
+    });
+
+    it('undo after removeTrack restores the track', () => {
+      const clip1 = makeClip(0, 48000);
+      const clip2 = makeClip(0, 24000);
+      const track1 = makeTrack([clip1]);
+      const track2 = makeTrack([clip2]);
+      engine.setTracks([track1, track2]);
+      expect(engine.getState().tracks).toHaveLength(2);
+
+      const trackId = engine.getState().tracks[1].id;
+      engine.removeTrack(trackId);
+      expect(engine.getState().tracks).toHaveLength(1);
+
+      engine.undo();
+      expect(engine.getState().tracks).toHaveLength(2);
+    });
+  });
+
+  describe('empty stack safety', () => {
+    it('undo on empty stack is a no-op (no throw, no state change)', () => {
+      expect(engine.canUndo).toBe(false);
+      expect(() => engine.undo()).not.toThrow();
+      expect(engine.canUndo).toBe(false);
+      expect(engine.canRedo).toBe(false);
+    });
+
+    it('redo on empty stack is a no-op (no throw, no state change)', () => {
+      expect(engine.canRedo).toBe(false);
+      expect(() => engine.redo()).not.toThrow();
+      expect(engine.canUndo).toBe(false);
+      expect(engine.canRedo).toBe(false);
+    });
+  });
+
+  describe('transaction edge cases', () => {
+    it('commitTransaction without beginTransaction is a no-op', () => {
+      expect(() => engine.commitTransaction()).not.toThrow();
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('abortTransaction without beginTransaction is a no-op', () => {
+      expect(() => engine.abortTransaction()).not.toThrow();
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('double beginTransaction warns but does not throw', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      engine.beginTransaction();
+      engine.beginTransaction();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already in a transaction'));
+      // Clean up — commit the second transaction
+      engine.commitTransaction();
+      warnSpy.mockRestore();
+    });
+
+    it('double commitTransaction warns on second call', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      engine.beginTransaction();
+      engine.moveClip(
+        engine.getState().tracks[0].id,
+        engine.getState().tracks[0].clips[0].id,
+        1000
+      );
+      engine.commitTransaction();
+      expect(engine.canUndo).toBe(true);
+
+      engine.commitTransaction(); // second commit — no active transaction
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no active transaction to commit')
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/engine/src/__tests__/undo.test.ts
+++ b/packages/engine/src/__tests__/undo.test.ts
@@ -139,7 +139,7 @@ describe('PlaylistEngine — Undo/Redo', () => {
 
   describe('stack limit', () => {
     it('respects undoLimit', () => {
-      engine.undoLimit = 3;
+      engine = new PlaylistEngine({ sampleRate: 48000, undoLimit: 3 });
       const clip = makeClip(0, 48000);
       const track = makeTrack([clip]);
       engine.setTracks([track]);

--- a/packages/engine/src/__tests__/undo.test.ts
+++ b/packages/engine/src/__tests__/undo.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PlaylistEngine } from '../PlaylistEngine';
+import { createClip, createTrack } from '@waveform-playlist/core';
+
+function makeClip(startSample: number, durationSamples: number) {
+  return createClip({
+    startSample,
+    durationSamples,
+    offsetSamples: 0,
+    sampleRate: 48000,
+    sourceDurationSamples: 96000,
+  });
+}
+
+function makeTrack(clips: ReturnType<typeof makeClip>[]) {
+  return createTrack({ name: 'Test', clips });
+}
+
+describe('PlaylistEngine — Undo/Redo', () => {
+  let engine: PlaylistEngine;
+
+  beforeEach(() => {
+    engine = new PlaylistEngine({ sampleRate: 48000 });
+  });
+
+  describe('basic undo/redo', () => {
+    it('canUndo is false initially', () => {
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('canRedo is false initially', () => {
+      expect(engine.canRedo).toBe(false);
+    });
+
+    it('undo restores previous track state after moveClip', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+      const originalStart = engine.getState().tracks[0].clips[0].startSample;
+
+      engine.moveClip(trackId, clipId, 10000);
+      expect(engine.getState().tracks[0].clips[0].startSample).toBe(originalStart + 10000);
+      expect(engine.canUndo).toBe(true);
+
+      engine.undo();
+      expect(engine.getState().tracks[0].clips[0].startSample).toBe(originalStart);
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('redo re-applies undone operation', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.moveClip(trackId, clipId, 10000);
+      const movedStart = engine.getState().tracks[0].clips[0].startSample;
+
+      engine.undo();
+      expect(engine.canRedo).toBe(true);
+
+      engine.redo();
+      expect(engine.getState().tracks[0].clips[0].startSample).toBe(movedStart);
+      expect(engine.canRedo).toBe(false);
+    });
+
+    it('new edit clears redo stack', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.moveClip(trackId, clipId, 10000);
+      engine.undo();
+      expect(engine.canRedo).toBe(true);
+
+      engine.moveClip(trackId, clipId, 5000);
+      expect(engine.canRedo).toBe(false);
+    });
+  });
+
+  describe('undoable operations', () => {
+    it('trimClip is undoable', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+      const originalDuration = engine.getState().tracks[0].clips[0].durationSamples;
+
+      engine.trimClip(trackId, clipId, 'right', -10000);
+
+      engine.undo();
+      expect(engine.getState().tracks[0].clips[0].durationSamples).toBe(originalDuration);
+    });
+
+    it('splitClip is undoable', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      expect(engine.getState().tracks[0].clips).toHaveLength(1);
+
+      engine.splitClip(trackId, clipId, 24000);
+      expect(engine.getState().tracks[0].clips).toHaveLength(2);
+
+      engine.undo();
+      expect(engine.getState().tracks[0].clips).toHaveLength(1);
+    });
+  });
+
+  describe('non-undoable operations', () => {
+    it('setSelection does not create undo step', () => {
+      engine.setSelection(1.0, 2.0);
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('setZoomLevel does not create undo step', () => {
+      engine.setZoomLevel(2048);
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('setMasterVolume does not create undo step', () => {
+      engine.setMasterVolume(0.5);
+      expect(engine.canUndo).toBe(false);
+    });
+  });
+
+  describe('stack limit', () => {
+    it('respects undoLimit', () => {
+      engine.undoLimit = 3;
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      // 4 moves but limit is 3
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 1000);
+
+      // Can undo 3 times, not 4
+      engine.undo();
+      engine.undo();
+      engine.undo();
+      expect(engine.canUndo).toBe(false);
+    });
+  });
+
+  describe('clearHistory', () => {
+    it('clears both undo and redo stacks', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 1000);
+      engine.undo();
+
+      expect(engine.canUndo).toBe(true);
+      expect(engine.canRedo).toBe(true);
+
+      engine.clearHistory();
+      expect(engine.canUndo).toBe(false);
+      expect(engine.canRedo).toBe(false);
+    });
+
+    it('setTracks clears history', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.moveClip(trackId, clipId, 1000);
+      expect(engine.canUndo).toBe(true);
+
+      engine.setTracks([makeTrack([makeClip(0, 24000)])]);
+      expect(engine.canUndo).toBe(false);
+    });
+  });
+
+  describe('transactions', () => {
+    it('groups multiple operations into one undo step', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.beginTransaction();
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 2000);
+      engine.moveClip(trackId, clipId, 3000);
+      engine.commitTransaction();
+
+      // One undo step undoes all three moves
+      engine.undo();
+      expect(engine.getState().tracks[0].clips[0].startSample).toBe(0);
+    });
+
+    it('abortTransaction restores pre-transaction state', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.beginTransaction();
+      engine.moveClip(trackId, clipId, 5000);
+      engine.moveClip(trackId, clipId, 5000);
+
+      engine.abortTransaction();
+      expect(engine.getState().tracks[0].clips[0].startSample).toBe(0);
+      // Abort does not add to undo stack
+      expect(engine.canUndo).toBe(false);
+    });
+
+    it('operations during transaction do not create individual undo steps', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+
+      engine.beginTransaction();
+      engine.moveClip(trackId, clipId, 1000);
+      engine.moveClip(trackId, clipId, 1000);
+      engine.commitTransaction();
+
+      // Only one undo step, not two
+      engine.undo();
+      expect(engine.canUndo).toBe(false);
+    });
+  });
+
+  describe('statechange', () => {
+    it('undo emits statechange with canUndo/canRedo', () => {
+      const clip = makeClip(0, 48000);
+      const track = makeTrack([clip]);
+      engine.setTracks([track]);
+
+      const trackId = engine.getState().tracks[0].id;
+      const clipId = engine.getState().tracks[0].clips[0].id;
+      engine.moveClip(trackId, clipId, 1000);
+
+      const states: { canUndo: boolean; canRedo: boolean }[] = [];
+      engine.on('statechange', (state) => {
+        states.push({ canUndo: state.canUndo, canRedo: state.canRedo });
+      });
+
+      engine.undo();
+      expect(states).toHaveLength(1);
+      expect(states[0].canUndo).toBe(false);
+      expect(states[0].canRedo).toBe(true);
+    });
+  });
+});

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -71,6 +71,8 @@ export interface PlaylistEngineOptions {
   sampleRate?: number;
   samplesPerPixel?: number;
   zoomLevels?: number[];
+  /** Maximum number of undo steps (default 100). */
+  undoLimit?: number;
 }
 
 /**

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -57,6 +57,10 @@ export interface EngineState {
   loopEnd: number;
   /** Whether loop playback is active. */
   isLoopEnabled: boolean;
+  /** Whether undo is available. */
+  canUndo: boolean;
+  /** Whether redo is available. */
+  canRedo: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add snapshot-based undo/redo stack to `PlaylistEngine`
- Wire undo/redo to `<daw-editor>` with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z shortcuts
- Wrap clip move/trim drags in transactions (one undo step per gesture)

## Details

**Engine (`@waveform-playlist/engine`):**
- `undo()`, `redo()`, `clearHistory()` — snapshot-based, no per-operation inverse logic
- `canUndo`, `canRedo` getters (also in `EngineState`)
- `beginTransaction()` / `commitTransaction()` / `abortTransaction()` — groups mutations into one step
- `undoLimit` (default 100, configurable)
- Undoable: `moveClip`, `trimClip`, `splitClip`, `addTrack`, `removeTrack`
- Not undoable: selection, zoom, volume, loop, seek (navigation/mixing, not structural edits)
- `setTracks()` clears history (new track set)
- 17 unit tests

**Dawcore (`@dawcore/components`):**
- `editor.undo()`, `editor.redo()`, `editor.canUndo`, `editor.canRedo` — delegate to engine
- Default keyboard shortcuts when `keyboard-shortcuts` attribute is set:
  - Cmd/Ctrl+Z → undo
  - Cmd/Ctrl+Shift+Z → redo
- Clip drag transactions: `beginTransaction()` at drag start, `commitTransaction()` at drop
  - Without this, a 1-second move drag at 60fps created 60 individual undo steps

## Test plan

- [x] 17 engine undo/redo tests (basic undo/redo, transactions, stack limit, clearHistory, statechange events)
- [x] 262 dawcore tests pass (no regressions)
- [x] Engine typecheck + build clean
- [x] Manual: move clip → Cmd+Z → clip reverts (one step, not 60)
- [x] Manual: trim clip → Cmd+Z → trim reverts
- [x] Manual: split clip → Cmd+Z → un-splits
- [x] Manual: Cmd+Shift+Z → redo works
- [x] Manual: multiple undos chain correctly