### PR TITLE
feat(transport): branded Tick and Sample types

### DIFF
--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -34,6 +34,10 @@ Sliding window event generation. `advance(currentTime)` expands the window to `c
 
 Drives the scheduler via `requestAnimationFrame` exclusively — never `setTimeout` or `setInterval`. The scheduler's 200ms lookahead absorbs any frame timing jitter.
 
+## Branded Types
+
+`Tick` and `Sample` are branded `number` types in `types.ts` — zero runtime cost, compile-time only. Conversion functions are the canonical producers: `secondsToTicks()` → `Tick`, `secondsToSamples()` → `Sample`. Internal fields stay `number`; casts (`as Tick`) only at API boundaries and in tests for literals. MeterMap methods are not yet branded (deferred — heavy internal arithmetic).
+
 ## Timeline Layer
 
 ### Dual Coordinate System

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -10,6 +10,7 @@ Native Web Audio transport for multi-track audio scheduling, looping, tempo, and
 - **Built-in metronome** — Beat-grid click scheduling with accent on beat 1. Just another scheduler listener.
 - **Per-track signal chain** — Native GainNode (volume) → StereoPannerNode → GainNode (mute) → effects hook → master output.
 - **Effects plugin hook** — `connectTrackOutput(trackId, node)` inserts any `AudioNode` chain (Tone.js effects, WAM plugins, native nodes).
+- **Type-safe coordinates** — Branded `Tick` and `Sample` types prevent accidentally passing seconds where ticks or samples are expected. Zero runtime cost.
 - **PlayoutAdapter bridge** — `NativePlayoutAdapter` implements the `PlayoutAdapter` interface from `@waveform-playlist/engine`.
 
 ## Installation
@@ -145,9 +146,9 @@ new Transport(audioContext: AudioContext, options?: TransportOptions)
 - `setMasterVolume(volume)`
 
 **Loop:**
-- `setLoop(enabled, startTick, endTick)` — Set loop region in ticks (primary API)
+- `setLoop(enabled, startTick: Tick, endTick: Tick)` — Set loop region in ticks (primary API)
 - `setLoopSeconds(enabled, start, end)` — Set loop region in seconds (convenience)
-- `setLoopSamples(enabled, startSample, endSample)` — Set loop region in samples (convenience)
+- `setLoopSamples(enabled, startSample: Sample, endSample: Sample)` — Set loop region in samples (convenience)
 
 **Tempo & Meter:**
 - `setTempo(bpm, atTick?)` / `getTempo(atTick?)`

--- a/packages/transport/TRANSPORT.md
+++ b/packages/transport/TRANSPORT.md
@@ -82,17 +82,22 @@ The scheduler runs 200ms ahead of real-time audio. This means:
 Both `ClipPlayer` and `MetronomePlayer` implement the same interface:
 
 ```typescript
+type Tick = number & { readonly [__tick]: never };   // branded — zero runtime cost
+type Sample = number & { readonly [__sample]: never };
+
 interface SchedulerEvent {
-  tick: number;  // integer tick position on the timeline
+  tick: Tick;  // integer tick position on the timeline
 }
 
 interface SchedulerListener<T extends SchedulerEvent> {
-  generate(fromTick: number, toTick: number): T[];
+  generate(fromTick: Tick, toTick: Tick): T[];
   consume(event: T): void;
-  onPositionJump(newTick: number): void;
+  onPositionJump(newTick: Tick): void;
   silence(): void;
 }
 ```
+
+`Tick` and `Sample` are branded types that prevent accidentally passing seconds where ticks or samples are expected. They are plain `number` at runtime — the brand exists only at compile time. Conversion functions are the canonical producers: `secondsToTicks()` returns `Tick`, `secondsToSamples()` returns `Sample`. Tests use `as Tick` / `as Sample` casts for literal values.
 
 - **`generate()`** — Produce events for a tick window `[fromTick, toTick)`. Called by the scheduler when the window expands. Each listener converts ticks to its native unit internally (MetronomePlayer stays in ticks, ClipPlayer converts to samples).
 - **`consume()`** — Realize an event — create `AudioBufferSourceNode`, connect to audio graph, call `source.start()`. Each listener converts `event.tick` → seconds → audio time internally.
@@ -128,8 +133,8 @@ This conversion happens inside `consume()` — events carry transport time, and 
 
 Audio clips and music events live in different coordinate spaces:
 
-- **SampleTimeline** — Audio clips use absolute sample positions (`startSample`, `durationSamples`). Position does NOT change when tempo changes.
-- **TempoMap** — Converts between ticks and seconds. Supports tempo changes at arbitrary tick positions with cached cumulative seconds for O(log n) lookups.
+- **SampleTimeline** — Audio clips use absolute sample positions (`startSample`, `durationSamples`), typed as `Sample`. Position does NOT change when tempo changes. Also converts between ticks and samples via TempoMap (`ticksToSamples()` / `samplesToTicks()`).
+- **TempoMap** — Converts between ticks and seconds. `secondsToTicks()` returns branded `Tick`; `ticksToSeconds()` accepts `Tick`. Supports tempo changes at arbitrary tick positions with cached cumulative seconds for O(log n) lookups.
 - **MeterMap** — Time signature entries at tick positions. Determines beat unit (from denominator) and bar length (from numerator). See Meter Map section below.
 
 The scheduler works in integer ticks — `advance()` converts Clock seconds → ticks via TempoMap at entry. MetronomePlayer receives ticks directly; ClipPlayer converts ticks to samples via SampleTimeline.

--- a/packages/transport/src/__tests__/clip-player.test.ts
+++ b/packages/transport/src/__tests__/clip-player.test.ts
@@ -4,6 +4,7 @@ import type { ClipTrack, AudioClip } from '@waveform-playlist/core';
 import type { TrackNode } from '../audio/track-node';
 import { SampleTimeline } from '../timeline/sample-timeline';
 import { TempoMap } from '../timeline/tempo-map';
+import type { Sample } from '../types';
 
 // At 120 BPM, 960 PPQN, 48kHz:
 // 0.5s = 960 ticks  = 24000 samples
@@ -249,7 +250,7 @@ describe('ClipPlayer', () => {
     const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
     player.setTracks([track], new Map([['track-1', trackNode]]));
     // setLoopSamples: loop ends at 48000 samples = 1s
-    player.setLoopSamples(true, 0, 48000);
+    player.setLoopSamples(true, 0 as Sample, 48000 as Sample);
 
     // Window [0, 384) ticks = [0, 0.2s)
     const events = player.generate(0, 384);

--- a/packages/transport/src/__tests__/clip-player.test.ts
+++ b/packages/transport/src/__tests__/clip-player.test.ts
@@ -4,7 +4,7 @@ import type { ClipTrack, AudioClip } from '@waveform-playlist/core';
 import type { TrackNode } from '../audio/track-node';
 import { SampleTimeline } from '../timeline/sample-timeline';
 import { TempoMap } from '../timeline/tempo-map';
-import type { Sample } from '../types';
+import type { Tick, Sample } from '../types';
 
 // At 120 BPM, 960 PPQN, 48kHz:
 // 0.5s = 960 ticks  = 24000 samples
@@ -107,7 +107,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // Window [0, 960 ticks) = [0, 0.5s)
-    const events = player.generate(0, 960);
+    const events = player.generate(0 as Tick, 960 as Tick);
     expect(events.length).toBe(1);
     expect(events[0].tick).toBe(0);
     expect(events[0].durationSamples).toBe(48000);
@@ -120,7 +120,7 @@ describe('ClipPlayer', () => {
     const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
-    const events = player.generate(0, 1920);
+    const events = player.generate(0 as Tick, 1920 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -131,7 +131,7 @@ describe('ClipPlayer', () => {
     const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
-    const events = player.generate(0, 1920);
+    const events = player.generate(0 as Tick, 1920 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -141,7 +141,7 @@ describe('ClipPlayer', () => {
     const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
-    const events = player.generate(0, 1920);
+    const events = player.generate(0 as Tick, 1920 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -153,7 +153,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // Window [0, 384 ticks) = [0, 0.2s)
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     expect(events.length).toBe(1);
 
     player.consume(events[0]);
@@ -174,7 +174,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // Window [0, 384 ticks) = [0, 0.2s)
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     player.consume(events[0]);
 
     player.silence();
@@ -195,11 +195,11 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // First consume an event
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     player.consume(events[0]);
 
     // Jump to mid-clip (tick 960 = 0.5s)
-    player.onPositionJump(960);
+    player.onPositionJump(960 as Tick);
     const source = (ctx.createBufferSource as any).mock.results[0].value;
     expect(source.stop).toHaveBeenCalledTimes(1);
 
@@ -218,7 +218,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // Window [1920, 2304) ticks = [1.0s, 1.2s) — after clip ends at 0.5s
-    const events = player.generate(1920, 2304);
+    const events = player.generate(1920 as Tick, 2304 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -234,7 +234,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // Window [960, 1344) ticks = [0.5s, 0.7s) — clip started at 0, already scheduled
-    const events = player.generate(960, 1344);
+    const events = player.generate(960 as Tick, 1344 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -253,7 +253,7 @@ describe('ClipPlayer', () => {
     player.setLoopSamples(true, 0 as Sample, 48000 as Sample);
 
     // Window [0, 384) ticks = [0, 0.2s)
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     expect(events.length).toBe(1);
     // Duration should be clamped to 48000 samples (1s), not full 96000 (2s)
     expect(events[0].durationSamples).toBe(48000);
@@ -271,7 +271,7 @@ describe('ClipPlayer', () => {
     player.setTracks([track], new Map([['track-1', trackNode]]));
 
     // onPositionJump at tick 960 = 0.5s
-    player.onPositionJump(960);
+    player.onPositionJump(960 as Tick);
     // A source should be created for mid-clip playback
     expect((ctx.createBufferSource as any).mock.results.length).toBe(1);
     const source = (ctx.createBufferSource as any).mock.results[0].value;

--- a/packages/transport/src/__tests__/metronome-player.test.ts
+++ b/packages/transport/src/__tests__/metronome-player.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MetronomePlayer } from '../audio/metronome-player';
 import { TempoMap } from '../timeline/tempo-map';
 import { MeterMap } from '../timeline/meter-map';
+import type { Tick } from '../types';
 
 function createMockSource() {
   return {
@@ -51,7 +52,7 @@ describe('MetronomePlayer', () => {
 
     // At 120 BPM, 960 PPQN: 1 beat = 960 ticks = 0.5s
     // generate(0, 2112) covers ticks 0..2111 → beats at 0, 960, 1920
-    const events = player.generate(0, 2112);
+    const events = player.generate(0 as Tick, 2112 as Tick);
     expect(events.length).toBe(3);
     expect(events[0].tick).toBe(0);
     expect(events[1].tick).toBe(960);
@@ -68,7 +69,7 @@ describe('MetronomePlayer', () => {
 
     // At 120 BPM, 4/4: 1 bar = 4 beats = 3840 ticks = 2s
     // generate(0, 4032) covers ticks 0..4031 → beats at 0, 960, 1920, 2880, 3840
-    const events = player.generate(0, 4032);
+    const events = player.generate(0 as Tick, 4032 as Tick);
     expect(events[0].isAccent).toBe(true); // beat 1 of bar 1
     expect(events[1].isAccent).toBe(false); // beat 2
     expect(events[2].isAccent).toBe(false); // beat 3
@@ -81,7 +82,7 @@ describe('MetronomePlayer', () => {
     player.setEnabled(false);
     player.setClickSounds(createMockBuffer(), createMockBuffer());
 
-    const events = player.generate(0, 3840);
+    const events = player.generate(0 as Tick, 3840 as Tick);
     expect(events.length).toBe(0);
   });
 
@@ -91,7 +92,7 @@ describe('MetronomePlayer', () => {
     player.setClickSounds(createMockBuffer(), createMockBuffer());
 
     // 0.2s = 384 ticks at 120 BPM, 960 PPQN
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     expect(events.length).toBe(1);
     player.consume(events[0]);
 
@@ -104,7 +105,7 @@ describe('MetronomePlayer', () => {
     player.setEnabled(true);
     player.setClickSounds(createMockBuffer(), createMockBuffer());
 
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     player.consume(events[0]);
     player.silence();
 
@@ -117,9 +118,9 @@ describe('MetronomePlayer', () => {
     player.setEnabled(true);
     player.setClickSounds(createMockBuffer(), createMockBuffer());
 
-    const events = player.generate(0, 384);
+    const events = player.generate(0 as Tick, 384 as Tick);
     player.consume(events[0]);
-    player.onPositionJump(1920);
+    player.onPositionJump(1920 as Tick);
 
     // Clicks should NOT be stopped on position jump — they finish naturally.
     // Only silence() (stop/pause) kills active sources.
@@ -135,7 +136,7 @@ describe('MetronomePlayer', () => {
 
     // At 120 BPM, 6/8: beat = eighth note = 480 ticks = 0.25s
     // generate(0, 1152) covers 0..1151 → beats at 0, 480, 960
-    const events = player.generate(0, 1152);
+    const events = player.generate(0 as Tick, 1152 as Tick);
     expect(events.length).toBe(3);
     expect(events[0].tick).toBe(0);
     expect(events[1].tick).toBe(480);
@@ -151,7 +152,7 @@ describe('MetronomePlayer', () => {
     // Bar 1 (4/4): beats at 0, 960, 1920, 2880 — accent at 0
     // Bar 2 (3/4): beats at 3840, 4800, 5760 — accent at 3840
     // generate(0, 5952) covers 0..5951
-    const events = player.generate(0, 5952);
+    const events = player.generate(0 as Tick, 5952 as Tick);
     expect(events[0].isAccent).toBe(true); // beat 1 of bar 1
     expect(events[1].isAccent).toBe(false); // beat 2
     expect(events[4].isAccent).toBe(true); // beat 1 of bar 2 (3/4)
@@ -170,7 +171,7 @@ describe('MetronomePlayer', () => {
     // Bar 1 (4/4): quarter-note beats every 960 ticks (0, 960, 1920, 2880)
     // Bar 2 (6/8): eighth-note beats every 480 ticks starting at 3840
     // generate(0, 6720) covers 0..6719
-    const events = player.generate(0, 6720);
+    const events = player.generate(0 as Tick, 6720 as Tick);
 
     // Bar 1: quarter-note beats
     expect(events[0].tick).toBe(0);
@@ -191,7 +192,7 @@ describe('MetronomePlayer', () => {
     // At 120 BPM, 4/4: beats at 0, 960, 1920...
     // 0.3s = 576 ticks — mid-beat, should snap to next beat at 960
     // generate(576, 2112) → beats at 960, 1920
-    const events = player.generate(576, 2112);
+    const events = player.generate(576 as Tick, 2112 as Tick);
     expect(events.length).toBe(2);
     expect(events[0].tick).toBe(960);
     expect(events[1].tick).toBe(1920);
@@ -204,7 +205,7 @@ describe('MetronomePlayer', () => {
 
     // 8 bars of 4/4 at 960 PPQN = 8 * 4 * 960 = 30720 ticks
     // Half-open interval [0, 30720) — tick 30720 (bar 9 beat 1) must NOT be included
-    const events = player.generate(0, 30720);
+    const events = player.generate(0 as Tick, 30720 as Tick);
 
     // 8 bars × 4 beats = 32 total beats
     expect(events.length).toBe(32);

--- a/packages/transport/src/__tests__/sample-timeline.test.ts
+++ b/packages/transport/src/__tests__/sample-timeline.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { SampleTimeline } from '../timeline/sample-timeline';
 import { TempoMap } from '../timeline/tempo-map';
+import type { Tick, Sample } from '../types';
 
 describe('SampleTimeline', () => {
   it('samplesToSeconds converts at given rate', () => {
     const st = new SampleTimeline(48000);
-    expect(st.samplesToSeconds(48000)).toBe(1);
-    expect(st.samplesToSeconds(24000)).toBe(0.5);
-    expect(st.samplesToSeconds(0)).toBe(0);
+    expect(st.samplesToSeconds(48000 as Sample)).toBe(1);
+    expect(st.samplesToSeconds(24000 as Sample)).toBe(0.5);
+    expect(st.samplesToSeconds(0 as Sample)).toBe(0);
   });
 
   it('secondsToSamples converts at given rate', () => {
@@ -20,7 +21,7 @@ describe('SampleTimeline', () => {
   it('round-trips accurately', () => {
     const st = new SampleTimeline(44100);
     const samples = 123456;
-    expect(st.secondsToSamples(st.samplesToSeconds(samples))).toBe(samples);
+    expect(st.secondsToSamples(st.samplesToSeconds(samples as Sample))).toBe(samples);
   });
 
   it('sampleRate getter returns rate', () => {
@@ -35,18 +36,18 @@ describe('SampleTimeline tick conversions', () => {
     const st = new SampleTimeline(48000);
     st.setTempoMap(tempoMap);
     // 960 ticks = 0.5s at 120 BPM = 24000 samples at 48kHz
-    expect(st.ticksToSamples(960)).toBe(24000);
-    expect(st.ticksToSamples(1920)).toBe(48000);
-    expect(st.ticksToSamples(0)).toBe(0);
+    expect(st.ticksToSamples(960 as Tick)).toBe(24000);
+    expect(st.ticksToSamples(1920 as Tick)).toBe(48000);
+    expect(st.ticksToSamples(0 as Tick)).toBe(0);
   });
 
   it('samplesToTicks converts via seconds', () => {
     const tempoMap = new TempoMap(960, 120);
     const st = new SampleTimeline(48000);
     st.setTempoMap(tempoMap);
-    expect(st.samplesToTicks(24000)).toBe(960);
-    expect(st.samplesToTicks(48000)).toBe(1920);
-    expect(st.samplesToTicks(0)).toBe(0);
+    expect(st.samplesToTicks(24000 as Sample)).toBe(960);
+    expect(st.samplesToTicks(48000 as Sample)).toBe(1920);
+    expect(st.samplesToTicks(0 as Sample)).toBe(0);
   });
 
   it('tick-sample round-trip is exact', () => {
@@ -54,11 +55,11 @@ describe('SampleTimeline tick conversions', () => {
     const st = new SampleTimeline(48000);
     st.setTempoMap(tempoMap);
     const ticks = 4800;
-    expect(st.samplesToTicks(st.ticksToSamples(ticks))).toBe(ticks);
+    expect(st.samplesToTicks(st.ticksToSamples(ticks as Tick))).toBe(ticks);
   });
 
   it('ticksToSamples throws if no tempoMap set', () => {
     const st = new SampleTimeline(48000);
-    expect(() => st.ticksToSamples(960)).toThrow();
+    expect(() => st.ticksToSamples(960 as Tick)).toThrow();
   });
 });

--- a/packages/transport/src/__tests__/scheduler.test.ts
+++ b/packages/transport/src/__tests__/scheduler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Scheduler } from '../core/scheduler';
 import { TempoMap } from '../timeline/tempo-map';
-import type { SchedulerEvent, SchedulerListener } from '../types';
+import type { SchedulerEvent, SchedulerListener, Tick } from '../types';
 
 interface TestEvent extends SchedulerEvent {
   id: string;
@@ -29,7 +29,7 @@ function createMockListener(): SchedulerListener<TestEvent> & {
       const step = 480;
       const start = Math.ceil(fromTick / step) * step;
       for (let t = start; t < toTick; t += step) {
-        const event = { tick: t, id: 'e-' + t };
+        const event = { tick: t as Tick, id: 'e-' + t };
         events.push(event);
         state.generated.push(event);
       }
@@ -86,7 +86,7 @@ describe('Scheduler (tick-based)', () => {
     const listener = createMockListener();
     scheduler.addListener(listener);
     // Loop [0, 960) ticks = [0, 0.5s) at 120 BPM
-    scheduler.setLoop(true, 0, 960);
+    scheduler.setLoop(true, 0 as Tick, 960 as Tick);
     scheduler.advance(0.35);
     expect(listener.jumpedTo.length).toBe(1);
     expect(listener.jumpedTo[0]).toBe(0);
@@ -101,7 +101,7 @@ describe('Scheduler (tick-based)', () => {
     const scheduler = createScheduler(0.2);
     const listener = createMockListener();
     scheduler.addListener(listener);
-    scheduler.setLoop(true, 0, 480);
+    scheduler.setLoop(true, 0 as Tick, 480 as Tick);
     for (let i = 0; i < 100; i++) {
       scheduler.advance(i * 0.01);
     }
@@ -114,7 +114,7 @@ describe('Scheduler (tick-based)', () => {
     const scheduler = createScheduler(0.5);
     const listener = createMockListener();
     scheduler.addListener(listener);
-    scheduler.setLoop(true, 0, 480);
+    scheduler.setLoop(true, 0 as Tick, 480 as Tick);
     scheduler.advance(0);
     expect(listener.jumpedTo.length).toBeGreaterThanOrEqual(2);
   });
@@ -122,7 +122,7 @@ describe('Scheduler (tick-based)', () => {
   it('setLoop rejects start >= end', () => {
     const scheduler = createScheduler();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    scheduler.setLoop(true, 960, 480);
+    scheduler.setLoop(true, 960 as Tick, 480 as Tick);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/packages/transport/src/__tests__/tempo-map.test.ts
+++ b/packages/transport/src/__tests__/tempo-map.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { TempoMap } from '../timeline/tempo-map';
+import type { Tick } from '../types';
 
 describe('TempoMap', () => {
   it('single tempo: ticksToSeconds at 120 BPM, 960 PPQN', () => {
     const tm = new TempoMap(960, 120);
     // 1 beat = 960 ticks = 0.5s at 120 BPM
-    expect(tm.ticksToSeconds(960)).toBeCloseTo(0.5);
-    expect(tm.ticksToSeconds(1920)).toBeCloseTo(1.0);
-    expect(tm.ticksToSeconds(0)).toBe(0);
+    expect(tm.ticksToSeconds(960 as Tick)).toBeCloseTo(0.5);
+    expect(tm.ticksToSeconds(1920 as Tick)).toBeCloseTo(1.0);
+    expect(tm.ticksToSeconds(0 as Tick)).toBe(0);
   });
 
   it('single tempo: secondsToTicks', () => {
@@ -19,7 +20,7 @@ describe('TempoMap', () => {
   it('round-trips ticks through seconds', () => {
     const tm = new TempoMap(960, 140);
     const ticks = 4800;
-    expect(tm.secondsToTicks(tm.ticksToSeconds(ticks))).toBe(ticks);
+    expect(tm.secondsToTicks(tm.ticksToSeconds(ticks as Tick))).toBe(ticks);
   });
 
   it('getTempo returns BPM', () => {
@@ -31,7 +32,7 @@ describe('TempoMap', () => {
     const tm = new TempoMap(960, 120);
     tm.setTempo(60);
     // 1 beat = 960 ticks = 1.0s at 60 BPM
-    expect(tm.ticksToSeconds(960)).toBeCloseTo(1.0);
+    expect(tm.ticksToSeconds(960 as Tick)).toBeCloseTo(1.0);
   });
 
   it('multiple tempos: second region uses new tempo', () => {
@@ -39,9 +40,9 @@ describe('TempoMap', () => {
     // At tick 1920 (1s at 120BPM), switch to 60 BPM
     tm.setTempo(60, 1920);
     // First 1920 ticks at 120 BPM = 1.0s
-    expect(tm.ticksToSeconds(1920)).toBeCloseTo(1.0);
+    expect(tm.ticksToSeconds(1920 as Tick)).toBeCloseTo(1.0);
     // Next 960 ticks at 60 BPM = 1.0s (total: 2.0s)
-    expect(tm.ticksToSeconds(2880)).toBeCloseTo(2.0);
+    expect(tm.ticksToSeconds(2880 as Tick)).toBeCloseTo(2.0);
   });
 
   it('secondsToTicks with multiple tempos', () => {

--- a/packages/transport/src/__tests__/transport-loop.test.ts
+++ b/packages/transport/src/__tests__/transport-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Transport } from '../transport';
+import type { Tick, Sample } from '../types';
 
 function createMockAudioContext() {
   return {
@@ -32,7 +33,7 @@ describe('Transport loop APIs', () => {
   it('setLoop accepts ticks as primary API', () => {
     const ctx = createMockAudioContext();
     const transport = new Transport(ctx);
-    expect(() => transport.setLoop(true, 0, 3840)).not.toThrow();
+    expect(() => transport.setLoop(true, 0 as Tick, 3840 as Tick)).not.toThrow();
   });
 
   it('setLoopSeconds converts seconds to ticks', () => {
@@ -44,6 +45,6 @@ describe('Transport loop APIs', () => {
   it('setLoopSamples converts samples to ticks', () => {
     const ctx = createMockAudioContext();
     const transport = new Transport(ctx);
-    expect(() => transport.setLoopSamples(true, 0, 96000)).not.toThrow();
+    expect(() => transport.setLoopSamples(true, 0 as Sample, 96000 as Sample)).not.toThrow();
   });
 });

--- a/packages/transport/src/audio/clip-player.ts
+++ b/packages/transport/src/audio/clip-player.ts
@@ -77,11 +77,11 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
     this._silenceTrack(trackId);
   }
 
-  generate(fromTick: number, toTick: number): ClipEvent[] {
+  generate(fromTick: Tick, toTick: Tick): ClipEvent[] {
     const events: ClipEvent[] = [];
 
-    const fromSample = this._sampleTimeline.ticksToSamples(fromTick as Tick);
-    const toSample = this._sampleTimeline.ticksToSamples(toTick as Tick);
+    const fromSample = this._sampleTimeline.ticksToSamples(fromTick);
+    const toSample = this._sampleTimeline.ticksToSamples(toTick);
 
     for (const [trackId, state] of this._tracks) {
       for (const clip of state.clips) {
@@ -210,10 +210,10 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
     source.start(when, offsetSeconds, durationSeconds);
   }
 
-  onPositionJump(newTick: number): void {
+  onPositionJump(newTick: Tick): void {
     this.silence();
 
-    const newSample = this._sampleTimeline.ticksToSamples(newTick as Tick);
+    const newSample = this._sampleTimeline.ticksToSamples(newTick);
 
     // Re-schedule mid-clip sources for clips that span the new position
     for (const [trackId, state] of this._tracks) {

--- a/packages/transport/src/audio/clip-player.ts
+++ b/packages/transport/src/audio/clip-player.ts
@@ -1,5 +1,5 @@
 import type { ClipTrack, AudioClip } from '@waveform-playlist/core';
-import type { SchedulerEvent, SchedulerListener } from '../types';
+import type { Tick, Sample, SchedulerEvent, SchedulerListener } from '../types';
 import type { SampleTimeline } from '../timeline/sample-timeline';
 import type { TempoMap } from '../timeline/tempo-map';
 import type { TrackNode } from './track-node';
@@ -9,17 +9,17 @@ export interface ClipEvent extends SchedulerEvent {
   clipId: string;
   audioBuffer: AudioBuffer;
   /** Clip position on timeline (integer samples) */
-  startSample: number;
+  startSample: Sample;
   /** Offset into audioBuffer (integer samples) */
-  offsetSamples: number;
+  offsetSamples: Sample;
   /** Duration to play (integer samples) */
-  durationSamples: number;
+  durationSamples: Sample;
   /** Clip gain multiplier */
   gain: number;
   /** Fade in duration (integer samples) */
-  fadeInDurationSamples: number;
+  fadeInDurationSamples: Sample;
   /** Fade out duration (integer samples) */
-  fadeOutDurationSamples: number;
+  fadeOutDurationSamples: Sample;
 }
 
 interface TrackClipState {
@@ -61,13 +61,13 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
 
   /** Set loop region using ticks. startTick is unused — loop clamping only needs
    *  the end boundary; mid-clip restart at loopStart is handled by onPositionJump. */
-  setLoop(enabled: boolean, _startTick: number, endTick: number): void {
+  setLoop(enabled: boolean, _startTick: Tick, endTick: Tick): void {
     this._loopEnabled = enabled;
     this._loopEndSamples = this._sampleTimeline.ticksToSamples(endTick);
   }
 
   /** Set loop region using samples directly */
-  setLoopSamples(enabled: boolean, _startSample: number, endSample: number): void {
+  setLoopSamples(enabled: boolean, _startSample: Sample, endSample: Sample): void {
     this._loopEnabled = enabled;
     this._loopEndSamples = endSample;
   }
@@ -80,8 +80,8 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
   generate(fromTick: number, toTick: number): ClipEvent[] {
     const events: ClipEvent[] = [];
 
-    const fromSample = this._sampleTimeline.ticksToSamples(fromTick);
-    const toSample = this._sampleTimeline.ticksToSamples(toTick);
+    const fromSample = this._sampleTimeline.ticksToSamples(fromTick as Tick);
+    const toSample = this._sampleTimeline.ticksToSamples(toTick as Tick);
 
     for (const [trackId, state] of this._tracks) {
       for (const clip of state.clips) {
@@ -107,19 +107,19 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
           durationSamples = this._loopEndSamples - clipStartSample;
         }
 
-        const clipTick = this._sampleTimeline.samplesToTicks(clipStartSample);
+        const clipTick = this._sampleTimeline.samplesToTicks(clipStartSample as Sample);
 
         events.push({
           trackId,
           clipId: clip.id,
           audioBuffer: clip.audioBuffer,
           tick: clipTick,
-          startSample: clipStartSample,
-          offsetSamples: clip.offsetSamples,
-          durationSamples,
+          startSample: clipStartSample as Sample,
+          offsetSamples: clip.offsetSamples as Sample,
+          durationSamples: durationSamples as Sample,
           gain: clip.gain,
-          fadeInDurationSamples,
-          fadeOutDurationSamples,
+          fadeInDurationSamples: fadeInDurationSamples as Sample,
+          fadeOutDurationSamples: fadeOutDurationSamples as Sample,
         });
       }
     }
@@ -213,7 +213,7 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
   onPositionJump(newTick: number): void {
     this.silence();
 
-    const newSample = this._sampleTimeline.ticksToSamples(newTick);
+    const newSample = this._sampleTimeline.ticksToSamples(newTick as Tick);
 
     // Re-schedule mid-clip sources for clips that span the new position
     for (const [trackId, state] of this._tracks) {
@@ -242,13 +242,13 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
             trackId,
             clipId: clip.id,
             audioBuffer: clip.audioBuffer,
-            tick: newTick,
-            startSample: newSample,
-            offsetSamples,
-            durationSamples,
+            tick: newTick as Tick,
+            startSample: newSample as Sample,
+            offsetSamples: offsetSamples as Sample,
+            durationSamples: durationSamples as Sample,
             gain: clip.gain,
-            fadeInDurationSamples: 0,
-            fadeOutDurationSamples,
+            fadeInDurationSamples: 0 as Sample,
+            fadeOutDurationSamples: fadeOutDurationSamples as Sample,
           });
         }
       }

--- a/packages/transport/src/audio/metronome-player.ts
+++ b/packages/transport/src/audio/metronome-player.ts
@@ -44,7 +44,7 @@ export class MetronomePlayer implements SchedulerListener<MetronomeEvent> {
     this._normalBuffer = normal;
   }
 
-  generate(fromTick: number, toTick: number): MetronomeEvent[] {
+  generate(fromTick: Tick, toTick: Tick): MetronomeEvent[] {
     if (!this._enabled || !this._accentBuffer || !this._normalBuffer) {
       return [];
     }
@@ -102,7 +102,7 @@ export class MetronomePlayer implements SchedulerListener<MetronomeEvent> {
     source.start(this._toAudioTime(transportTime));
   }
 
-  onPositionJump(_newTick: number): void {
+  onPositionJump(_newTick: Tick): void {
     // Don't silence — clicks are short one-shots that finish naturally.
     // Calling silence() here kills clicks scheduled in the lookahead window
     // that haven't played yet, causing the last beat before a loop wrap

--- a/packages/transport/src/audio/metronome-player.ts
+++ b/packages/transport/src/audio/metronome-player.ts
@@ -1,4 +1,4 @@
-import type { SchedulerEvent, SchedulerListener } from '../types';
+import type { Tick, SchedulerEvent, SchedulerListener } from '../types';
 import type { TempoMap } from '../timeline/tempo-map';
 import { MeterMap } from '../timeline/meter-map';
 
@@ -68,7 +68,7 @@ export class MetronomePlayer implements SchedulerListener<MetronomeEvent> {
       const isAccent = this._meterMap.isBarBoundary(tick);
 
       events.push({
-        tick,
+        tick: tick as Tick,
         isAccent,
         buffer: isAccent ? this._accentBuffer : this._normalBuffer,
       });

--- a/packages/transport/src/core/scheduler.ts
+++ b/packages/transport/src/core/scheduler.ts
@@ -1,4 +1,4 @@
-import type { SchedulerEvent, SchedulerListener } from '../types';
+import type { Tick, SchedulerEvent, SchedulerListener } from '../types';
 import type { TempoMap } from '../timeline/tempo-map';
 
 export interface SchedulerOptions {
@@ -37,7 +37,7 @@ export class Scheduler<T extends SchedulerEvent> {
   }
 
   /** Primary API — ticks as source of truth */
-  setLoop(enabled: boolean, startTick: number, endTick: number): void {
+  setLoop(enabled: boolean, startTick: Tick, endTick: Tick): void {
     if (enabled && (!Number.isFinite(startTick) || !Number.isFinite(endTick))) {
       console.warn(
         '[waveform-playlist] Scheduler.setLoop: non-finite tick values (' +
@@ -95,13 +95,13 @@ export class Scheduler<T extends SchedulerEvent> {
         remaining -= distToEnd;
         // Notify listeners of position jump (in ticks)
         for (const listener of this._listeners) {
-          listener.onPositionJump(this._loopStart);
+          listener.onPositionJump(this._loopStart as Tick);
         }
         // Seek clock — passes the currentTimeSeconds snapshot so Transport
         // uses the same clock reading as advance(), not a live re-read.
         this._onLoop?.(
-          this._tempoMap.ticksToSeconds(this._loopStart),
-          this._tempoMap.ticksToSeconds(this._loopEnd),
+          this._tempoMap.ticksToSeconds(this._loopStart as Tick),
+          this._tempoMap.ticksToSeconds(this._loopEnd as Tick),
           currentTimeSeconds
         );
         this._rightEdge = this._loopStart;
@@ -121,7 +121,7 @@ export class Scheduler<T extends SchedulerEvent> {
   private _generateAndConsume(fromTick: number, toTick: number): void {
     for (const listener of this._listeners) {
       try {
-        const events = listener.generate(fromTick, toTick);
+        const events = listener.generate(fromTick as Tick, toTick as Tick);
         for (const event of events) {
           try {
             listener.consume(event);

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,5 +1,7 @@
 // packages/transport/src/index.ts
 export type {
+  Tick,
+  Sample,
   SchedulerEvent,
   SchedulerListener,
   TransportOptions,

--- a/packages/transport/src/timeline/meter-map.ts
+++ b/packages/transport/src/timeline/meter-map.ts
@@ -1,8 +1,8 @@
 // packages/transport/src/timeline/meter-map.ts
-import type { MeterEntry, MeterSignature } from '../types';
+import type { Tick, MeterEntry, MeterSignature } from '../types';
 
 interface MutableMeterEntry {
-  tick: number;
+  tick: Tick;
   numerator: number;
   denominator: number;
   barAtTick: number;
@@ -18,7 +18,7 @@ export class MeterMap {
 
   constructor(ppqn: number, numerator: number = 4, denominator: number = 4) {
     this._ppqn = ppqn;
-    this._entries = [{ tick: 0, numerator, denominator, barAtTick: 0 }];
+    this._entries = [{ tick: 0 as Tick, numerator, denominator, barAtTick: 0 }];
   }
 
   get ppqn(): number {
@@ -63,7 +63,7 @@ export class MeterMap {
       this._entries[i] = { ...this._entries[i], numerator, denominator };
     } else {
       const barAtTick = this._computeBarAtTick(snapped);
-      this._entries.splice(i + 1, 0, { tick: snapped, numerator, denominator, barAtTick });
+      this._entries.splice(i + 1, 0, { tick: snapped as Tick, numerator, denominator, barAtTick });
       i = i + 1;
     }
     this._resnapDownstreamEntries(i);
@@ -198,7 +198,7 @@ export class MeterMap {
             snapped +
             ' (bar boundary alignment)'
         );
-        this._entries[i] = { ...this._entries[i], tick: snapped };
+        this._entries[i] = { ...this._entries[i], tick: snapped as Tick };
       }
     }
   }

--- a/packages/transport/src/timeline/sample-timeline.ts
+++ b/packages/transport/src/timeline/sample-timeline.ts
@@ -1,3 +1,4 @@
+import type { Tick, Sample } from '../types';
 import type { TempoMap } from './tempo-map';
 
 export class SampleTimeline {
@@ -16,24 +17,24 @@ export class SampleTimeline {
     this._tempoMap = tempoMap;
   }
 
-  samplesToSeconds(samples: number): number {
+  samplesToSeconds(samples: Sample): number {
     return samples / this._sampleRate;
   }
 
-  secondsToSamples(seconds: number): number {
-    return Math.round(seconds * this._sampleRate);
+  secondsToSamples(seconds: number): Sample {
+    return Math.round(seconds * this._sampleRate) as Sample;
   }
 
-  ticksToSamples(ticks: number): number {
+  ticksToSamples(ticks: Tick): Sample {
     if (!this._tempoMap) {
       throw new Error(
         '[waveform-playlist] SampleTimeline: tempoMap not set — call setTempoMap() first'
       );
     }
-    return Math.round(this._tempoMap.ticksToSeconds(ticks) * this._sampleRate);
+    return Math.round(this._tempoMap.ticksToSeconds(ticks) * this._sampleRate) as Sample;
   }
 
-  samplesToTicks(samples: number): number {
+  samplesToTicks(samples: Sample): Tick {
     if (!this._tempoMap) {
       throw new Error(
         '[waveform-playlist] SampleTimeline: tempoMap not set — call setTempoMap() first'

--- a/packages/transport/src/timeline/tempo-map.ts
+++ b/packages/transport/src/timeline/tempo-map.ts
@@ -1,8 +1,8 @@
-import type { TempoEntry } from '../types';
+import type { Tick, TempoEntry } from '../types';
 
 /** Mutable internal version of TempoEntry (exported interface has readonly secondsAtTick) */
 interface MutableTempoEntry {
-  tick: number;
+  tick: Tick;
   bpm: number;
   secondsAtTick: number;
 }
@@ -13,7 +13,7 @@ export class TempoMap {
 
   constructor(ppqn: number = 960, initialBpm: number = 120) {
     this._ppqn = ppqn;
-    this._entries = [{ tick: 0, bpm: initialBpm, secondsAtTick: 0 }];
+    this._entries = [{ tick: 0 as Tick, bpm: initialBpm, secondsAtTick: 0 }];
   }
 
   getTempo(atTick: number = 0): number {
@@ -35,17 +35,17 @@ export class TempoMap {
       this._entries[i] = { ...this._entries[i], bpm };
     } else {
       const secondsAtTick = this._ticksToSecondsInternal(atTick);
-      this._entries.splice(i + 1, 0, { tick: atTick, bpm, secondsAtTick });
+      this._entries.splice(i + 1, 0, { tick: atTick as Tick, bpm, secondsAtTick });
       i = i + 1;
     }
     this._recomputeCache(i);
   }
 
-  ticksToSeconds(ticks: number): number {
+  ticksToSeconds(ticks: Tick): number {
     return this._ticksToSecondsInternal(ticks);
   }
 
-  secondsToTicks(seconds: number): number {
+  secondsToTicks(seconds: number): Tick {
     let lo = 0;
     let hi = this._entries.length - 1;
     while (lo < hi) {
@@ -59,11 +59,11 @@ export class TempoMap {
     const entry = this._entries[lo];
     const secondsIntoSegment = seconds - entry.secondsAtTick;
     const ticksPerSecond = (entry.bpm / 60) * this._ppqn;
-    return Math.round(entry.tick + secondsIntoSegment * ticksPerSecond);
+    return Math.round(entry.tick + secondsIntoSegment * ticksPerSecond) as Tick;
   }
 
   beatsToSeconds(beats: number): number {
-    return this.ticksToSeconds(beats * this._ppqn);
+    return this.ticksToSeconds((beats * this._ppqn) as Tick);
   }
 
   secondsToBeats(seconds: number): number {
@@ -72,7 +72,7 @@ export class TempoMap {
 
   clearTempos(): void {
     const first = this._entries[0];
-    this._entries = [{ tick: 0, bpm: first.bpm, secondsAtTick: 0 }];
+    this._entries = [{ tick: 0 as Tick, bpm: first.bpm, secondsAtTick: 0 }];
   }
 
   private _ticksToSecondsInternal(ticks: number): number {

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -1,5 +1,5 @@
 import type { ClipTrack } from '@waveform-playlist/core';
-import type { TransportOptions, MeterSignature } from './types';
+import type { Tick, Sample, TransportOptions, MeterSignature } from './types';
 import { Clock } from './core/clock';
 import { Scheduler } from './core/scheduler';
 import { Timer } from './core/timer';
@@ -319,7 +319,7 @@ export class Transport {
   // --- Loop ---
 
   /** Primary loop API — ticks as source of truth */
-  setLoop(enabled: boolean, startTick: number, endTick: number): void {
+  setLoop(enabled: boolean, startTick: Tick, endTick: Tick): void {
     if (enabled && startTick >= endTick) {
       console.warn(
         '[waveform-playlist] Transport.setLoop: startTick (' +
@@ -345,7 +345,7 @@ export class Transport {
   }
 
   /** Convenience — sets loop in samples */
-  setLoopSamples(enabled: boolean, startSample: number, endSample: number): void {
+  setLoopSamples(enabled: boolean, startSample: Sample, endSample: Sample): void {
     if (enabled && (!Number.isFinite(startSample) || !Number.isFinite(endSample))) {
       console.warn(
         '[waveform-playlist] Transport.setLoopSamples: non-finite sample values (' +
@@ -427,7 +427,7 @@ export class Transport {
 
   /** Convert tick position to transport time (seconds), using the tempo map. */
   tickToTime(tick: number): number {
-    return this._tempoMap.ticksToSeconds(tick);
+    return this._tempoMap.ticksToSeconds(tick as Tick);
   }
 
   // --- Metronome ---

--- a/packages/transport/src/types.ts
+++ b/packages/transport/src/types.ts
@@ -1,17 +1,25 @@
+/** Branded type for tick positions — prevents accidentally passing seconds where ticks are expected. */
+declare const __tick: unique symbol;
+export type Tick = number & { readonly [__tick]: never };
+
+/** Branded type for sample counts — prevents accidentally passing seconds where samples are expected. */
+declare const __sample: unique symbol;
+export type Sample = number & { readonly [__sample]: never };
+
 export interface SchedulerEvent {
   /** Tick position (integer) on the timeline */
-  tick: number;
+  tick: Tick;
 }
 
 export interface SchedulerListener<T extends SchedulerEvent> {
   /** Generate events in the tick window [fromTick, toTick) */
-  generate(fromTick: number, toTick: number): T[];
+  generate(fromTick: Tick, toTick: Tick): T[];
   /** Realize an event (create audio nodes, start sources) */
   consume(event: T): void;
   /** Position jumped (loop/seek) — listeners may stop and re-schedule as appropriate
    *  (ClipPlayer stops sources and creates mid-clip restarts; MetronomePlayer is a no-op
    *  since clicks are short one-shots that finish naturally) */
-  onPositionJump(newTick: number): void;
+  onPositionJump(newTick: Tick): void;
   /** Stop all active audio immediately */
   silence(): void;
 }
@@ -40,7 +48,7 @@ export interface MeterSignature {
 /** Storage entry for MeterMap */
 export interface MeterEntry {
   /** Tick position where this meter starts */
-  tick: number;
+  tick: Tick;
   /** Time signature numerator (e.g., 6 in 6/8) */
   numerator: number;
   /** Time signature denominator (e.g., 8 in 6/8) */
@@ -51,7 +59,7 @@ export interface MeterEntry {
 
 export interface TempoEntry {
   /** Tick position where this tempo starts */
-  tick: number;
+  tick: Tick;
   /** Beats per minute */
   bpm: number;
   /** Cached cumulative seconds up to this tick (for O(log n) lookup). Derived — do not set manually. */
@@ -65,5 +73,5 @@ export interface TransportPosition {
   beat: number;
   /** Sub-beat tick remainder (0 to ppqn-1). Named subTick to avoid
    *  collision with SchedulerEvent.tick (absolute timeline position). */
-  subTick: number;
+  subTick: Tick;
 }

--- a/packages/transport/src/types.ts
+++ b/packages/transport/src/types.ts
@@ -72,6 +72,7 @@ export interface TransportPosition {
   /** 1-indexed beat within bar */
   beat: number;
   /** Sub-beat tick remainder (0 to ppqn-1). Named subTick to avoid
-   *  collision with SchedulerEvent.tick (absolute timeline position). */
-  subTick: Tick;
+   *  collision with SchedulerEvent.tick (absolute timeline position).
+   *  Not branded Tick — a remainder within a beat, not an absolute position. */
+  subTick: number;
 }


### PR DESCRIPTION
## Summary

- Adds zero-runtime-cost branded types `Tick` and `Sample` to `@dawcore/transport`
- Prevents accidentally passing seconds where ticks are expected (and vice versa for samples) at compile time
- Applied to public API signatures, conversion function returns, and entry types
- Internal fields stay `number` — casts only at API boundaries
- MeterMap methods deferred to follow-up (heavy internal arithmetic)

## Test plan

- [x] Typecheck clean (zero errors)
- [x] 144 unit tests pass
- [x] Build clean
- [x] Lint clean (0 errors)
- [x] No runtime behavior changes — types only

🤖 Generated with [Claude Code](https://claude.com/claude-code)