### PR TITLE
feat(dawcore): replace Tone.js with native AudioContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,7 @@ const LazyExample = createLazyExample(() =>
 25. **Grep Comments When Renaming APIs** — When renaming an option or prop across files (e.g., `progressive` → `immediate`), also grep for the old name in comments. Mechanical find-replace on code misses adjacent comments that describe the old behavior.
 26. **Prefer Props Over Mount/Unmount for Optional Providers** — If a provider controls both data (e.g., snap config) and rendering (e.g., timescale mode), add a mode prop instead of conditionally mounting/unmounting. Unmounting tears down the subtree and loses state; a prop switch is cheaper and keeps context consumers stable.
 27. **Stop Before Clear** — Always call `stop()` before clearing tracks. Clearing React state without stopping Tone.js Transport leaves orphaned audio playing. Use `ClearAllButton` (from `@waveform-playlist/browser`) which handles this automatically via `usePlaylistControls().stop()`.
-28. **Tone.js Panner Stereo Preservation** — `new Panner(pan)` defaults to `channelCount: 1`, downmixing stereo to mono at 1/√2 gain. Use `new Panner({ pan, channelCount: 2 })` for audio tracks with stereo content. MIDI/SoundFont tracks use mono synths so `channelCount: 1` is fine.
+28. **StereoPanner Stereo Preservation** — Both Tone.js `Panner` and native `StereoPannerNode` default to `channelCount: 1`, downmixing stereo to mono at 1/√2 gain. Always set `channelCount: 2` for audio tracks with stereo content.
 29. **Never Use Tone.js `addAudioWorkletModule`** — Tone.js caches a single `_workletPromise` per context. Only the first URL is loaded; subsequent calls with different URLs are silently skipped. Always use `rawContext.audioWorklet.addModule(url)` directly. `context.createAudioWorkletNode()` is still fine for node creation.
 30. **No Manual `external` in tsup Configs** — tsup auto-externalizes `dependencies` and `peerDependencies` (including deep imports like `react/jsx-runtime`). Never add a manual `external` list — it drifts when dependencies change, causing duplicate instances at runtime (#317). All 13 packages use tsup with no `external` field.
 31. **Dynamic Import Tone.js Outside Playout Package** — `import * as Tone from 'tone'` eagerly creates a default context with AudioWorklet nodes, which fails before user gesture. Outside the playout package (which handles init via `getGlobalContext()`), use `import type` for types and `await import('tone')` inside effects after AudioContext is running. Call `Tone.setContext(new Tone.Context(audioContext))` to share the native AudioContext.
@@ -391,8 +391,9 @@ const LazyExample = createLazyExample(() =>
 - **Roadmap & Progress:** `TODO.md`
 - **Architecture Details:** `PROJECT_STRUCTURE.md`
 - **Main branch:** `main`
-- **Current work:** `experimental/native-transport`
+- **Current work:** `main`
 - **Dev server:** `http://localhost:3000/` (Docusaurus)
+- **dawcore uses `@dawcore/transport`** — No Tone.js dependency. Native `AudioContext` for decode, playback, and recording. The `audioContext` property on `<daw-editor>` accepts a consumer-provided context.
 
 ---
 
@@ -408,7 +409,7 @@ Package-specific conventions, architecture, and patterns live in each package's 
 - `packages/annotations/CLAUDE.md` — Integration context, annotation provider pattern
 - `packages/worklets/CLAUDE.md` — AudioWorklet processors (metering, recording)
 - `packages/spectrogram/CLAUDE.md` — Integration context, SpectrogramChannel index
-- `packages/dawcore/CLAUDE.md` — Lit Web Components, element types, CSS theming, engine lifecycle
+- `packages/dawcore/CLAUDE.md` — Lit Web Components, native AudioContext (no Tone.js), element types, CSS theming
 - `packages/transport/CLAUDE.md` — Native Web Audio transport, scheduler, clock, PlayoutAdapter bridge
 - `website/CLAUDE.md` — Docusaurus site, CSS pitfalls, custom pages
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -47,6 +47,7 @@
 - **Worklet loading** — `rawContext.audioWorklet.addModule(recordingProcessorUrl)` (native API, not Tone.js which caches single module).
 - **Recording uses native AudioContext** — `RecordingController` accesses `host.audioContext` directly for `createMediaStreamSource()` and `new AudioWorkletNode()`. No Tone.js wrapper needed.
 - **Worklet requires `start` command** — `recording-processor` defaults `isRecording=false`. Must `port.postMessage({ command: 'start', channelCount })` after connecting source→worklet. Without it, no data flows. Do NOT send `sampleRate` — the worklet uses its global `sampleRate`.
+- **Worklet registration tied to AudioContext identity** — `_workletLoadedCtx` stores the context that had `addModule()` called. If `editor.audioContext` is swapped, the new context needs re-registration. A simple boolean flag goes stale.
 - **Handler ordering critical** — Set `workletNode.port.onmessage` BEFORE `source.connect(workletNode)` and `postMessage({ command: 'start' })`. The worklet can flush data immediately; messages before handler is wired are silently dropped.
 - **Use `createClip()` not `createClipFromSeconds()` for recorded clips** — Recording session provides exact integer samples. The seconds round-trip (`samples/rateA → seconds → Math.round(seconds*rateB)`) drifts when `effectiveSampleRate` differs from `audioBuffer.sampleRate`.
 - **`RecordingHost` must declare all host dependencies** — Any property or method the controller accesses on the host must be on the `RecordingHost` interface. No `as any` casts — the editor satisfies the interface directly. `_addRecordedClip?` is optional (runtime check), `shadowRoot` comes from `HTMLElement` intersection.
@@ -97,6 +98,8 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 **`audioContext` JS property** — Optional `AudioContext` on `<daw-editor>`. When set before tracks load, the editor uses it for decode, playback (via `NativePlayoutAdapter`), and recording. When not set, the editor creates its own `AudioContext({ sampleRate })` lazily on first audio operation.
 
 Example: `editor.audioContext = new AudioContext({ sampleRate: 48000, latencyHint: 0 });`
+
+- **Close owned AudioContext on disconnect** — `disconnectedCallback` calls `_ownedAudioContext.close()`. Skip when consumer provided an external context (they own its lifecycle).
 
 ## Ported Utilities
 

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -1,6 +1,6 @@
 # dawcore Package (`@dawcore/components`)
 
-**Purpose:** Framework-agnostic Web Components for multi-track audio editing. Wraps `PlaylistEngine` + `createToneAdapter()` in Lit elements so any framework (or vanilla HTML) can render waveforms and control playback.
+**Purpose:** Framework-agnostic Web Components for multi-track audio editing. Wraps `PlaylistEngine` + `NativePlayoutAdapter` in Lit elements so any framework (or vanilla HTML) can render waveforms and control playback. No Tone.js dependency — uses native Web Audio exclusively.
 
 **Architecture:** Data elements (`<daw-track>`, `<daw-clip>`) use light DOM; visual elements (`<daw-waveform>`, `<daw-playhead>`, `<daw-ruler>`) use Shadow DOM with chunked canvas rendering. `<daw-editor>` orchestrates everything. Transport elements find their target via `for` attribute.
 
@@ -17,7 +17,7 @@
 
 ## Dev Page Dependencies
 
-- **`pnpm dev:page` resolves peer packages from source** — `dev/vite.config.ts` has `resolve.alias` for core, engine, and playout pointing to `src/index.ts`. Changes are picked up immediately without rebuilding.
+- **`pnpm dev:page` resolves peer packages from source** — `dev/vite.config.ts` has `resolve.alias` for core, engine, and transport pointing to `src/index.ts`. Changes are picked up immediately without rebuilding.
 - **Incremental track removal** — `engine.removeTrack(trackId)` uses `adapter.removeTrack()` when available (disposes single track, preserves playback). Falls back to `adapter.setTracks()` (full rebuild, stops Transport).
 
 ## Element Types
@@ -45,7 +45,7 @@
 - **Cancelable clip creation** — `daw-recording-complete` event is cancelable. `preventDefault()` skips automatic clip creation; consumer handles the `AudioBuffer` themselves.
 - **Channel detection** — `stream.getAudioTracks()[0].getSettings().channelCount`, not `source.channelCount` (defaults to 2 per spec).
 - **Worklet loading** — `rawContext.audioWorklet.addModule(recordingProcessorUrl)` (native API, not Tone.js which caches single module).
-- **Use `getGlobalContext()` not `getGlobalAudioContext()`** — Recording audio graph (source, worklet node) must use Tone.js Context methods (`context.createMediaStreamSource()`, `context.createAudioWorkletNode()`). `getGlobalAudioContext()` returns a `standardized-audio-context` wrapper that fails `instanceof BaseAudioContext` in native constructors. Use `rawContext` only for `audioWorklet.addModule()` and `sampleRate`.
+- **Recording uses native AudioContext** — `RecordingController` accesses `host.audioContext` directly for `createMediaStreamSource()` and `new AudioWorkletNode()`. No Tone.js wrapper needed.
 - **Worklet requires `start` command** — `recording-processor` defaults `isRecording=false`. Must `port.postMessage({ command: 'start', channelCount })` after connecting source→worklet. Without it, no data flows. Do NOT send `sampleRate` — the worklet uses its global `sampleRate`.
 - **Handler ordering critical** — Set `workletNode.port.onmessage` BEFORE `source.connect(workletNode)` and `postMessage({ command: 'start' })`. The worklet can flush data immediately; messages before handler is wired are silently dropped.
 - **Use `createClip()` not `createClipFromSeconds()` for recorded clips** — Recording session provides exact integer samples. The seconds round-trip (`samples/rateA → seconds → Math.round(seconds*rateB)`) drifts when `effectiveSampleRate` differs from `audioBuffer.sampleRate`.
@@ -62,9 +62,9 @@
 ## Key Patterns
 
 - **Event-driven track loading** — `<daw-track>` dispatches `daw-track-connected` (bubbling, composed); `<daw-editor>` listens and loads audio for that track individually. Track removal uses MutationObserver (events from `disconnectedCallback` can't bubble since element is already detached).
-- **Eager audio decode** — Audio fetches and decodes on track connect using `getGlobalAudioContext()` from playout (works while suspended, pre-gesture). Waveforms render immediately without waiting for play.
-- **Engine built lazily on first track load** — `PlaylistEngine` + adapter created when the first `_loadTrack` resolves (uses correct `sampleRate` from decoded audio). `engine.setTracks()` called as tracks load (builds playout structure). `engine.init()` deferred to first `play()` (resumes AudioContext, requires user gesture).
-- **Engine API note** — Initial track loading uses `engine.setTracks()`. Recording clip finalization uses `engine.updateTrack()` for incremental updates. `adapter.addTrack()` throws if no playout exists.
+- **Eager audio decode** — Audio fetches and decodes on track connect using `this.audioContext.decodeAudioData()` (works while suspended, pre-gesture). Waveforms render immediately without waiting for play.
+- **Engine built lazily on first track load** — `PlaylistEngine` + `NativePlayoutAdapter` created when the first `_loadTrack` resolves (uses correct `sampleRate` from decoded audio). `engine.setTracks()` called as tracks load. `engine.init()` deferred to first `play()` (resumes AudioContext, requires user gesture).
+- **Engine API note** — Initial track loading uses `engine.setTracks()`. Recording clip finalization uses `engine.updateTrack()` for incremental updates.
 - **Immutable state updates** — All `@state()` Maps are replaced with `new Map(old).set(...)`, never mutated in place.
 - **Derived width, not stored state** — `_totalWidth` is a getter derived from `_duration`, `effectiveSampleRate`, and `samplesPerPixel`. Not a `@state()` property — avoids Lit update loops from setting state in `updated()`.
 - **Error events** — `daw-track-error` dispatched on load failure (with `{ trackId, error }`). `daw-error` dispatched on playback failure (with `{ operation, error }`). Failed fetch promises are removed from cache to allow retry.
@@ -92,11 +92,11 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 **Lit controller lifecycle gotcha:** `hostConnected()` fires during `connectedCallback()`, BEFORE the first `willUpdate()`. Controllers that read properties set from attributes must defer work with `requestAnimationFrame` (as `ViewportController` and `AudioResumeController` do), otherwise the property will still be `undefined`.
 
-## Pluggable Audio Backend
+## AudioContext Ownership
 
-**`adapterFactory` JS property** — Optional function `() => PlayoutAdapter` on `<daw-editor>`. When set before tracks load, `_buildEngine` uses it instead of `createToneAdapter()`. Enables swapping Tone.js for `NativePlayoutAdapter` or custom backends without modifying dawcore source.
+**`audioContext` JS property** — Optional `AudioContext` on `<daw-editor>`. When set before tracks load, the editor uses it for decode, playback (via `NativePlayoutAdapter`), and recording. When not set, the editor creates its own `AudioContext({ sampleRate })` lazily on first audio operation.
 
-Example: `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);`
+Example: `editor.audioContext = new AudioContext({ sampleRate: 48000, latencyHint: 0 });`
 
 ## Ported Utilities
 
@@ -106,7 +106,7 @@ Example: `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);`
 
 ## Interaction Patterns
 
-- **Seek during playback requires stop+play** — Tone.js `transport.seconds = time` doesn't reschedule audio sources. Must call `engine.stop()` then `engine.play(newTime)` and restart playhead animation.
+- **Seek during playback requires stop+play** — Must call `engine.stop()` then `engine.play(newTime)` and restart playhead animation.
 - **Stop returns to play start position** — Standard DAW behavior. Engine tracks `_playStartPosition`; read `engine.getCurrentTime()` in the `stop` event handler, not `_currentTime`.
 - **Pointer events, not click** — Use `pointerdown`/`pointermove`/`pointerup` with 3px activation threshold to distinguish click (seek) from drag (selection). Wrap `releasePointerCapture` in try-catch; use `finally` to reset `_isDragging`.
 - **No scrollLeft in pointer math** — `:host` has `overflow-x: auto`; `.timeline` is wider. `getBoundingClientRect().left` on `.timeline` already reflects scroll (goes negative when scrolled right), so `clientX - rect.left` gives the correct pixel. Do NOT add `scrollLeft`.
@@ -114,7 +114,7 @@ Example: `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);`
 - **File type detection** — `file.type` can be empty string for valid audio (`.opus` on some browsers). Only reject files with explicitly non-audio MIME types: `if (file.type && !file.type.startsWith('audio/'))`.
 - **`loadFiles()` returns result** — Returns `{ loaded: string[], failed: Array<{ file, error }> }` so callers can detect partial failures. Individual file errors are caught and reported via `daw-files-load-error` events.
 - **sampleRate comes from decoded audio** — Always use `audioBuffer.sampleRate` for clip creation. The global AudioContext decodes at the hardware rate (may be 44100 or 48000). Set `this.sampleRate` from the first decoded buffer so the ruler, peaks, and engine all agree.
-- **Use `getGlobalAudioContext()` for decode** — Import from `@waveform-playlist/playout`. Same context Tone.js uses. `decodeAudioData` works while suspended (pre-gesture). Never create a separate AudioContext for decoding.
+- **Use `this.audioContext` for decode** — The editor's native AudioContext. `decodeAudioData` works while suspended (pre-gesture).
 - **Pointer interactions extracted** — `interactions/pointer-handler.ts` handles pointerdown/move/up, caches timeline ref and rect, distinguishes click vs drag. The host implements `PointerHandlerHost` interface.
 - **Peak pipeline extracted** — `workers/peakPipeline.ts` manages worker lifecycle, WaveformData cache, inflight dedup.
 - **Prevent native drag on interactive elements** — `<daw-editor>` has `@dragover`/`@drop` for file drops, which activates the browser's drag-and-drop system. Clip headers and boundaries need `e.preventDefault()` on `pointerdown` (in pointer-handler delegation), `-webkit-user-drag: none` and `user-select: none` in CSS to prevent the browser from stealing pointer events during custom drag operations.
@@ -123,7 +123,7 @@ Example: `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);`
 
 - **`ClipPointerHandler`** in `interactions/clip-pointer-handler.ts` — handles move/trim drag. `ClipEngineContract` is a narrow interface (`moveClip`, `trimClip`, `updateTrack`). `ClipPointerHost` interface satisfied by `<daw-editor>` via getters.
 - **Hit detection uses `closest()`** — `composedPath()[0]` returns the deepest element (e.g., `<span>` inside `.clip-header`). Always use `target.closest('.clip-header')` / `target.closest('.clip-boundary')` to walk up.
-- **Move: incremental deltas with `skipAdapter`** — `engine.moveClip(id, clipId, delta, true)` skips adapter during drag (60fps). Call `engine.updateTrack(trackId)` once on `pointerup` to sync Tone.js.
+- **Move: incremental deltas with `skipAdapter`** — `engine.moveClip(id, clipId, delta, true)` skips adapter during drag (60fps). Call `engine.updateTrack(trackId)` once on `pointerup` to sync the transport.
 - **Trim: cumulative delta on drop only** — Engine's `constrainBoundaryTrim` checks constraints against current clip state, so incremental deltas compound incorrectly. Accumulate total delta during drag, call `engine.trimClip()` once on `pointerup`.
 - **Trim visual feedback** — Imperatively update `.clip-container` CSS (`left`/`width`) during drag. Restore original CSS before engine applies.
 - **`splitAtPlayhead()`** in `interactions/split-handler.ts` — discovers new clip IDs by diffing `engine.getState().tracks` before/after `engine.splitClip()` (returns void). Requires exactly 2 new IDs.
@@ -139,8 +139,7 @@ Example: `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);`
 - **Undo/redo keyboard shortcuts** — Cmd/Ctrl+Z (undo), Cmd/Ctrl+Shift+Z (redo) when `<daw-keyboard-shortcuts undo>` is present. Auto-expands to both Ctrl and Meta variants when no specific modifier is provided. Uses `=== undefined` checks (not falsy) to distinguish "not specified" from "explicitly false".
 - **Peaks-First Rendering** — When `peaks-src` is set, `_loadTrack` awaits the `.dat` file first (small, fast), creates a clip via `createClipFromSeconds({ waveformData, ... })` (no `audioBuffer`), extracts peaks, and renders a preview track immediately. Audio decode runs in the background; on completion, `clip.audioBuffer` is backfilled and the clip is added to `_clipBuffers`. WaveformData is cached in `PeakPipeline` via `cacheWaveformData(audioBuffer, waveformData)` so all downstream paths (zoom, split/trim) skip the worker. If `.dat` loading fails, falls through to the standard audio-first path. If audio decode fails after peaks render, preview state is cleaned up (peaks, engineTracks, clipOffsets, zoom floor) before dispatching `daw-track-error`. `_peaksCache` (`Map<string, Promise<WaveformData>>`) deduplicates in-flight and repeated fetches for the same `.dat`/`.json` URL, mirroring `_audioCache`. Cleared in `disconnectedCallback`; deleted on rejection to allow retry.
 - **`samplesPerPixel` Zoom Floor via `noAccessor`** — `samplesPerPixel` uses `@property({ noAccessor: true })` with a custom getter/setter that clamps to `_minSamplesPerPixel` synchronously and rejects NaN/Infinity/zero/negative. `_minSamplesPerPixel` lifecycle: set only after successful `extractPeaks` in `_loadTrack` (not before — avoids restricting zoom on failure), recomputed via `_peakPipeline.getMaxCachedScale()` on track removal, reset to 0 on `disconnectedCallback`.
-- **`configureGlobalContext` Race with Eager Resume** — `AudioResumeController` (or any gesture handler) can call `getGlobalContext()` before `_ensureContextConfigured` runs, creating the context without the sample rate hint. `configureGlobalContext` handles this gracefully: warns and returns the existing rate instead of throwing. For reliable sample rate control, avoid `eager-resume` or ensure `configureGlobalContext` runs before any user gesture.
-- **`sample-rate` Attribute for Peaks Matching** — `<daw-editor sample-rate="48000">` passes the rate to `configureGlobalContext({ sampleRate })` in `_ensureContextConfigured`. Cannot force the rate (Tone.js limitation) but warns on mismatch and triggers worker fallback for pre-computed peaks.
+- **`sample-rate` Attribute** — `<daw-editor sample-rate="48000">` creates the native AudioContext at that rate. Warns if the browser doesn't honor the requested rate. Pre-computed `.dat` peaks must match the AudioContext's actual rate.
 
 ## Typed Events
 

--- a/packages/dawcore/COMPONENTS.md
+++ b/packages/dawcore/COMPONENTS.md
@@ -28,7 +28,7 @@ The central orchestrator. Manages the audio engine, loads tracks, renders wavefo
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `adapterFactory` | `() => PlayoutAdapter \| null` | Custom audio backend factory. Set before tracks load. |
+| `audioContext` | `AudioContext \| null` | Custom AudioContext for decode, playback, and recording. Set before tracks load. |
 | `recordingStream` | `MediaStream \| null` | Mic stream for recording. Consumer provides via `getUserMedia`. |
 | `samplesPerPixel` | number | Zoom level (same as attribute, but with validation and clamping) |
 

--- a/packages/dawcore/README.md
+++ b/packages/dawcore/README.md
@@ -13,7 +13,7 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 - **Recording** — Live mic recording with waveform preview (optional)
 - **Pre-computed peaks** — Instant waveform rendering from `.dat` files before audio decodes
 - **CSS theming** — Dark mode by default, fully customizable via CSS custom properties
-- **Pluggable audio backend** — Tone.js (default) or native Web Audio via `@dawcore/transport`
+- **Native Web Audio** — Uses `@dawcore/transport` for playback scheduling. No Tone.js dependency.
 
 ## Installation
 
@@ -23,7 +23,7 @@ npm install @dawcore/components
 
 Peer dependencies:
 ```bash
-npm install @waveform-playlist/core @waveform-playlist/engine @waveform-playlist/playout
+npm install @waveform-playlist/core @waveform-playlist/engine @dawcore/transport
 ```
 
 Optional (for recording):
@@ -150,17 +150,16 @@ editor.addEventListener('daw-clip-split', (e) => console.log('split:', e.detail)
 editor.addEventListener('daw-track-error', (e) => console.error('error:', e.detail));
 ```
 
-## Pluggable Audio Backend
+## Custom AudioContext
 
-By default, `<daw-editor>` uses Tone.js for audio playback. To use the native Web Audio transport instead:
+By default, `<daw-editor>` creates its own `AudioContext` using the `sample-rate` attribute. To provide your own:
 
 ```javascript
-import { NativePlayoutAdapter } from '@dawcore/transport';
-
 const editor = document.getElementById('editor');
-const audioCtx = new AudioContext({ sampleRate: 48000, latencyHint: 0 });
-editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);
+editor.audioContext = new AudioContext({ sampleRate: 48000, latencyHint: 0 });
 ```
+
+Set this before tracks load. The provided context is used for decoding, playback, and recording.
 
 ## API
 

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -131,13 +131,9 @@
   <div id="log"></div>
 
   <script type="module">
-    import { NativePlayoutAdapter } from '@dawcore/transport';
-
     const editor = document.getElementById('editor');
-    // Create AudioContext at 48000 Hz to match .dat peaks, with low latency
-    const audioCtx = new AudioContext({ sampleRate: 48000, latencyHint: 0 });
-    // Use NativePlayoutAdapter instead of TonePlayoutAdapter
-    editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx);
+    // Pass AudioContext at 48000 Hz to match .dat peaks
+    editor.audioContext = new AudioContext({ sampleRate: 48000, latencyHint: 0 });
     const log = document.getElementById('log');
 
     function addLog(msg) {

--- a/packages/dawcore/dev/record.html
+++ b/packages/dawcore/dev/record.html
@@ -99,7 +99,7 @@
     }
 
     const micSelect = document.getElementById('mic-select');
-    const audioConstraints = { echoCancellation: false, noiseSuppression: false, autoGainControl: false };
+    const audioConstraints = { echoCancellation: false, noiseSuppression: false, autoGainControl: false, channelCount: 1 };
 
     function updateMicStatus(stream) {
       const track = stream.getAudioTracks()[0];

--- a/packages/dawcore/dev/record.html
+++ b/packages/dawcore/dev/record.html
@@ -105,11 +105,13 @@
       const track = stream.getAudioTracks()[0];
       const settings = track.getSettings();
       const ctxRate = editor.effectiveSampleRate;
+      // Firefox doesn't report sampleRate in getSettings()
       const micRate = settings.sampleRate;
+      const micRateStr = micRate ? micRate + 'Hz' : 'unknown Hz';
       const ch = settings.channelCount ?? 1;
       const rateNote = micRate && micRate !== ctxRate ? ' (resampling)' : '';
-      micStatus.textContent = ch + 'ch ' + micRate + 'Hz \u2192 ' + ctxRate + 'Hz' + rateNote;
-      addLog('Mic: ' + track.label + ' ' + ch + 'ch ' + micRate + 'Hz, ctx ' + ctxRate + 'Hz' + rateNote);
+      micStatus.textContent = ch + 'ch ' + micRateStr + ' \u2192 ' + ctxRate + 'Hz' + rateNote;
+      addLog('Mic: ' + track.label + ' ' + ch + 'ch ' + micRateStr + ', ctx ' + ctxRate + 'Hz' + rateNote);
     }
 
     async function enumerateDevices() {

--- a/packages/dawcore/dev/record.html
+++ b/packages/dawcore/dev/record.html
@@ -99,19 +99,17 @@
     }
 
     const micSelect = document.getElementById('mic-select');
-    const audioConstraints = { echoCancellation: false, noiseSuppression: false, autoGainControl: false, channelCount: 1 };
+    const audioConstraints = { echoCancellation: false, noiseSuppression: false, autoGainControl: false };
 
     function updateMicStatus(stream) {
       const track = stream.getAudioTracks()[0];
       const settings = track.getSettings();
       const ctxRate = editor.effectiveSampleRate;
-      // Firefox doesn't report sampleRate in getSettings()
       const micRate = settings.sampleRate;
-      const micRateStr = micRate ? micRate + 'Hz' : 'unknown Hz';
       const ch = settings.channelCount ?? 1;
       const rateNote = micRate && micRate !== ctxRate ? ' (resampling)' : '';
-      micStatus.textContent = ch + 'ch ' + micRateStr + ' \u2192 ' + ctxRate + 'Hz' + rateNote;
-      addLog('Mic: ' + track.label + ' ' + ch + 'ch ' + micRateStr + ', ctx ' + ctxRate + 'Hz' + rateNote);
+      micStatus.textContent = ch + 'ch ' + micRate + 'Hz \u2192 ' + ctxRate + 'Hz' + rateNote;
+      addLog('Mic: ' + track.label + ' ' + ch + 'ch ' + micRate + 'Hz, ctx ' + ctxRate + 'Hz' + rateNote);
     }
 
     async function enumerateDevices() {

--- a/packages/dawcore/dev/vite.config.ts
+++ b/packages/dawcore/dev/vite.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
     alias: {
       '@waveform-playlist/core': path.resolve(repoRoot, 'packages/core/src/index.ts'),
       '@waveform-playlist/engine': path.resolve(repoRoot, 'packages/engine/src/index.ts'),
-      '@waveform-playlist/playout': path.resolve(repoRoot, 'packages/playout/src/index.ts'),
       '@dawcore/transport': path.resolve(repoRoot, 'packages/transport/src/index.ts'),
     },
   },

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawcore/components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Web Components for multi-track audio editing — framework-agnostic",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@waveform-playlist/engine": ">=7.0.0",
     "@waveform-playlist/core": ">=7.0.0",
-    "@waveform-playlist/playout": ">=7.0.0",
+    "@dawcore/transport": ">=0.0.1",
     "@waveform-playlist/worklets": ">=7.0.0",
     "@waveform-playlist/recording": ">=7.0.0"
   },
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@waveform-playlist/engine": "workspace:*",
     "@waveform-playlist/core": "workspace:*",
-    "@waveform-playlist/playout": "workspace:*",
+    "@dawcore/transport": "workspace:*",
     "@waveform-playlist/worklets": "workspace:*",
     "@waveform-playlist/recording": "workspace:*",
     "happy-dom": "^17.0.0",

--- a/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
+++ b/packages/dawcore/src/__tests__/audio-resume-controller.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('@waveform-playlist/playout', () => ({
-  resumeGlobalAudioContext: vi.fn(() => Promise.resolve()),
-}));
-
 import { AudioResumeController } from '../controllers/audio-resume-controller';
-import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
 
 let rafCallbacks: Array<(time: number) => void>;
 
-function createMockHost() {
+function createMockAudioContext(state: AudioContextState = 'suspended') {
+  return {
+    state,
+    sampleRate: 48000,
+    resume: vi.fn(() => Promise.resolve()),
+  } as unknown as AudioContext;
+}
+
+function createMockHost(audioContext?: AudioContext) {
+  const ctx = audioContext ?? createMockAudioContext();
   const el = document.createElement('div');
   document.body.appendChild(el);
-  // isConnected is a read-only getter on HTMLElement; add the controller methods directly
   Object.assign(el, {
     addController: vi.fn(),
     requestUpdate: vi.fn(),
     updateComplete: Promise.resolve(true),
+    audioContext: ctx,
   });
   return el as any;
 }
@@ -56,7 +60,7 @@ describe('AudioResumeController', () => {
     expect(addSpy).not.toHaveBeenCalled();
   });
 
-  it('calls resumeGlobalAudioContext on first pointerdown', () => {
+  it('resumes suspended AudioContext on first pointerdown', () => {
     const controller = new AudioResumeController(host);
     controller.target = '';
     controller.hostConnected();
@@ -64,10 +68,10 @@ describe('AudioResumeController', () => {
 
     host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
-    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    expect(host.audioContext.resume).toHaveBeenCalledOnce();
   });
 
-  it('calls resumeGlobalAudioContext on first keydown', () => {
+  it('resumes suspended AudioContext on first keydown', () => {
     const controller = new AudioResumeController(host);
     controller.target = '';
     controller.hostConnected();
@@ -75,10 +79,10 @@ describe('AudioResumeController', () => {
 
     host.dispatchEvent(new Event('keydown', { bubbles: true }));
 
-    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    expect(host.audioContext.resume).toHaveBeenCalledOnce();
   });
 
-  it('only calls resume once (second event is no-op)', () => {
+  it('only resumes once (second event is no-op)', () => {
     const controller = new AudioResumeController(host);
     controller.target = '';
     controller.hostConnected();
@@ -87,7 +91,20 @@ describe('AudioResumeController', () => {
     host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
     host.dispatchEvent(new Event('keydown', { bubbles: true }));
 
-    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    expect(host.audioContext.resume).toHaveBeenCalledOnce();
+  });
+
+  it('skips resume when AudioContext is already running', () => {
+    const ctx = createMockAudioContext('running');
+    host = createMockHost(ctx);
+    const controller = new AudioResumeController(host);
+    controller.target = '';
+    controller.hostConnected();
+    flushRaf();
+
+    host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    expect(ctx.resume).not.toHaveBeenCalled();
   });
 
   it('removes listeners on hostDisconnected before any event fires', () => {
@@ -103,7 +120,7 @@ describe('AudioResumeController', () => {
       ([, , opts]) => (opts as any)?.capture === true
     );
     expect(captureRemovals.length).toBe(2);
-    expect(resumeGlobalAudioContext).not.toHaveBeenCalled();
+    expect(host.audioContext.resume).not.toHaveBeenCalled();
   });
 
   it('attaches to document when target is "document"', () => {
@@ -115,7 +132,7 @@ describe('AudioResumeController', () => {
 
     document.dispatchEvent(new Event('pointerdown'));
 
-    expect(resumeGlobalAudioContext).toHaveBeenCalledOnce();
+    expect(host.audioContext.resume).toHaveBeenCalledOnce();
     docSpy.mockRestore();
   });
 
@@ -158,7 +175,6 @@ describe('AudioResumeController', () => {
     controller.target = '';
     controller.hostConnected();
 
-    // Disconnect before rAF fires
     host.remove();
     flushRaf();
 
@@ -168,9 +184,9 @@ describe('AudioResumeController', () => {
     expect(captureListeners.length).toBe(0);
   });
 
-  it('logs warning when resumeGlobalAudioContext rejects', async () => {
+  it('logs warning when context.resume() rejects', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.mocked(resumeGlobalAudioContext).mockRejectedValueOnce(new Error('Context closed'));
+    host.audioContext.resume.mockRejectedValueOnce(new Error('Context closed'));
 
     const controller = new AudioResumeController(host);
     controller.target = '';
@@ -179,7 +195,6 @@ describe('AudioResumeController', () => {
 
     host.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
-    // Allow microtask to settle
     await new Promise((r) => setTimeout(r, 0));
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('eager resume failed'));
@@ -209,19 +224,14 @@ describe('AudioResumeController', () => {
     const controller = new AudioResumeController(host);
     controller.target = '';
 
-    // First connect schedules rAF-A
     controller.hostConnected();
-    // Disconnect invalidates rAF-A
     controller.hostDisconnected();
-    // Reconnect schedules rAF-B
     controller.hostConnected();
-    // Both rAFs fire — only rAF-B should attach listeners
     flushRaf();
 
     const captureListeners = addSpy.mock.calls.filter(
       ([, , opts]) => (opts as any)?.capture === true
     );
-    // Exactly 2 listeners (pointerdown + keydown), not 4
     expect(captureListeners.length).toBe(2);
   });
 });

--- a/packages/dawcore/src/__tests__/recording-controller.test.ts
+++ b/packages/dawcore/src/__tests__/recording-controller.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
-vi.mock('@waveform-playlist/playout', () => ({
-  getGlobalContext: vi.fn(() => mockToneContext),
-}));
-
 vi.mock('@waveform-playlist/worklets', () => ({
   recordingProcessorUrl: 'blob:mock-recording-processor',
 }));
@@ -15,8 +11,6 @@ vi.mock('@waveform-playlist/recording', () => ({
   createAudioBuffer: vi.fn(() => mockAudioBuffer),
 }));
 
-let mockToneContext: any;
-let mockRawContext: any;
 let mockAudioBuffer: any;
 let mockWorkletNode: any;
 let mockSource: any;
@@ -30,6 +24,17 @@ function createMockHost() {
     addController: vi.fn(),
     requestUpdate: vi.fn(),
     updateComplete: Promise.resolve(true),
+    audioContext: {
+      sampleRate: 48000,
+      outputLatency: 0,
+      state: 'running',
+      resume: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+    },
     samplesPerPixel: 1024,
     effectiveSampleRate: 48000,
     resolveAudioContextSampleRate: vi.fn(),
@@ -75,21 +80,26 @@ describe('RecordingController', () => {
       connect: vi.fn(),
       disconnect: vi.fn(),
     };
-    mockRawContext = {
-      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
-      sampleRate: 48000,
-    };
-    mockToneContext = {
-      rawContext: mockRawContext,
-      createMediaStreamSource: vi.fn(() => mockSource),
-      createAudioWorkletNode: vi.fn(() => mockWorkletNode),
-    };
     mockAudioBuffer = {
       length: 48000,
       sampleRate: 48000,
       numberOfChannels: 1,
     };
+    // Stub AudioWorkletNode constructor (recording-controller uses `new AudioWorkletNode()`)
+    vi.stubGlobal(
+      'AudioWorkletNode',
+      vi.fn(() => mockWorkletNode)
+    );
     host = createMockHost();
+    // Override audioContext with mocks that tests can mutate
+    host.audioContext = {
+      sampleRate: 48000,
+      outputLatency: 0,
+      state: 'running',
+      resume: vi.fn(() => Promise.resolve()),
+      createMediaStreamSource: vi.fn(() => mockSource),
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+    };
   });
 
   afterEach(() => {
@@ -184,7 +194,7 @@ describe('RecordingController', () => {
   });
 
   it('resolves editor sampleRate from AudioContext on start', async () => {
-    mockRawContext.sampleRate = 44100;
+    host.audioContext.sampleRate = 44100;
     const controller = new RecordingController(host);
     await controller.startRecording(createMockStream(), { trackId: 'track-1' });
 
@@ -193,7 +203,7 @@ describe('RecordingController', () => {
 
   it('computes startSample using resolved effectiveSampleRate', async () => {
     // Simulate: host effectiveSampleRate updated by resolveAudioContextSampleRate
-    mockRawContext.sampleRate = 44100;
+    host.audioContext.sampleRate = 44100;
     host._currentTime = 2.0;
     host.effectiveSampleRate = 44100;
     host.resolveAudioContextSampleRate = vi.fn(() => {
@@ -315,7 +325,9 @@ describe('RecordingController', () => {
   });
 
   it('cleans up session on startRecording failure', async () => {
-    mockRawContext.audioWorklet.addModule = vi.fn(() => Promise.reject(new Error('CSP blocked')));
+    host.audioContext.audioWorklet.addModule = vi.fn(() =>
+      Promise.reject(new Error('CSP blocked'))
+    );
     const controller = new RecordingController(host);
     const events: CustomEvent[] = [];
     const origDispatch = host.dispatchEvent.bind(host);
@@ -394,9 +406,8 @@ describe('RecordingController', () => {
   // --- Latency compensation tests ---
 
   it('passes latency offsetSamples to _addRecordedClip', async () => {
-    // Set up latency: outputLatency=0.01s + lookAhead=0.1s = 0.11s
-    mockRawContext.outputLatency = 0.01;
-    mockToneContext.lookAhead = 0.1;
+    // Set up latency: outputLatency=0.01s (no Tone.js lookAhead)
+    host.audioContext.outputLatency = 0.01;
     host._addRecordedClip = vi.fn();
 
     const controller = new RecordingController(host);
@@ -408,21 +419,27 @@ describe('RecordingController', () => {
 
     controller.stopRecording();
 
-    // offsetSamples = floor(0.11 * 48000) = 5280
-    // durationSamples = 48000 - 5280 = 42720
+    // offsetSamples = floor(0.01 * 48000) = 480
+    // durationSamples = 48000 - 480 = 47520
     expect(host._addRecordedClip).toHaveBeenCalledWith(
       'track-1',
       expect.anything(),
       expect.any(Number),
-      42720, // effectiveDuration
-      5280 // latencyOffsetSamples
+      47520, // effectiveDuration
+      480 // latencyOffsetSamples
     );
   });
 
   it('dispatches error when recording too short for latency compensation', async () => {
-    // Latency of 1 second on a 0.5s recording
-    mockRawContext.outputLatency = 0.5;
-    mockToneContext.lookAhead = 0.5;
+    // Latency of 0.5s matches 0.5s recording — no usable samples
+    host.audioContext.outputLatency = 0.5;
+    // Mock createAudioBuffer to return a buffer matching the short recording
+    const { createAudioBuffer } = await import('@waveform-playlist/recording');
+    vi.mocked(createAudioBuffer).mockReturnValueOnce({
+      length: 24000,
+      sampleRate: 48000,
+      numberOfChannels: 1,
+    } as any);
 
     const controller = new RecordingController(host);
     await controller.startRecording(createMockStream(), { trackId: 'track-1' });
@@ -446,8 +463,7 @@ describe('RecordingController', () => {
   });
 
   it('includes offsetSamples in daw-recording-complete event detail', async () => {
-    mockRawContext.outputLatency = 0.02;
-    mockToneContext.lookAhead = 0.1;
+    host.audioContext.outputLatency = 0.02;
 
     const controller = new RecordingController(host);
     await controller.startRecording(createMockStream(), { trackId: 'track-1' });
@@ -464,14 +480,13 @@ describe('RecordingController', () => {
 
     const completeEvent = events.find((e) => e.type === 'daw-recording-complete');
     expect(completeEvent).toBeTruthy();
-    // offsetSamples = floor(0.12 * 48000) = 5760
-    expect(completeEvent!.detail.offsetSamples).toBe(5760);
-    expect(completeEvent!.detail.durationSamples).toBe(48000 - 5760);
+    // offsetSamples = floor(0.02 * 48000) = 960
+    expect(completeEvent!.detail.offsetSamples).toBe(960);
+    expect(completeEvent!.detail.durationSamples).toBe(48000 - 960);
   });
 
   it('zero latency passes offsetSamples=0', async () => {
-    mockRawContext.outputLatency = 0;
-    mockToneContext.lookAhead = 0;
+    host.audioContext.outputLatency = 0;
     host._addRecordedClip = vi.fn();
 
     const controller = new RecordingController(host);

--- a/packages/dawcore/src/__tests__/recording-controller.test.ts
+++ b/packages/dawcore/src/__tests__/recording-controller.test.ts
@@ -118,6 +118,33 @@ describe('RecordingController', () => {
     expect(mockSource.connect).toHaveBeenCalledWith(mockWorkletNode);
   });
 
+  it('creates AudioWorkletNode with correct context, processor, and channel options', async () => {
+    const controller = new RecordingController(host);
+    const stream = createMockStream(2);
+
+    await controller.startRecording(stream, { trackId: 'track-1' });
+
+    expect(AudioWorkletNode).toHaveBeenCalledWith(
+      host.audioContext,
+      'recording-processor',
+      expect.objectContaining({
+        channelCount: 2,
+        channelCountMode: 'explicit',
+      })
+    );
+  });
+
+  it('only calls addModule once across multiple recordings', async () => {
+    const controller = new RecordingController(host);
+
+    await controller.startRecording(createMockStream(), { trackId: 'track-1' });
+    controller.stopRecording();
+    host._selectedTrackId = 'track-2';
+    await controller.startRecording(createMockStream(), { trackId: 'track-2' });
+
+    expect(host.audioContext.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+  });
+
   it('startRecording warns and returns when no trackId', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const controller = new RecordingController(host);

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -61,7 +61,9 @@ export class AudioResumeController implements ReactiveController {
 
   private _onGesture = (e: Event) => {
     const ctx = this._host.audioContext;
-    if (ctx.state === 'suspended') {
+    if (ctx.state === 'closed') {
+      console.warn('[dawcore] AudioResumeController: AudioContext is closed, cannot resume.');
+    } else if (ctx.state === 'suspended') {
       ctx.resume().catch((err) => {
         console.warn(
           '[dawcore] AudioResumeController: eager resume failed, will retry on play: ' + String(err)

--- a/packages/dawcore/src/controllers/audio-resume-controller.ts
+++ b/packages/dawcore/src/controllers/audio-resume-controller.ts
@@ -1,8 +1,12 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
-import { resumeGlobalAudioContext } from '@waveform-playlist/playout';
+
+export interface AudioResumeHost extends ReactiveControllerHost, HTMLElement {
+  /** Returns the AudioContext to resume on user gesture */
+  readonly audioContext: AudioContext;
+}
 
 export class AudioResumeController implements ReactiveController {
-  private _host: ReactiveControllerHost & HTMLElement;
+  private _host: AudioResumeHost;
   private _target: EventTarget | null = null;
   private _attached = false;
   private _generation = 0;
@@ -10,7 +14,7 @@ export class AudioResumeController implements ReactiveController {
   /** CSS selector, or 'document'. When undefined, controller is inert. */
   target?: string;
 
-  constructor(host: ReactiveControllerHost & HTMLElement) {
+  constructor(host: AudioResumeHost) {
     this._host = host;
     host.addController(this);
   }
@@ -56,11 +60,14 @@ export class AudioResumeController implements ReactiveController {
   }
 
   private _onGesture = (e: Event) => {
-    resumeGlobalAudioContext().catch((err) => {
-      console.warn(
-        '[dawcore] AudioResumeController: eager resume failed, will retry on play: ' + String(err)
-      );
-    });
+    const ctx = this._host.audioContext;
+    if (ctx.state === 'suspended') {
+      ctx.resume().catch((err) => {
+        console.warn(
+          '[dawcore] AudioResumeController: eager resume failed, will retry on play: ' + String(err)
+        );
+      });
+    }
     // Remove the other listener (the fired one was auto-removed by { once: true })
     const otherType = e.type === 'pointerdown' ? 'keydown' : 'pointerdown';
     this._target?.removeEventListener(otherType, this._onGesture, {

--- a/packages/dawcore/src/controllers/recording-controller.ts
+++ b/packages/dawcore/src/controllers/recording-controller.ts
@@ -70,7 +70,7 @@ export interface RecordingHost extends ReactiveControllerHost {
 export class RecordingController implements ReactiveController {
   private _host: RecordingHost & HTMLElement;
   private _sessions = new Map<string, RecordingSession>();
-  private _workletLoaded = false;
+  private _workletLoadedCtx: AudioContext | null = null;
 
   constructor(host: RecordingHost & HTMLElement) {
     this._host = host;
@@ -105,16 +105,18 @@ export class RecordingController implements ReactiveController {
     }
 
     const bits: Bits = options.bits ?? 16;
-    const rawCtx = this._host.audioContext;
-
-    // Resolve editor sample rate from AudioContext before computing startSample
-    this._host.resolveAudioContextSampleRate(rawCtx.sampleRate);
 
     try {
-      // Load worklet via native API (not Tone.js addAudioWorkletModule — caches single URL)
-      if (!this._workletLoaded) {
+      const rawCtx = this._host.audioContext;
+
+      // Resolve editor sample rate from AudioContext before computing startSample
+      this._host.resolveAudioContextSampleRate(rawCtx.sampleRate);
+
+      // Load worklet via native API — guard tied to context identity so a
+      // swapped AudioContext gets the module re-registered.
+      if (!this._workletLoadedCtx || this._workletLoadedCtx !== rawCtx) {
         await rawCtx.audioWorklet.addModule(recordingProcessorUrl);
-        this._workletLoaded = true;
+        this._workletLoadedCtx = rawCtx;
       }
 
       // Detect channel count from stream (not source.channelCount — defaults to 2)

--- a/packages/dawcore/src/controllers/recording-controller.ts
+++ b/packages/dawcore/src/controllers/recording-controller.ts
@@ -1,6 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import type { Bits } from '@waveform-playlist/core';
-import { getGlobalContext } from '@waveform-playlist/playout';
 import type { DawWaveformElement } from '../elements/daw-waveform';
 import { recordingProcessorUrl } from '@waveform-playlist/worklets';
 import { appendPeaks, concatenateAudioData, createAudioBuffer } from '@waveform-playlist/recording';
@@ -49,6 +48,7 @@ export type ReadonlyRecordingSession = Readonly<
 
 /** Narrow interface for the host editor. */
 export interface RecordingHost extends ReactiveControllerHost {
+  readonly audioContext: AudioContext;
   readonly samplesPerPixel: number;
   readonly effectiveSampleRate: number;
   readonly _selectedTrackId: string | null;
@@ -105,8 +105,7 @@ export class RecordingController implements ReactiveController {
     }
 
     const bits: Bits = options.bits ?? 16;
-    const context = getGlobalContext();
-    const rawCtx = context.rawContext as AudioContext;
+    const rawCtx = this._host.audioContext;
 
     // Resolve editor sample rate from AudioContext before computing startSample
     this._host.resolveAudioContextSampleRate(rawCtx.sampleRate);
@@ -126,12 +125,11 @@ export class RecordingController implements ReactiveController {
 
       // Compute latency offset once at start (doesn't change during session)
       const outputLatency = rawCtx.outputLatency ?? 0;
-      const lookAhead = context.lookAhead ?? 0;
-      const latencySamples = Math.floor((outputLatency + lookAhead) * rawCtx.sampleRate);
+      const latencySamples = Math.floor(outputLatency * rawCtx.sampleRate);
 
-      // Use Tone.js Context methods — avoids standardized-audio-context identity issues
-      const source = context.createMediaStreamSource(stream);
-      const workletNode = context.createAudioWorkletNode('recording-processor', {
+      // Use native AudioContext methods directly (no Tone.js wrapper)
+      const source = rawCtx.createMediaStreamSource(stream);
+      const workletNode = new AudioWorkletNode(rawCtx, 'recording-processor', {
         channelCount,
         channelCountMode: 'explicit' as globalThis.ChannelCountMode,
       });
@@ -258,8 +256,7 @@ export class RecordingController implements ReactiveController {
       );
       return;
     }
-    const context = getGlobalContext();
-    const stopCtx = context.rawContext as AudioContext;
+    const stopCtx = this._host.audioContext;
     const channelData = session.chunks.map((chunkArr) => concatenateAudioData(chunkArr));
     const audioBuffer = createAudioBuffer(
       stopCtx,

--- a/packages/dawcore/src/controllers/recording-controller.ts
+++ b/packages/dawcore/src/controllers/recording-controller.ts
@@ -83,6 +83,7 @@ export class RecordingController implements ReactiveController {
     for (const trackId of [...this._sessions.keys()]) {
       this._cleanupSession(trackId);
     }
+    this._workletLoadedCtx = null;
   }
 
   get isRecording(): boolean {

--- a/packages/dawcore/src/controllers/recording-controller.ts
+++ b/packages/dawcore/src/controllers/recording-controller.ts
@@ -29,7 +29,7 @@ export interface RecordingSession {
   readonly channelCount: number;
   readonly bits: Bits;
   isFirstMessage: boolean;
-  /** Latency samples to skip in live preview (outputLatency + lookAhead). */
+  /** Latency samples to skip in live preview (outputLatency only). */
   readonly latencySamples: number;
   readonly wasOverdub: boolean;
   /** Stored so it can be removed on stop/cleanup — not just when stream ends. */

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -92,6 +92,16 @@ export class DawEditorElement extends LitElement {
 
   /** Set an AudioContext to use for all audio operations. Must be set before tracks load. */
   set audioContext(ctx: AudioContext | null) {
+    if (ctx && ctx.state === 'closed') {
+      console.warn('[dawcore] Provided AudioContext is already closed. Ignoring.');
+      return;
+    }
+    if (this._engine) {
+      console.warn(
+        '[dawcore] audioContext set after engine is built. ' +
+          'The engine will continue using the previous context.'
+      );
+    }
     this._externalAudioContext = ctx;
   }
 

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -784,7 +784,6 @@ export class DawEditorElement extends LitElement {
   async play(startTime?: number) {
     try {
       const engine = await this._ensureEngine();
-      // Always init — adapter awaits pending rebuild init if needed,
       // Always init — resumes AudioContext if suspended (requires user gesture).
       await engine.init();
       engine.play(startTime);

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -279,6 +279,14 @@ export class DawEditorElement extends LitElement {
     } catch (err) {
       console.warn('[dawcore] Error disposing engine: ' + String(err));
     }
+    // Close owned AudioContext to release hardware resources.
+    // Skip when consumer provided an external context (they own its lifecycle).
+    if (this._ownedAudioContext) {
+      this._ownedAudioContext.close().catch((err) => {
+        console.warn('[dawcore] Error closing AudioContext: ' + String(err));
+      });
+      this._ownedAudioContext = null;
+    }
   }
   willUpdate(changedProperties: Map<string, unknown>) {
     if (changedProperties.has('eagerResume')) {
@@ -777,7 +785,7 @@ export class DawEditorElement extends LitElement {
     try {
       const engine = await this._ensureEngine();
       // Always init — adapter awaits pending rebuild init if needed,
-      // and Tone.start() is a no-op if already running.
+      // Always init — resumes AudioContext if suspended (requires user gesture).
       await engine.init();
       engine.play(startTime);
       this._startPlayhead();
@@ -819,7 +827,7 @@ export class DawEditorElement extends LitElement {
       return;
     }
     if (this._isPlaying) {
-      // Tone.js needs stop+play to reschedule audio sources at new position
+      // Transport needs stop+play to reschedule audio sources at new position
       this.stop();
       this.play(time);
     } else {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -86,8 +86,30 @@ export class DawEditorElement extends LitElement {
   _selectionStartTime = 0;
   _selectionEndTime = 0;
   _currentTime = 0;
-  /** Optional adapter factory. When set, _buildEngine uses this instead of createToneAdapter(). */
-  adapterFactory: (() => import('@waveform-playlist/engine').PlayoutAdapter) | null = null;
+  /** Consumer-provided AudioContext. When set, used for decode, playback, and recording. */
+  private _externalAudioContext: AudioContext | null = null;
+  private _ownedAudioContext: AudioContext | null = null;
+
+  /** Set an AudioContext to use for all audio operations. Must be set before tracks load. */
+  set audioContext(ctx: AudioContext | null) {
+    this._externalAudioContext = ctx;
+  }
+
+  get audioContext(): AudioContext {
+    if (this._externalAudioContext) return this._externalAudioContext;
+    if (!this._ownedAudioContext) {
+      this._ownedAudioContext = new AudioContext({ sampleRate: this.sampleRate });
+      if (this._ownedAudioContext.sampleRate !== this.sampleRate) {
+        console.warn(
+          '[dawcore] Requested sampleRate ' +
+            this.sampleRate +
+            ' but AudioContext is running at ' +
+            this._ownedAudioContext.sampleRate
+        );
+      }
+    }
+    return this._ownedAudioContext;
+  }
   _engine: PlaylistEngine | null = null;
   private _enginePromise: Promise<PlaylistEngine> | null = null;
   _audioCache = new Map<string, Promise<AudioBuffer>>();
@@ -252,7 +274,6 @@ export class DawEditorElement extends LitElement {
     this._clipOffsets.clear();
     this._peakPipeline.terminate();
     this._minSamplesPerPixel = 0;
-    this._contextConfigurePromise = null;
     try {
       this._disposeEngine();
     } catch (err) {
@@ -457,10 +478,7 @@ export class DawEditorElement extends LitElement {
         if (waveformDataPromise) {
           try {
             const wd = await waveformDataPromise;
-            // Ensure context is configured so we can compare rates
-            await this._ensureContextConfigured();
-            const { getGlobalAudioContext } = await import('@waveform-playlist/playout');
-            const contextRate = getGlobalAudioContext().sampleRate;
+            const contextRate = this.audioContext.sampleRate;
             if (wd.sample_rate === contextRate) {
               waveformData = wd;
             } else {
@@ -615,35 +633,6 @@ export class DawEditorElement extends LitElement {
       );
     }
   }
-  private _contextConfigurePromise: Promise<void> | null = null;
-  /**
-   * Ensure the global AudioContext is configured with the editor's sample-rate hint
-   * before the first audio operation. Idempotent — concurrent callers await the
-   * same promise so no one proceeds to getGlobalAudioContext() before configuration.
-   */
-  private _ensureContextConfigured(): Promise<void> {
-    if (!this._contextConfigurePromise) {
-      this._contextConfigurePromise = (async () => {
-        const { configureGlobalContext } = await import('@waveform-playlist/playout');
-        const actualRate = configureGlobalContext({
-          sampleRate: this.sampleRate,
-        });
-        if (actualRate !== this.sampleRate) {
-          console.warn(
-            '[dawcore] Requested sampleRate ' +
-              this.sampleRate +
-              ' but AudioContext is running at ' +
-              actualRate
-          );
-        }
-      })().catch((err) => {
-        // Clear on rejection so next call can retry (same pattern as _enginePromise)
-        this._contextConfigurePromise = null;
-        throw err;
-      });
-    }
-    return this._contextConfigurePromise;
-  }
   async _fetchAndDecode(src: string): Promise<AudioBuffer> {
     if (this._audioCache.has(src)) {
       return this._audioCache.get(src)!;
@@ -656,10 +645,7 @@ export class DawEditorElement extends LitElement {
         );
       }
       const arrayBuffer = await response.arrayBuffer();
-      // Configure context with sample-rate hint before first decode
-      await this._ensureContextConfigured();
-      const { getGlobalAudioContext } = await import('@waveform-playlist/playout');
-      return getGlobalAudioContext().decodeAudioData(arrayBuffer);
+      return this.audioContext.decodeAudioData(arrayBuffer);
     })();
     this._audioCache.set(src, promise);
     try {
@@ -700,20 +686,11 @@ export class DawEditorElement extends LitElement {
     return this._enginePromise;
   }
   private async _buildEngine() {
-    let adapter: import('@waveform-playlist/engine').PlayoutAdapter;
-    let PlaylistEngine: typeof import('@waveform-playlist/engine').PlaylistEngine;
-
-    if (this.adapterFactory) {
-      adapter = this.adapterFactory();
-      ({ PlaylistEngine } = await import('@waveform-playlist/engine'));
-    } else {
-      const [engineMod, playoutMod] = await Promise.all([
-        import('@waveform-playlist/engine'),
-        import('@waveform-playlist/playout'),
-      ]);
-      PlaylistEngine = engineMod.PlaylistEngine;
-      adapter = playoutMod.createToneAdapter();
-    }
+    const [{ PlaylistEngine }, { NativePlayoutAdapter }] = await Promise.all([
+      import('@waveform-playlist/engine'),
+      import('@dawcore/transport'),
+    ]);
+    const adapter = new NativePlayoutAdapter(this.audioContext);
     const engine = new PlaylistEngine({
       adapter,
       sampleRate: this.effectiveSampleRate,

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -130,11 +130,11 @@ The reference library (webaudio-transport) avoids this entirely by not implement
 
 ### dawcore (`<daw-editor>`)
 
-Set `editor.adapterFactory = () => new NativePlayoutAdapter(audioCtx)` before tracks load. The editor uses this factory instead of `createToneAdapter()` when building the engine.
+Set `editor.audioContext = new AudioContext({ sampleRate: 48000 })` before tracks load. The editor uses `NativePlayoutAdapter` internally — no Tone.js dependency.
 
 ### dawcore dev pages
 
-Only `multiclip.html` uses the native transport. `record.html` and `index.html` still use `createToneAdapter()`.
+All dev pages use the native transport. `multiclip.html` passes a custom AudioContext; `index.html` and `record.html` use the editor's default.
 
 ### React (WaveformPlaylistContext)
 

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -91,6 +91,7 @@ Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (requir
 - **No Tone.js in the signal path** — all audio nodes are native Web Audio.
 - **`_activeSources` cleanup** — ClipPlayer uses `ended` event listener for automatic cleanup. MetronomePlayer clicks are short one-shots.
 - **rAF exclusively** — no setTimeout/setInterval anywhere. The lookahead window (200ms) provides sufficient scheduling headroom.
+- **Scheduler lookahead ≠ perceptible latency** — The 200ms lookahead is scheduling headroom only. `source.start(when)` uses precise `AudioContext.currentTime` values, so audio plays at the exact right time. Recording latency compensation only needs `outputLatency`, not `outputLatency + lookahead`.
 
 ## Critical Gotchas
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,15 +176,15 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2
     devDependencies:
+      '@dawcore/transport':
+        specifier: workspace:*
+        version: link:../transport
       '@waveform-playlist/core':
         specifier: workspace:*
         version: link:../core
       '@waveform-playlist/engine':
         specifier: workspace:*
         version: link:../engine
-      '@waveform-playlist/playout':
-        specifier: workspace:*
-        version: link:../playout
       '@waveform-playlist/recording':
         specifier: workspace:*
         version: link:../recording


### PR DESCRIPTION
## Summary

- Drop `@waveform-playlist/playout` peer dependency — dawcore no longer uses Tone.js for anything
- `<daw-editor>` creates/accepts a native `AudioContext` via the new `audioContext` property
- All audio operations (decode, playback, recording) use the native context
- `_buildEngine` always uses `NativePlayoutAdapter` from `@dawcore/transport`
- `AudioResumeController` resumes the host's native context (no `resumeGlobalAudioContext`)
- `RecordingController` uses native `createMediaStreamSource` + `AudioWorkletNode` (no Tone.js wrapper)
- Latency compensation simplified: `outputLatency` only (no Tone.js `lookAhead`)

**Breaking:** Removes `adapterFactory` property (replaced by `audioContext`).

**Usage:**
```html
<daw-editor id="editor" sample-rate="48000"></daw-editor>
<script>
  // Optional: provide your own AudioContext
  editor.audioContext = new AudioContext({ sampleRate: 48000, latencyHint: 0 });
</script>
```

## Test plan

- [x] `cd packages/dawcore && npx vitest run` — 294 tests pass
- [x] `cd packages/dawcore && pnpm build` — clean typecheck + build
- [x] `pnpm lint` — 0 errors
- [ ] Manual: test multiclip dev page (play, pause, stop, seek, split)
- [ ] Manual: test recording dev page