### PR TITLE
feat(browser): add undo/redo support to React app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ pnpm publish --filter @waveform-playlist/NEW-PACKAGE --no-git-checks --access pu
 
 - `website/static/llms.txt` — Library discovery page, served at `/llms.txt`. Update when packages, architecture, or key APIs change.
 - `website/docs/api/llm-reference.md` — All TypeScript interfaces from source, no prose. Update when any context type, hook signature, or component prop changes.
-- **Keep both in sync** — When adding new providers or components, update both `llms.txt` and `llm-reference.md`.
+- **Keep all doc surfaces in sync** — When adding new context fields, hook returns, or component props, update: (1) `llm-reference.md` (interfaces), (2) `llms.txt` (descriptions), (3) `docs/api/hooks.md` (context value interfaces), (4) `docs/examples.md` (code snippets), (5) example page files in `src/pages/examples/` (keyboard shortcuts sections, feature lists).
 
 ---
 

--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -142,6 +142,7 @@ const rebuildChain = useCallback(() => {
 - `useSelectedTrack` — selectedTrackId
 - `useZoomControls` — samplesPerPixel, canZoomIn, canZoomOut
 - `useMasterVolume` — masterVolume
+- `useUndoState` — canUndo, canRedo
 
 **Still React-only:** isPlaying (animation loop timing), tracks (loaded via useAudioTracks). `currentTime` is read from engine during playback via `getPlaybackTime()` (→ `engine.getCurrentTime()` → `Transport.seconds`).
 
@@ -154,6 +155,7 @@ const rebuildChain = useCallback(() => {
 - `if (isLoopEnabledRef.current) engine.setLoopEnabled(true)`
 - `engine.setMasterVolume(masterVolumeRef.current ?? 1.0)`
 - `if (selectedTrackIdRef.current) engine.selectTrack(selectedTrackIdRef.current)`
+- `canUndo`/`canRedo` — no seed needed. `setTracks()` calls `clearHistory()`, so undo state always resets on rebuild.
 
 **Guard handler with ref comparisons:** Each hook's `onEngineState()` compares `state.field !== ref.current` before calling `setState` to skip unnecessary React updates. Ref assignments are synchronous; `setState` calls are batched by React.
 

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -40,6 +40,7 @@ import {
   useSelectionState,
   useLoopState,
   useSelectedTrack,
+  useUndoState,
   useAnimationFrameLoop,
   useWaveformDataCache,
 } from './hooks';
@@ -106,6 +107,10 @@ export interface PlaylistStateContextValue {
   loopEnd: number;
   /** Whether playback continues past the end of loaded audio */
   indefinitePlayback: boolean;
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Whether redo is available */
+  canRedo: boolean;
 }
 
 export interface PlaylistControlsContextValue {
@@ -154,6 +159,10 @@ export interface PlaylistControlsContextValue {
   setLoopRegion: (start: number, end: number) => void;
   setLoopRegionFromSelection: () => void;
   clearLoopRegion: () => void;
+
+  // Undo/redo
+  undo: () => void;
+  redo: () => void;
 }
 
 export interface PlaylistDataContextValue {
@@ -412,6 +421,13 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     onEngineState: onSelectedTrackEngineState,
     selectedTrackIdRef,
   } = useSelectedTrack({ engineRef });
+  const {
+    canUndo,
+    canRedo,
+    undo,
+    redo,
+    onEngineState: onUndoEngineState,
+  } = useUndoState({ engineRef });
   const { animationFrameRef, startAnimationFrameLoop, stopAnimationFrameLoop } =
     useAnimationFrameLoop();
 
@@ -752,6 +768,7 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
           onSelectedTrackEngineState(state);
           onZoomEngineState(state);
           onVolumeEngineState(state);
+          onUndoEngineState(state);
 
           // Mirror engine tracks changes to parent via onTracksChange.
           // tracksVersion only increments on track mutations (move, trim, split,
@@ -825,6 +842,7 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     onSelectedTrackEngineState,
     onZoomEngineState,
     onVolumeEngineState,
+    onUndoEngineState,
     onTracksChange,
     masterVolumeRef,
     selectionStartRef,
@@ -1365,6 +1383,8 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       loopStart,
       loopEnd,
       indefinitePlayback,
+      canUndo,
+      canRedo,
     }),
     [
       continuousPlay,
@@ -1380,6 +1400,8 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       loopStart,
       loopEnd,
       indefinitePlayback,
+      canUndo,
+      canRedo,
     ]
   );
 
@@ -1442,6 +1464,10 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       setLoopRegion,
       setLoopRegionFromSelection,
       clearLoopRegion,
+
+      // Undo/redo
+      undo,
+      redo,
     }),
     [
       play,
@@ -1472,6 +1498,8 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       setLoopRegion,
       setLoopRegionFromSelection,
       clearLoopRegion,
+      undo,
+      redo,
     ]
   );
 

--- a/packages/browser/src/components/KeyboardShortcuts.tsx
+++ b/packages/browser/src/components/KeyboardShortcuts.tsx
@@ -12,6 +12,8 @@ export interface KeyboardShortcutsProps {
   clipSplitting?: boolean;
   /** Enable annotation keyboard controls (arrow nav, boundary editing). Defaults to false. */
   annotations?: boolean;
+  /** Enable undo/redo shortcuts (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z). Defaults to false. */
+  undo?: boolean;
   /** Additional shortcuts appended to the defaults. */
   additionalShortcuts?: KeyboardShortcut[];
 }
@@ -32,6 +34,7 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
   playback = false,
   clipSplitting = false,
   annotations = false,
+  undo: undoEnabled = false,
   additionalShortcuts = [],
 }) => {
   // Clip splitting setup
@@ -42,7 +45,8 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
     activeAnnotationId,
     continuousPlay,
   } = usePlaylistState();
-  const { setAnnotations, setActiveAnnotationId, scrollContainerRef, play } = usePlaylistControls();
+  const { setAnnotations, setActiveAnnotationId, scrollContainerRef, play, undo, redo } =
+    usePlaylistControls();
 
   const { splitClipAtPlayhead } = useClipSplitting({
     tracks,
@@ -60,6 +64,15 @@ export const KeyboardShortcuts: React.FC<KeyboardShortcutsProps> = ({
       description: 'Split clip at playhead',
       preventDefault: true,
     });
+  }
+
+  if (undoEnabled) {
+    allAdditional.push(
+      { key: 'z', ctrlKey: true, shiftKey: false, action: undo, description: 'Undo' },
+      { key: 'z', metaKey: true, shiftKey: false, action: undo, description: 'Undo' },
+      { key: 'z', ctrlKey: true, shiftKey: true, action: redo, description: 'Redo' },
+      { key: 'z', metaKey: true, shiftKey: true, action: redo, description: 'Redo' }
+    );
   }
 
   if (additionalShortcuts.length > 0) {

--- a/packages/browser/src/hooks/index.ts
+++ b/packages/browser/src/hooks/index.ts
@@ -16,6 +16,9 @@ export type { LoopControls, UseLoopStateProps } from './useLoopState';
 export { useSelectedTrack } from './useSelectedTrack';
 export type { SelectedTrackControls, UseSelectedTrackProps } from './useSelectedTrack';
 
+export { useUndoState } from './useUndoState';
+export type { UndoControls, UseUndoStateProps } from './useUndoState';
+
 export { useMasterAnalyser } from './useAudioEffects';
 
 export { useAudioTracks } from './useAudioTracks';

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -281,6 +281,7 @@ export function useClipDragHandlers({
 
       if (!data) {
         // Transaction was opened in onDragStart — abort to prevent leak
+        isDraggingRef.current = false;
         engineRef.current?.abortTransaction();
         return;
       }
@@ -305,14 +306,15 @@ export function useClipDragHandlers({
           console.warn(
             `[waveform-playlist] onDragEnd: track at index ${trackIndex} not found — trim not synced to adapter`
           );
+          engineRef.current?.abortTransaction();
         } else if (!engineRef.current) {
           console.warn('[waveform-playlist] engineRef is null — trim not synced to adapter');
         } else {
           engineRef.current.trimClip(trackId, clipId, boundary, Math.floor(sampleDelta));
+          engineRef.current.commitTransaction();
         }
         originalClipStateRef.current = null;
         lastBoundaryDeltaRef.current = 0;
-        engineRef.current?.commitTransaction();
         return;
       }
 
@@ -321,12 +323,13 @@ export function useClipDragHandlers({
         console.warn(
           `[waveform-playlist] onDragEnd: track at index ${trackIndex} not found — move not synced to adapter`
         );
+        engineRef.current?.abortTransaction();
       } else if (!engineRef.current) {
         console.warn('[waveform-playlist] engineRef is null — move not synced to adapter');
       } else {
         engineRef.current.moveClip(trackId, clipId, Math.floor(sampleDelta));
+        engineRef.current.commitTransaction();
       }
-      engineRef.current?.commitTransaction();
     },
     [tracks, onTracksChange, samplesPerPixel, engineRef, isDraggingRef]
   );

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -98,6 +98,8 @@ export function useClipDragHandlers({
       // Only store state for boundary trimming operations
       if (!data.boundary) {
         originalClipStateRef.current = null;
+        // Group move into one undo step
+        engineRef.current?.beginTransaction();
         return;
       }
 
@@ -113,9 +115,11 @@ export function useClipDragHandlers({
         };
         // Signal provider to skip loadAudio rebuilds during the drag
         isDraggingRef.current = true;
+        // Group the drag into one undo step
+        engineRef.current?.beginTransaction();
       }
     },
-    [tracks, isDraggingRef]
+    [tracks, isDraggingRef, engineRef]
   );
 
   const onDragMove = React.useCallback(
@@ -250,6 +254,8 @@ export function useClipDragHandlers({
         isDraggingRef.current = false;
         originalClipStateRef.current = null;
         lastBoundaryDeltaRef.current = 0;
+        // Cancel aborts the transaction — no undo step pushed
+        engineRef.current?.abortTransaction();
         return;
       }
 
@@ -290,6 +296,7 @@ export function useClipDragHandlers({
         }
         originalClipStateRef.current = null;
         lastBoundaryDeltaRef.current = 0;
+        engineRef.current?.commitTransaction();
         return;
       }
 
@@ -303,6 +310,7 @@ export function useClipDragHandlers({
       } else {
         engineRef.current.moveClip(trackId, clipId, Math.floor(sampleDelta));
       }
+      engineRef.current?.commitTransaction();
     },
     [tracks, onTracksChange, samplesPerPixel, engineRef, isDraggingRef]
   );

--- a/packages/browser/src/hooks/useClipDragHandlers.ts
+++ b/packages/browser/src/hooks/useClipDragHandlers.ts
@@ -99,7 +99,13 @@ export function useClipDragHandlers({
       if (!data.boundary) {
         originalClipStateRef.current = null;
         // Group move into one undo step
-        engineRef.current?.beginTransaction();
+        if (engineRef.current) {
+          engineRef.current.beginTransaction();
+        } else {
+          console.warn(
+            '[waveform-playlist] onDragStart: engine not ready, move will not be grouped for undo'
+          );
+        }
         return;
       }
 
@@ -116,7 +122,13 @@ export function useClipDragHandlers({
         // Signal provider to skip loadAudio rebuilds during the drag
         isDraggingRef.current = true;
         // Group the drag into one undo step
-        engineRef.current?.beginTransaction();
+        if (engineRef.current) {
+          engineRef.current.beginTransaction();
+        } else {
+          console.warn(
+            '[waveform-playlist] onDragStart: engine not ready, trim will not be grouped for undo'
+          );
+        }
       }
     },
     [tracks, isDraggingRef, engineRef]
@@ -267,7 +279,11 @@ export function useClipDragHandlers({
           }
         | undefined;
 
-      if (!data) return;
+      if (!data) {
+        // Transaction was opened in onDragStart — abort to prevent leak
+        engineRef.current?.abortTransaction();
+        return;
+      }
 
       const { trackIndex, clipId, boundary } = data;
 

--- a/packages/browser/src/hooks/useUndoState.ts
+++ b/packages/browser/src/hooks/useUndoState.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback, type RefObject } from 'react';
+import type { PlaylistEngine, EngineState } from '@waveform-playlist/engine';
+
+export interface UseUndoStateProps {
+  engineRef: RefObject<PlaylistEngine | null>;
+}
+
+export interface UndoControls {
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+}
+
+/**
+ * Hook for managing undo/redo state via PlaylistEngine delegation.
+ *
+ * undo/redo delegate to the engine. canUndo/canRedo are mirrored back
+ * from the engine via onEngineState(), which the provider's statechange
+ * handler calls on every engine event.
+ */
+export function useUndoState({ engineRef }: UseUndoStateProps): UndoControls & {
+  onEngineState: (state: EngineState) => void;
+} {
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const undo = useCallback(() => {
+    engineRef.current?.undo();
+  }, [engineRef]);
+
+  const redo = useCallback(() => {
+    engineRef.current?.redo();
+  }, [engineRef]);
+
+  // Called by the provider's statechange handler to mirror engine state.
+  const onEngineState = useCallback((state: EngineState) => {
+    setCanUndo((prev) => (prev !== state.canUndo ? state.canUndo : prev));
+    setCanRedo((prev) => (prev !== state.canRedo ? state.canRedo : prev));
+  }, []);
+
+  return {
+    canUndo,
+    canRedo,
+    undo,
+    redo,
+    onEngineState,
+  };
+}

--- a/packages/browser/src/hooks/useUndoState.ts
+++ b/packages/browser/src/hooks/useUndoState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, type RefObject } from 'react';
+import { useState, useCallback, useRef, type RefObject } from 'react';
 import type { PlaylistEngine, EngineState } from '@waveform-playlist/engine';
 
 export interface UseUndoStateProps {
@@ -18,12 +18,19 @@ export interface UndoControls {
  * undo/redo delegate to the engine. canUndo/canRedo are mirrored back
  * from the engine via onEngineState(), which the provider's statechange
  * handler calls on every engine event.
+ *
+ * No refs are exposed for engine seeding — undo history intentionally
+ * resets on engine rebuild (setTracks calls clearHistory).
  */
 export function useUndoState({ engineRef }: UseUndoStateProps): UndoControls & {
   onEngineState: (state: EngineState) => void;
 } {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
+
+  // Internal refs for statechange guard (same pattern as useSelectionState etc.)
+  const canUndoRef = useRef(false);
+  const canRedoRef = useRef(false);
 
   const undo = useCallback(() => {
     if (!engineRef.current) {
@@ -43,8 +50,14 @@ export function useUndoState({ engineRef }: UseUndoStateProps): UndoControls & {
 
   // Called by the provider's statechange handler to mirror engine state.
   const onEngineState = useCallback((state: EngineState) => {
-    setCanUndo((prev) => (prev !== state.canUndo ? state.canUndo : prev));
-    setCanRedo((prev) => (prev !== state.canRedo ? state.canRedo : prev));
+    if (state.canUndo !== canUndoRef.current) {
+      canUndoRef.current = state.canUndo;
+      setCanUndo(state.canUndo);
+    }
+    if (state.canRedo !== canRedoRef.current) {
+      canRedoRef.current = state.canRedo;
+      setCanRedo(state.canRedo);
+    }
   }, []);
 
   return {

--- a/packages/browser/src/hooks/useUndoState.ts
+++ b/packages/browser/src/hooks/useUndoState.ts
@@ -26,11 +26,19 @@ export function useUndoState({ engineRef }: UseUndoStateProps): UndoControls & {
   const [canRedo, setCanRedo] = useState(false);
 
   const undo = useCallback(() => {
-    engineRef.current?.undo();
+    if (!engineRef.current) {
+      console.warn('[waveform-playlist] undo: engine not ready, call ignored');
+      return;
+    }
+    engineRef.current.undo();
   }, [engineRef]);
 
   const redo = useCallback(() => {
-    engineRef.current?.redo();
+    if (!engineRef.current) {
+      console.warn('[waveform-playlist] redo: engine not ready, call ignored');
+      return;
+    }
+    engineRef.current.redo();
   }, [engineRef]);
 
   // Called by the provider's statechange handler to mirror engine state.

--- a/packages/dawcore/src/interactions/clip-pointer-handler.ts
+++ b/packages/dawcore/src/interactions/clip-pointer-handler.ts
@@ -315,6 +315,10 @@ export class ClipPointerHandler {
               },
             })
           );
+        } else {
+          console.warn(
+            '[dawcore] engine unavailable at trim drop — trim not applied for clip ' + this._clipId
+          );
         }
       }
     } finally {

--- a/packages/engine/src/PlaylistEngine.ts
+++ b/packages/engine/src/PlaylistEngine.ts
@@ -121,13 +121,18 @@ export class PlaylistEngine {
       console.warn('[waveform-playlist/engine] commitTransaction: no active transaction to commit');
       return;
     }
-    this._undoStack.push(this._transactionSnapshot);
-    if (this._undoStack.length > this.undoLimit) {
-      this._undoStack.shift();
+    // Only push undo entry if mutations actually occurred during the transaction.
+    // Without this, no-op drags (e.g., against a boundary) create phantom undo entries.
+    if (this._transactionMutated) {
+      this._undoStack.push(this._transactionSnapshot);
+      if (this._undoStack.length > this.undoLimit) {
+        this._undoStack.shift();
+      }
+      this._redoStack = [];
     }
-    this._redoStack = [];
     this._transactionSnapshot = null;
     this._inTransaction = false;
+    this._transactionMutated = false;
   }
 
   abortTransaction(): void {

--- a/website/docs/api/hooks.md
+++ b/website/docs/api/hooks.md
@@ -325,6 +325,10 @@ interface PlaylistStateContextValue {
   loopEnd: number;
   /** Whether playback continues past the end of loaded audio */
   indefinitePlayback: boolean;
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Whether redo is available */
+  canRedo: boolean;
 }
 ```
 
@@ -407,6 +411,10 @@ interface PlaylistControlsContextValue {
   setLoopRegion: (start: number, end: number) => void;
   setLoopRegionFromSelection: () => void;
   clearLoopRegion: () => void;
+
+  // Undo/redo
+  undo: () => void;
+  redo: () => void;
 }
 ```
 

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -192,6 +192,10 @@ interface PlaylistStateContextValue {
   loopEnd: number;
   /** Whether playback continues past the end of loaded audio */
   indefinitePlayback: boolean;
+  /** Whether undo is available */
+  canUndo: boolean;
+  /** Whether redo is available */
+  canRedo: boolean;
 }
 ```
 
@@ -244,6 +248,10 @@ interface PlaylistControlsContextValue {
   setLoopRegion: (start: number, end: number) => void;
   setLoopRegionFromSelection: () => void;
   clearLoopRegion: () => void;
+
+  // Undo/redo
+  undo: () => void;
+  redo: () => void;
 }
 ```
 
@@ -900,6 +908,7 @@ interface KeyboardShortcutsProps {
   playback?: boolean;                  // Default: false — Space (play/pause), Escape (stop), 0 (rewind)
   clipSplitting?: boolean;             // Default: false — 's' key splits clip at playhead
   annotations?: boolean;               // Default: false — arrow nav, boundary editing, Enter to play
+  undo?: boolean;                      // Default: false — Cmd/Ctrl+Z (undo), Cmd/Ctrl+Shift+Z (redo)
   additionalShortcuts?: KeyboardShortcut[];  // Appended to enabled defaults
 }
 ```

--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -217,7 +217,7 @@ import { KeyboardShortcuts } from '@waveform-playlist/browser';
 
 // Declarative — just enable the features you want
 <WaveformPlaylistProvider tracks={tracks} {...}>
-  <KeyboardShortcuts playback clipSplitting />
+  <KeyboardShortcuts playback clipSplitting undo />
   <Waveform />
 </WaveformPlaylistProvider>
 

--- a/website/src/components/examples/BeatsAndBarsExample.tsx
+++ b/website/src/components/examples/BeatsAndBarsExample.tsx
@@ -234,7 +234,7 @@ export function BeatsAndBarsExample() {
     >
       <BeatsAndBarsProvider bpm={bpm} timeSignature={timeSignature} snapTo={snapTo} scaleMode={scaleMode}>
         <ClipInteractionProvider snap={snap}>
-          <KeyboardShortcuts playback clipSplitting />
+          <KeyboardShortcuts playback clipSplitting undo />
           <Controls>
             <ControlGroup>
               <PlayButton />

--- a/website/src/components/examples/FlexibleApiExample.tsx
+++ b/website/src/components/examples/FlexibleApiExample.tsx
@@ -415,7 +415,7 @@ const FlexibleApiContent: React.FC<FlexibleApiContentProps> = ({ tracks }) => {
       </Card>
 
       <ClipInteractionProvider>
-        <KeyboardShortcuts playback clipSplitting />
+        <KeyboardShortcuts playback clipSplitting undo />
         <Waveform
           renderTrackControls={(trackIndex) => (
             <CustomTrackControls trackIndex={trackIndex} />

--- a/website/src/components/examples/MultiClipExample.tsx
+++ b/website/src/components/examples/MultiClipExample.tsx
@@ -225,7 +225,7 @@ export function MultiClipExample() {
       barGap={0}
     >
       <ClipInteractionProvider>
-        <KeyboardShortcuts playback clipSplitting />
+        <KeyboardShortcuts playback clipSplitting undo />
         <Controls>
           <ControlGroup>
             <PlayButton />

--- a/website/src/pages/examples/flexible-api.tsx
+++ b/website/src/pages/examples/flexible-api.tsx
@@ -32,6 +32,16 @@ export default function FlexibleApiExamplePage(): React.ReactElement {
           custom UI with any component library while the library handles the audio engine.
         </p>
 
+        <h3>Keyboard Shortcuts</h3>
+        <ul>
+          <li><code>Space</code> - Play/Pause</li>
+          <li><code>Escape</code> - Stop</li>
+          <li><code>0</code> - Rewind to start</li>
+          <li><code>S</code> - Split clip at playhead (select a track first)</li>
+          <li><code>Cmd/Ctrl+Z</code> - Undo</li>
+          <li><code>Cmd/Ctrl+Shift+Z</code> - Redo</li>
+        </ul>
+
         <div style={{ marginTop: '2rem' }}>
           <LazyFlexibleApiExample />
         </div>

--- a/website/src/pages/examples/multi-clip.tsx
+++ b/website/src/pages/examples/multi-clip.tsx
@@ -52,6 +52,8 @@ export default function MultiClipExamplePage(): React.ReactElement {
             <li><code>Escape</code> - Stop</li>
             <li><code>0</code> - Rewind to start</li>
             <li><code>S</code> - Split clip at playhead (select a track first)</li>
+            <li><code>Cmd/Ctrl+Z</code> - Undo</li>
+            <li><code>Cmd/Ctrl+Shift+Z</code> - Redo</li>
           </ul>
         </div>
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -84,7 +84,8 @@ Both providers use React Context with 4 split contexts for performance.
 - `useExportWav()` — Offline WAV export with effects support
 - `useKeyboardShortcuts(opts)` — Custom keyboard shortcuts
 - `usePlaybackShortcuts(opts)` — Default playback shortcuts (Space, Escape, 0)
-- `KeyboardShortcuts` — Self-closing component for declarative keyboard shortcut setup. Props: `playback` (Space/Escape/0), `clipSplitting` ('s' key), `annotations` (arrow nav, boundary editing), `additionalShortcuts`. All booleans default to false. Reads all required data from context. Replaces manual `usePlaybackShortcuts` + `useClipSplitting` + `useAnnotationKeyboardControls` wiring.
+- `useUndoState(opts)` — Undo/redo state (canUndo, canRedo, undo, redo) with engine delegation
+- `KeyboardShortcuts` — Self-closing component for declarative keyboard shortcut setup. Props: `playback` (Space/Escape/0), `clipSplitting` ('s' key), `annotations` (arrow nav, boundary editing), `undo` (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z), `additionalShortcuts`. All booleans default to false. Reads all required data from context.
 
 ### MIDI Hooks (from `@waveform-playlist/midi`)
 
@@ -117,7 +118,7 @@ Both providers use React Context with 4 split contexts for performance.
 - `MediaElementPlaylistProvider` — Single-track provider (HTMLAudioElement). Multiple instances per page OK (independent audio elements). Props: track, audioContext, playbackRate, timescale, controls, theme, annotationList, onAnnotationsChange, onReady, barWidth, barGap, waveHeight, samplesPerPixel. Track config supports fadeIn/fadeOut (requires audioContext). Use for language learning, podcasts, single-track viewers, and Tone.js effect bridging.
 - `Waveform` — Main visualization. Props: showClipHeaders, interactiveClips, renderPlayhead, renderTrackControls, showFades, touchOptimized
 - `ClipInteractionProvider` — Declarative wrapper for clip drag/move/trim/snap/collision. Props: snap (boolean, auto-detects beats vs timescale from BeatsAndBarsProvider context), touchOptimized. Auto-enables interactiveClips on descendant Waveform. Replaces manual DragDropProvider + useClipDragHandlers + modifier setup. `useClipInteractionEnabled()` hook returns true when inside this provider.
-- `KeyboardShortcuts` — Self-closing component for declarative keyboard shortcut setup. Props: `playback`, `clipSplitting`, `annotations`, `additionalShortcuts`. All booleans default to false. Must be inside WaveformPlaylistProvider.
+- `KeyboardShortcuts` — Self-closing component for declarative keyboard shortcut setup. Props: `playback`, `clipSplitting`, `annotations`, `undo`, `additionalShortcuts`. All booleans default to false. Must be inside WaveformPlaylistProvider.
 - Buttons: PlayButton, PauseButton, StopButton, RewindButton, FastForwardButton, LoopButton, SetLoopRegionButton, ClearAllButton, ZoomInButton, ZoomOutButton, ExportWavButton
 - Controls: MasterVolumeControl, TimeFormatSelect, AudioPosition, SelectionTimeInputs, AutomaticScrollCheckbox, ContinuousPlayCheckbox
 


### PR DESCRIPTION
## Summary

Wire the engine's undo/redo stack into the React browser package with hook, context, keyboard shortcuts, and drag transactions.

## Details

**`useUndoState` hook:**
- `canUndo`, `canRedo` state mirrored from engine via `onEngineState` pattern
- `undo()`, `redo()` delegate to engine
- Same pattern as `useSelectionState`, `useLoopState`, etc.

**`WaveformPlaylistContext`:**
- `canUndo`, `canRedo` added to `PlaylistStateContextValue`
- `undo`, `redo` added to `PlaylistControlsContextValue`
- `onUndoEngineState` wired into statechange handler

**`KeyboardShortcuts` component:**
- New `undo` boolean prop
- Cmd/Ctrl+Z (undo), Cmd/Ctrl+Shift+Z (redo)
- Usage: `<KeyboardShortcuts playback clipSplitting undo />`

**`useClipDragHandlers`:**
- `beginTransaction()` on drag start (both move and trim)
- `commitTransaction()` on successful drop
- `abortTransaction()` on cancelled drag (Escape)

## Test plan

- [x] Browser typecheck clean
- [x] Lint clean (0 errors)
- [x] Manual: move clip → Cmd+Z undoes the move
- [x] Manual: trim clip → Cmd+Z undoes the trim
- [x] Manual: split clip → Cmd+Z un-splits
- [x] Manual: Cmd+Shift+Z redoes
- [x] Manual: Escape during drag → no undo entry created