### PR TITLE
feat(transport): branded Tick type for MeterMap methods

### DIFF
--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -36,7 +36,7 @@ Drives the scheduler via `requestAnimationFrame` exclusively — never `setTimeo
 
 ## Branded Types
 
-`Tick` and `Sample` are branded `number` types in `types.ts` — zero runtime cost, compile-time only. Conversion functions are the canonical producers: `secondsToTicks()` → `Tick`, `secondsToSamples()` → `Sample`. Internal fields stay `number`; casts (`as Tick`) only at API boundaries and in tests for literals. MeterMap methods are not yet branded (deferred — heavy internal arithmetic).
+`Tick` and `Sample` are branded `number` types in `types.ts` — zero runtime cost, compile-time only. Conversion functions are the canonical producers: `secondsToTicks()` → `Tick`, `secondsToSamples()` → `Sample`. Internal fields stay `number`; casts (`as Tick`) only at API boundaries and in tests for literals. MeterMap public methods accept/return `Tick`. Internal arithmetic stays `number` with `as Tick` at return points.
 
 ## Timeline Layer
 

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -153,9 +153,10 @@ new Transport(audioContext: AudioContext, options?: TransportOptions)
 **Tempo & Meter:**
 - `setTempo(bpm, atTick?)` / `getTempo(atTick?)`
 - `clearTempos()` — remove all tempo entries
-- `setMeter(numerator, denominator, atTick?)` / `getMeter(atTick?)`
-- `removeMeter(atTick)` / `clearMeters()`
-- `barToTick(bar)` / `tickToBar(tick)`
+- `setMeter(numerator, denominator, atTick?: Tick)` / `getMeter(atTick?: Tick)`
+- `removeMeter(atTick: Tick)` / `clearMeters()`
+- `barToTick(bar): Tick` / `tickToBar(tick: Tick)`
+- `timeToTick(seconds): Tick` / `tickToTime(tick: Tick)`
 
 **Metronome:**
 - `setMetronomeEnabled(enabled)`

--- a/packages/transport/src/__tests__/meter-map.test.ts
+++ b/packages/transport/src/__tests__/meter-map.test.ts
@@ -1,5 +1,6 @@
 // packages/transport/src/__tests__/meter-map.test.ts
 import { describe, it, expect, vi } from 'vitest';
+import type { Tick } from '../types';
 import { MeterMap } from '../timeline/meter-map';
 
 describe('MeterMap', () => {
@@ -78,41 +79,41 @@ describe('MeterMap', () => {
 
   it('validates atTick is non-negative', () => {
     const mm = new MeterMap(960);
-    expect(() => mm.setMeter(4, 4, -1)).toThrow();
+    expect(() => mm.setMeter(4, 4, -1 as Tick)).toThrow();
   });
 
   it('setMeter at bar boundary inserts entry', () => {
     const mm = new MeterMap(960); // 4/4, ticksPerBar = 3840
-    mm.setMeter(7, 8, 3840); // switch to 7/8 at bar 2
-    expect(mm.getMeter(0).numerator).toBe(4);
-    expect(mm.getMeter(3840).numerator).toBe(7);
-    expect(mm.getMeter(3840).denominator).toBe(8);
+    mm.setMeter(7, 8, 3840 as Tick); // switch to 7/8 at bar 2
+    expect(mm.getMeter(0 as Tick).numerator).toBe(4);
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(7);
+    expect(mm.getMeter(3840 as Tick).denominator).toBe(8);
   });
 
   it('setMeter snaps to bar boundary with warning', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mm = new MeterMap(960); // 4/4, ticksPerBar = 3840
-    mm.setMeter(3, 4, 1000); // mid-bar → snaps to 3840
+    mm.setMeter(3, 4, 1000 as Tick); // mid-bar → snaps to 3840
     expect(warnSpy).toHaveBeenCalled();
-    expect(mm.getMeter(3840).numerator).toBe(3);
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(3);
     // No entry at the original tick — it was snapped
-    expect(mm.getMeter(1000).numerator).toBe(4); // still 4/4
+    expect(mm.getMeter(1000 as Tick).numerator).toBe(4); // still 4/4
     warnSpy.mockRestore();
   });
 
   it('setMeter at tick 0 preserves downstream entries (re-snapped)', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840); // bar 2 in 4/4
+    mm.setMeter(7, 8, 3840 as Tick); // bar 2 in 4/4
     mm.setMeter(6, 8); // change tick 0 to 6/8 (ticksPerBar=2880)
-    expect(mm.getMeter(0).numerator).toBe(6);
+    expect(mm.getMeter(0 as Tick).numerator).toBe(6);
     // 3840 is not on a 6/8 bar boundary — entry re-snapped to 5760 (2*2880)
-    expect(mm.getMeter(3840).numerator).toBe(6); // still 6/8 at 3840
-    expect(mm.getMeter(5760).numerator).toBe(7); // 7/8 moved here
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(6); // still 6/8 at 3840
+    expect(mm.getMeter(5760 as Tick).numerator).toBe(7); // 7/8 moved here
   });
 
   it('clearMeters preserves non-default initial meter', () => {
     const mm = new MeterMap(960, 6, 8);
-    mm.setMeter(4, 4, 2880);
+    mm.setMeter(4, 4, 2880 as Tick);
     mm.clearMeters();
     expect(mm.getMeter().numerator).toBe(6);
     expect(mm.getMeter().denominator).toBe(8);
@@ -120,12 +121,12 @@ describe('MeterMap', () => {
 
   it('barToTick round-trips after removeMeter', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
-    mm.removeMeter(3840);
+    mm.setMeter(7, 8, 3840 as Tick);
+    mm.removeMeter(3840 as Tick);
     // After removal, back to 4/4 everywhere
     expect(mm.barToTick(2)).toBe(3840);
     expect(mm.barToTick(3)).toBe(7680);
-    expect(mm.tickToBar(3840)).toBe(2);
+    expect(mm.tickToBar(3840 as Tick)).toBe(2);
   });
 
   it('barToTick with single meter', () => {
@@ -137,7 +138,7 @@ describe('MeterMap', () => {
 
   it('barToTick with mixed meters', () => {
     const mm = new MeterMap(960); // 4/4
-    mm.setMeter(7, 8, 3840); // bar 2 starts 7/8 (ticksPerBar = 3360)
+    mm.setMeter(7, 8, 3840 as Tick); // bar 2 starts 7/8 (ticksPerBar = 3360)
     expect(mm.barToTick(1)).toBe(0); // bar 1: 4/4
     expect(mm.barToTick(2)).toBe(3840); // bar 2: 7/8 starts
     expect(mm.barToTick(3)).toBe(3840 + 3360); // bar 3: still 7/8
@@ -145,56 +146,56 @@ describe('MeterMap', () => {
 
   it('tickToBar with single meter', () => {
     const mm = new MeterMap(960);
-    expect(mm.tickToBar(0)).toBe(1);
-    expect(mm.tickToBar(3840)).toBe(2);
-    expect(mm.tickToBar(5000)).toBe(2); // mid-bar 2
+    expect(mm.tickToBar(0 as Tick)).toBe(1);
+    expect(mm.tickToBar(3840 as Tick)).toBe(2);
+    expect(mm.tickToBar(5000 as Tick)).toBe(2); // mid-bar 2
   });
 
   it('tickToBar with mixed meters', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
-    expect(mm.tickToBar(0)).toBe(1);
-    expect(mm.tickToBar(3840)).toBe(2);
-    expect(mm.tickToBar(3840 + 3360)).toBe(3);
+    mm.setMeter(7, 8, 3840 as Tick);
+    expect(mm.tickToBar(0 as Tick)).toBe(1);
+    expect(mm.tickToBar(3840 as Tick)).toBe(2);
+    expect(mm.tickToBar((3840 + 3360) as Tick)).toBe(3);
   });
 
   it('isBarBoundary', () => {
     const mm = new MeterMap(960); // 4/4
-    expect(mm.isBarBoundary(0)).toBe(true);
-    expect(mm.isBarBoundary(960)).toBe(false); // beat 2
-    expect(mm.isBarBoundary(3840)).toBe(true); // bar 2
+    expect(mm.isBarBoundary(0 as Tick)).toBe(true);
+    expect(mm.isBarBoundary(960 as Tick)).toBe(false); // beat 2
+    expect(mm.isBarBoundary(3840 as Tick)).toBe(true); // bar 2
   });
 
   it('isBarBoundary with 6/8', () => {
     const mm = new MeterMap(960, 6, 8); // ticksPerBar = 2880
-    expect(mm.isBarBoundary(0)).toBe(true);
-    expect(mm.isBarBoundary(480)).toBe(false); // beat 2 (eighth note)
-    expect(mm.isBarBoundary(2880)).toBe(true); // bar 2
+    expect(mm.isBarBoundary(0 as Tick)).toBe(true);
+    expect(mm.isBarBoundary(480 as Tick)).toBe(false); // beat 2 (eighth note)
+    expect(mm.isBarBoundary(2880 as Tick)).toBe(true); // bar 2
   });
 
   it('removeMeter removes entry', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
-    mm.removeMeter(3840);
-    expect(mm.getMeter(3840).numerator).toBe(4); // back to 4/4
+    mm.setMeter(7, 8, 3840 as Tick);
+    mm.removeMeter(3840 as Tick);
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(4); // back to 4/4
   });
 
   it('removeMeter at tick 0 throws', () => {
     const mm = new MeterMap(960);
-    expect(() => mm.removeMeter(0)).toThrow();
+    expect(() => mm.removeMeter(0 as Tick)).toThrow();
   });
 
   it('clearMeters resets to single entry', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
-    mm.setMeter(3, 4, 7200);
+    mm.setMeter(7, 8, 3840 as Tick);
+    mm.setMeter(3, 4, 7200 as Tick);
     mm.clearMeters();
-    expect(mm.getMeter(3840).numerator).toBe(4); // default 4/4
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(4); // default 4/4
   });
 
   it('barToTick round-trips with tickToBar', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
+    mm.setMeter(7, 8, 3840 as Tick);
     for (let bar = 1; bar <= 10; bar++) {
       const tick = mm.barToTick(bar);
       expect(mm.tickToBar(tick)).toBe(bar);
@@ -203,7 +204,7 @@ describe('MeterMap', () => {
 
   it('setMeter at tick 0 re-snaps downstream entries', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840); // bar 2 in 4/4
+    mm.setMeter(7, 8, 3840 as Tick); // bar 2 in 4/4
     mm.setMeter(6, 8); // change tick 0 to 6/8 (ticksPerBar=2880)
     // 3840 is not on a 6/8 bar boundary (3840/2880=1.33)
     // Should snap to 2880*2=5760
@@ -216,14 +217,14 @@ describe('MeterMap', () => {
 
   it('setMeter updating an existing non-zero entry recomputes cache', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840);
+    mm.setMeter(7, 8, 3840 as Tick);
     // Update the same tick with different meter
-    mm.setMeter(5, 4, 3840);
-    expect(mm.getMeter(3840).numerator).toBe(5);
-    expect(mm.getMeter(3840).denominator).toBe(4);
+    mm.setMeter(5, 4, 3840 as Tick);
+    expect(mm.getMeter(3840 as Tick).numerator).toBe(5);
+    expect(mm.getMeter(3840 as Tick).denominator).toBe(4);
     // barToTick should still work
     expect(mm.barToTick(2)).toBe(3840);
-    expect(mm.tickToBar(3840)).toBe(2);
+    expect(mm.tickToBar(3840 as Tick)).toBe(2);
   });
 
   it('barToTick throws for bar < 1', () => {
@@ -235,18 +236,18 @@ describe('MeterMap', () => {
   it('removeMeter warns for non-existent tick', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mm = new MeterMap(960);
-    mm.removeMeter(9999);
+    mm.removeMeter(9999 as Tick);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no entry at tick'));
     warnSpy.mockRestore();
   });
 
   it('isBarBoundary with mixed meters: old bar boundary is not bar boundary in new meter', () => {
     const mm = new MeterMap(960);
-    mm.setMeter(7, 8, 3840); // bar 2 starts 7/8 (ticksPerBar=3360)
+    mm.setMeter(7, 8, 3840 as Tick); // bar 2 starts 7/8 (ticksPerBar=3360)
     // 7680 was bar 3 in 4/4 (2*3840), but in 7/8 section:
     // 7680 - 3840 = 3840, 3840 % 3360 = 480 ≠ 0
-    expect(mm.isBarBoundary(7680)).toBe(false);
+    expect(mm.isBarBoundary(7680 as Tick)).toBe(false);
     // Actual bar 3 in 7/8: 3840 + 3360 = 7200
-    expect(mm.isBarBoundary(7200)).toBe(true);
+    expect(mm.isBarBoundary(7200 as Tick)).toBe(true);
   });
 });

--- a/packages/transport/src/__tests__/meter-map.test.ts
+++ b/packages/transport/src/__tests__/meter-map.test.ts
@@ -1,7 +1,7 @@
 // packages/transport/src/__tests__/meter-map.test.ts
 import { describe, it, expect, vi } from 'vitest';
-import type { Tick } from '../types';
 import { MeterMap } from '../timeline/meter-map';
+import type { Tick } from '../types';
 
 describe('MeterMap', () => {
   it('defaults to 4/4', () => {

--- a/packages/transport/src/__tests__/metronome-player.test.ts
+++ b/packages/transport/src/__tests__/metronome-player.test.ts
@@ -144,7 +144,7 @@ describe('MetronomePlayer', () => {
 
   it('accents on bar boundaries with mixed meters', () => {
     const mixedMap = new MeterMap(960);
-    mixedMap.setMeter(3, 4, 3840); // switch to 3/4 at bar 2
+    mixedMap.setMeter(3, 4, 3840 as Tick); // switch to 3/4 at bar 2
     const player = new MetronomePlayer(ctx, tempoMap, mixedMap, destination, (t) => t);
     player.setEnabled(true);
     player.setClickSounds(createMockBuffer(), createMockBuffer());
@@ -163,7 +163,7 @@ describe('MetronomePlayer', () => {
 
   it('beat step size changes at meter boundary within scheduling window', () => {
     const mixedMap = new MeterMap(960);
-    mixedMap.setMeter(6, 8, 3840); // switch to 6/8 at bar 2
+    mixedMap.setMeter(6, 8, 3840 as Tick); // switch to 6/8 at bar 2
     const player = new MetronomePlayer(ctx, tempoMap, mixedMap, destination, (t) => t);
     player.setEnabled(true);
     player.setClickSounds(createMockBuffer(), createMockBuffer());

--- a/packages/transport/src/__tests__/tempo-map.test.ts
+++ b/packages/transport/src/__tests__/tempo-map.test.ts
@@ -38,7 +38,7 @@ describe('TempoMap', () => {
   it('multiple tempos: second region uses new tempo', () => {
     const tm = new TempoMap(960, 120);
     // At tick 1920 (1s at 120BPM), switch to 60 BPM
-    tm.setTempo(60, 1920);
+    tm.setTempo(60, 1920 as Tick);
     // First 1920 ticks at 120 BPM = 1.0s
     expect(tm.ticksToSeconds(1920 as Tick)).toBeCloseTo(1.0);
     // Next 960 ticks at 60 BPM = 1.0s (total: 2.0s)
@@ -47,7 +47,7 @@ describe('TempoMap', () => {
 
   it('secondsToTicks with multiple tempos', () => {
     const tm = new TempoMap(960, 120);
-    tm.setTempo(60, 1920);
+    tm.setTempo(60, 1920 as Tick);
     expect(tm.secondsToTicks(1.0)).toBe(1920);
     expect(tm.secondsToTicks(2.0)).toBe(2880);
   });

--- a/packages/transport/src/__tests__/transport.test.ts
+++ b/packages/transport/src/__tests__/transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Transport } from '../transport';
 import type { ClipTrack, AudioClip } from '@waveform-playlist/core';
+import type { Tick } from '../types';
 
 function createMockSource() {
   return {
@@ -301,7 +302,7 @@ describe('Transport', () => {
     const transport = new Transport(ctx);
     const onMeter = vi.fn();
     transport.on('meterchange', onMeter);
-    transport.setMeter(3, 4, 3840);
+    transport.setMeter(3, 4, 3840 as Tick);
     expect(onMeter).toHaveBeenCalledTimes(1);
   });
 
@@ -315,10 +316,10 @@ describe('Transport', () => {
   it('removeMeter fires meterchange event', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    transport.setMeter(7, 8, 3840);
+    transport.setMeter(7, 8, 3840 as Tick);
     const onMeter = vi.fn();
     transport.on('meterchange', onMeter);
-    transport.removeMeter(3840);
+    transport.removeMeter(3840 as Tick);
     expect(onMeter).toHaveBeenCalledTimes(1);
   });
 
@@ -332,7 +333,7 @@ describe('Transport', () => {
   it('clearMeters fires meterchange and resets state', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    transport.setMeter(7, 8, 3840);
+    transport.setMeter(7, 8, 3840 as Tick);
     const onMeter = vi.fn();
     transport.on('meterchange', onMeter);
     transport.clearMeters();
@@ -354,14 +355,14 @@ describe('Transport', () => {
   it('tickToBar delegates to MeterMap', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    expect(transport.tickToBar(0)).toBe(1);
-    expect(transport.tickToBar(3840)).toBe(2);
+    expect(transport.tickToBar(0 as Tick)).toBe(1);
+    expect(transport.tickToBar(3840 as Tick)).toBe(2);
   });
 
   it('timeToTick and tickToTime round-trip', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    const tick = 3840;
+    const tick = 3840 as Tick;
     const time = transport.tickToTime(tick);
     expect(transport.timeToTick(time)).toBe(tick);
   });

--- a/packages/transport/src/__tests__/transport.test.ts
+++ b/packages/transport/src/__tests__/transport.test.ts
@@ -283,9 +283,9 @@ describe('Transport', () => {
   it('setTempo with atTick schedules tempo change', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    transport.setTempo(140, 3840); // 140 BPM at bar 2
-    expect(transport.getTempo(0)).toBe(120); // default
-    expect(transport.getTempo(3840)).toBe(140);
+    transport.setTempo(140, 3840 as Tick); // 140 BPM at bar 2
+    expect(transport.getTempo(0 as Tick)).toBe(120); // default
+    expect(transport.getTempo(3840 as Tick)).toBe(140);
   });
 
   it('setMeter changes time signature', () => {
@@ -344,7 +344,7 @@ describe('Transport', () => {
   it('clearTempos fires tempochange', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);
-    transport.setTempo(140, 3840);
+    transport.setTempo(140, 3840 as Tick);
     const onTempo = vi.fn();
     transport.on('tempochange', onTempo);
     transport.clearTempos();

--- a/packages/transport/src/audio/metronome-player.ts
+++ b/packages/transport/src/audio/metronome-player.ts
@@ -58,22 +58,23 @@ export class MetronomePlayer implements SchedulerListener<MetronomeEvent> {
     let tick = entry.tick + Math.ceil(tickIntoSection / beatSize) * beatSize;
 
     while (tick < toTick) {
+      const tickPos = tick as Tick;
       // Re-snap at meter boundaries
-      const currentEntry = this._meterMap.getEntryAt(tick);
+      const currentEntry = this._meterMap.getEntryAt(tickPos);
       if (currentEntry.tick !== entry.tick) {
         entry = currentEntry;
-        beatSize = this._meterMap.ticksPerBeat(tick);
+        beatSize = this._meterMap.ticksPerBeat(tickPos);
       }
 
-      const isAccent = this._meterMap.isBarBoundary(tick);
+      const isAccent = this._meterMap.isBarBoundary(tickPos);
 
       events.push({
-        tick: tick as Tick,
+        tick: tickPos,
         isAccent,
         buffer: isAccent ? this._accentBuffer : this._normalBuffer,
       });
 
-      beatSize = this._meterMap.ticksPerBeat(tick);
+      beatSize = this._meterMap.ticksPerBeat(tickPos);
       tick += beatSize;
     }
 

--- a/packages/transport/src/timeline/meter-map.ts
+++ b/packages/transport/src/timeline/meter-map.ts
@@ -25,12 +25,12 @@ export class MeterMap {
     return this._ppqn;
   }
 
-  getMeter(atTick: number = 0): MeterSignature {
+  getMeter(atTick: Tick = 0 as Tick): MeterSignature {
     const entry = this._entryAt(atTick);
     return { numerator: entry.numerator, denominator: entry.denominator };
   }
 
-  setMeter(numerator: number, denominator: number, atTick: number = 0): void {
+  setMeter(numerator: number, denominator: number, atTick: Tick = 0 as Tick): void {
     this._validateMeter(numerator, denominator);
 
     if (atTick < 0) {
@@ -70,7 +70,7 @@ export class MeterMap {
     this._recomputeCache(i);
   }
 
-  removeMeter(atTick: number): void {
+  removeMeter(atTick: Tick): void {
     if (atTick === 0) {
       throw new Error('[waveform-playlist] MeterMap: cannot remove meter at tick 0');
     }
@@ -88,17 +88,17 @@ export class MeterMap {
     this._entries = [{ ...first, barAtTick: 0 }];
   }
 
-  ticksPerBeat(atTick: number = 0): number {
+  ticksPerBeat(atTick: Tick = 0 as Tick): number {
     const entry = this._entryAt(atTick);
     return this._ppqn * (4 / entry.denominator);
   }
 
-  ticksPerBar(atTick: number = 0): number {
+  ticksPerBar(atTick: Tick = 0 as Tick): number {
     const entry = this._entryAt(atTick);
     return entry.numerator * this._ppqn * (4 / entry.denominator);
   }
 
-  barToTick(bar: number): number {
+  barToTick(bar: number): Tick {
     if (bar < 1) {
       throw new Error('[waveform-playlist] MeterMap: bar must be >= 1, got ' + bar);
     }
@@ -108,20 +108,20 @@ export class MeterMap {
       if (targetBar < nextBar) {
         const barsInto = targetBar - this._entries[i].barAtTick;
         const tpb = this._ticksPerBarForEntry(this._entries[i]);
-        return this._entries[i].tick + barsInto * tpb;
+        return (this._entries[i].tick + barsInto * tpb) as Tick;
       }
     }
-    return 0; // unreachable — last iteration always matches (nextBar = Infinity)
+    return 0 as Tick; // unreachable — last iteration always matches (nextBar = Infinity)
   }
 
-  tickToBar(tick: number): number {
+  tickToBar(tick: Tick): number {
     const entry = this._entryAt(tick);
     const ticksInto = tick - entry.tick;
     const tpb = this._ticksPerBarForEntry(entry);
     return entry.barAtTick + Math.floor(ticksInto / tpb) + 1; // 1-indexed
   }
 
-  isBarBoundary(tick: number): boolean {
+  isBarBoundary(tick: Tick): boolean {
     const entry = this._entryAt(tick);
     const ticksInto = tick - entry.tick;
     const tpb = this._ticksPerBarForEntry(entry);
@@ -129,11 +129,11 @@ export class MeterMap {
   }
 
   /** Internal: get the full entry at a tick (for MetronomePlayer beat grid anchoring) */
-  getEntryAt(tick: number): MeterEntry {
+  getEntryAt(tick: Tick): MeterEntry {
     return this._entryAt(tick);
   }
 
-  private _entryAt(tick: number): MutableMeterEntry {
+  private _entryAt(tick: Tick): MutableMeterEntry {
     let lo = 0;
     let hi = this._entries.length - 1;
     while (lo < hi) {
@@ -151,16 +151,16 @@ export class MeterMap {
     return entry.numerator * this._ppqn * (4 / entry.denominator);
   }
 
-  private _snapToBarBoundary(atTick: number): number {
+  private _snapToBarBoundary(atTick: Tick): Tick {
     const entry = this._entryAt(atTick);
     const tpb = this._ticksPerBarForEntry(entry);
     const ticksInto = atTick - entry.tick;
     if (ticksInto % tpb === 0) return atTick;
     // Snap forward to next bar boundary
-    return entry.tick + Math.ceil(ticksInto / tpb) * tpb;
+    return (entry.tick + Math.ceil(ticksInto / tpb) * tpb) as Tick;
   }
 
-  private _computeBarAtTick(tick: number): number {
+  private _computeBarAtTick(tick: Tick): number {
     const entry = this._entryAt(tick);
     const ticksInto = tick - entry.tick;
     const tpb = this._ticksPerBarForEntry(entry);

--- a/packages/transport/src/timeline/tempo-map.ts
+++ b/packages/transport/src/timeline/tempo-map.ts
@@ -16,12 +16,12 @@ export class TempoMap {
     this._entries = [{ tick: 0 as Tick, bpm: initialBpm, secondsAtTick: 0 }];
   }
 
-  getTempo(atTick: number = 0): number {
+  getTempo(atTick: Tick = 0 as Tick): number {
     const entry = this._entryAt(atTick);
     return entry.bpm;
   }
 
-  setTempo(bpm: number, atTick: number = 0): void {
+  setTempo(bpm: number, atTick: Tick = 0 as Tick): void {
     if (atTick === 0) {
       this._entries[0] = { ...this._entries[0], bpm };
       this._recomputeCache(0);
@@ -35,7 +35,7 @@ export class TempoMap {
       this._entries[i] = { ...this._entries[i], bpm };
     } else {
       const secondsAtTick = this._ticksToSecondsInternal(atTick);
-      this._entries.splice(i + 1, 0, { tick: atTick as Tick, bpm, secondsAtTick });
+      this._entries.splice(i + 1, 0, { tick: atTick, bpm, secondsAtTick });
       i = i + 1;
     }
     this._recomputeCache(i);
@@ -75,14 +75,14 @@ export class TempoMap {
     this._entries = [{ tick: 0 as Tick, bpm: first.bpm, secondsAtTick: 0 }];
   }
 
-  private _ticksToSecondsInternal(ticks: number): number {
+  private _ticksToSecondsInternal(ticks: Tick): number {
     const entry = this._entryAt(ticks);
     const ticksIntoSegment = ticks - entry.tick;
     const secondsPerTick = 60 / (entry.bpm * this._ppqn);
     return entry.secondsAtTick + ticksIntoSegment * secondsPerTick;
   }
 
-  private _entryAt(tick: number): TempoEntry {
+  private _entryAt(tick: Tick): TempoEntry {
     let lo = 0;
     let hi = this._entries.length - 1;
     while (lo < hi) {

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -388,16 +388,16 @@ export class Transport {
 
   // --- Meter ---
 
-  setMeter(numerator: number, denominator: number, atTick?: number): void {
+  setMeter(numerator: number, denominator: number, atTick?: Tick): void {
     this._meterMap.setMeter(numerator, denominator, atTick);
     this._emit('meterchange');
   }
 
-  getMeter(atTick?: number): MeterSignature {
+  getMeter(atTick?: Tick): MeterSignature {
     return this._meterMap.getMeter(atTick);
   }
 
-  removeMeter(atTick: number): void {
+  removeMeter(atTick: Tick): void {
     this._meterMap.removeMeter(atTick);
     this._emit('meterchange');
   }
@@ -412,22 +412,22 @@ export class Transport {
     this._emit('tempochange');
   }
 
-  barToTick(bar: number): number {
+  barToTick(bar: number): Tick {
     return this._meterMap.barToTick(bar);
   }
 
-  tickToBar(tick: number): number {
+  tickToBar(tick: Tick): number {
     return this._meterMap.tickToBar(tick);
   }
 
   /** Convert transport time (seconds) to tick position, using the tempo map. */
-  timeToTick(seconds: number): number {
+  timeToTick(seconds: number): Tick {
     return this._tempoMap.secondsToTicks(seconds);
   }
 
   /** Convert tick position to transport time (seconds), using the tempo map. */
-  tickToTime(tick: number): number {
-    return this._tempoMap.ticksToSeconds(tick as Tick);
+  tickToTime(tick: Tick): number {
+    return this._tempoMap.ticksToSeconds(tick);
   }
 
   // --- Metronome ---

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -377,12 +377,12 @@ export class Transport {
 
   // --- Tempo ---
 
-  setTempo(bpm: number, atTick?: number): void {
+  setTempo(bpm: number, atTick?: Tick): void {
     this._tempoMap.setTempo(bpm, atTick);
     this._emit('tempochange');
   }
 
-  getTempo(atTick?: number): number {
+  getTempo(atTick?: Tick): number {
     return this._tempoMap.getTempo(atTick);
   }
 


### PR DESCRIPTION
## Summary

- Applies branded `Tick` type to all MeterMap public methods: `barToTick`, `tickToBar`, `ticksPerBeat`, `ticksPerBar`, `isBarBoundary`, `getEntryAt`, `getMeter`, `setMeter`, `removeMeter`
- Transport wrapper methods updated to match (`setMeter`, `getMeter`, `removeMeter`, `barToTick`, `tickToBar`, `timeToTick`, `tickToTime`)
- MetronomePlayer casts local tick variable once per beat iteration
- Follow-up to PR #355 which deferred MeterMap due to scope

## Test plan

- [x] Typecheck clean
- [x] 144 unit tests pass
- [x] Build clean
- [x] Lint clean (0 errors)
- [x] No runtime behavior changes — types only

🤖 Generated with [Claude Code](https://claude.com/claude-code)