### PR TITLE
fix(transport): Safari audio warmup + playhead latency compensation

### DIFF
--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -73,6 +73,7 @@
 - **Error events** — `daw-track-error` dispatched on load failure (with `{ trackId, error }`). `daw-error` dispatched on playback failure (with `{ operation, error }`). Failed fetch promises are removed from cache to allow retry.
 - **Engine promise retry** — `_enginePromise` is cleared on rejection so `_ensureEngine()` can retry instead of caching a permanent failure.
 - **Playhead outputLatency compensation** — `_startPlayhead()` subtracts `audioContext.outputLatency` from `engine.getCurrentTime()` so the playhead matches when audio reaches speakers, not when it's processed. Safari reports ~15ms outputLatency vs Chrome's ~3ms. Falls back to 0 if `outputLatency` is not supported.
+- **Do NOT compensate outputLatency in `_stopPlayhead()`** — The resting playhead position must use raw `_currentTime` (no latency subtraction). Subtracting `outputLatency` shifts the stored position, causing the next `play()` to start from the wrong time. Compensation is only safe in the per-frame animation callback.
 - **Web worker peak generation** — `PeakPipeline` (in `workers/peakPipeline.ts`) generates `WaveformData` via inline Blob worker at the current `samplesPerPixel`, caches per `AudioBuffer` (WeakMap), extracts `PeakData` via `resample()`. Resampling only works to coarser (larger) scales — the cached base scale determines the finest renderable zoom. Per-channel peaks when `mono=false`; weighted-average mono merge when `mono=true`.
 
 ## CSS Theming

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -72,6 +72,7 @@
 - **Derived width, not stored state** — `_totalWidth` is a getter derived from `_duration`, `effectiveSampleRate`, and `samplesPerPixel`. Not a `@state()` property — avoids Lit update loops from setting state in `updated()`.
 - **Error events** — `daw-track-error` dispatched on load failure (with `{ trackId, error }`). `daw-error` dispatched on playback failure (with `{ operation, error }`). Failed fetch promises are removed from cache to allow retry.
 - **Engine promise retry** — `_enginePromise` is cleared on rejection so `_ensureEngine()` can retry instead of caching a permanent failure.
+- **Playhead outputLatency compensation** — `_startPlayhead()` subtracts `audioContext.outputLatency` from `engine.getCurrentTime()` so the playhead matches when audio reaches speakers, not when it's processed. Safari reports ~15ms outputLatency vs Chrome's ~3ms. Falls back to 0 if `outputLatency` is not supported.
 - **Web worker peak generation** — `PeakPipeline` (in `workers/peakPipeline.ts`) generates `WaveformData` via inline Blob worker at the current `samplesPerPixel`, caches per `AudioBuffer` (WeakMap), extracts `PeakData` via `resample()`. Resampling only works to coarser (larger) scales — the cached base scale determines the finest renderable zoom. Per-channel peaks when `mono=false`; weighted-average mono merge when `mono=true`.
 
 ## CSS Theming

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -164,6 +164,52 @@
       }
     });
 
+    // --- Safari AudioContext diagnostics ---
+    const ctx = editor.audioContext;
+    editor.addEventListener('daw-play', () => {
+      const t0 = performance.now();
+      const ctxTime0 = ctx.currentTime;
+      const state0 = ctx.state;
+
+      // Sample audioContext.currentTime over the next second to detect stalls
+      let samples = [];
+      let samplingId;
+      const sample = () => {
+        const elapsed = performance.now() - t0;
+        const ctxElapsed = ctx.currentTime - ctxTime0;
+        samples.push({ elapsed: elapsed.toFixed(1), ctxElapsed: ctxElapsed.toFixed(4), state: ctx.state });
+        if (elapsed < 1000) {
+          samplingId = requestAnimationFrame(sample);
+        } else {
+          console.log('[safari-debug] AudioContext timing samples (first 1s):');
+          console.table(samples);
+
+          // Check for initial stall: how long before ctx.currentTime started advancing?
+          const firstAdvance = samples.find(s => parseFloat(s.ctxElapsed) > 0.001);
+          if (firstAdvance) {
+            addLog('ctx.currentTime started advancing at +' + firstAdvance.elapsed + 'ms (state at play: ' + state0 + ')');
+          } else {
+            addLog('WARNING: ctx.currentTime did NOT advance in first 1s');
+          }
+
+          // Check outputLatency
+          addLog('outputLatency=' + (ctx.outputLatency ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
+                 ' baseLatency=' + (ctx.baseLatency ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
+                 ' sampleRate=' + ctx.sampleRate);
+        }
+      };
+      samplingId = requestAnimationFrame(sample);
+
+      // Clean up on stop
+      const cleanup = () => {
+        cancelAnimationFrame(samplingId);
+        editor.removeEventListener('daw-stop', cleanup);
+        editor.removeEventListener('daw-pause', cleanup);
+      };
+      editor.addEventListener('daw-stop', cleanup);
+      editor.addEventListener('daw-pause', cleanup);
+    });
+
     // Editor events
     editor.addEventListener('daw-seek', (e) => addLog('seek: ' + e.detail.time.toFixed(3) + 's'));
     editor.addEventListener('daw-track-select', (e) => addLog('track-select: ' + e.detail.trackId));

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -164,54 +164,11 @@
       }
     });
 
-    // --- Safari AudioContext diagnostics ---
+    // --- AudioContext latency info ---
     const ctx = editor.audioContext;
-    addLog('outputLatency=' + ('outputLatency' in ctx ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'NOT SUPPORTED') +
-           ' baseLatency=' + ('baseLatency' in ctx ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'NOT SUPPORTED') +
+    addLog('outputLatency=' + ('outputLatency' in ctx ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
+           ' baseLatency=' + ('baseLatency' in ctx ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
            ' sampleRate=' + ctx.sampleRate);
-    editor.addEventListener('daw-play', () => {
-      const t0 = performance.now();
-      const ctxTime0 = ctx.currentTime;
-      const state0 = ctx.state;
-
-      // Sample audioContext.currentTime over the next second to detect stalls
-      let samples = [];
-      let samplingId;
-      const sample = () => {
-        const elapsed = performance.now() - t0;
-        const ctxElapsed = ctx.currentTime - ctxTime0;
-        samples.push({ elapsed: elapsed.toFixed(1), ctxElapsed: ctxElapsed.toFixed(4), state: ctx.state });
-        if (elapsed < 1000) {
-          samplingId = requestAnimationFrame(sample);
-        } else {
-          console.log('[safari-debug] AudioContext timing samples (first 1s):');
-          console.table(samples);
-
-          // Check for initial stall: how long before ctx.currentTime started advancing?
-          const firstAdvance = samples.find(s => parseFloat(s.ctxElapsed) > 0.001);
-          if (firstAdvance) {
-            addLog('ctx.currentTime started advancing at +' + firstAdvance.elapsed + 'ms (state at play: ' + state0 + ')');
-          } else {
-            addLog('WARNING: ctx.currentTime did NOT advance in first 1s');
-          }
-
-          // Check outputLatency
-          addLog('outputLatency=' + (ctx.outputLatency ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
-                 ' baseLatency=' + (ctx.baseLatency ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
-                 ' sampleRate=' + ctx.sampleRate);
-        }
-      };
-      samplingId = requestAnimationFrame(sample);
-
-      // Clean up on stop
-      const cleanup = () => {
-        cancelAnimationFrame(samplingId);
-        editor.removeEventListener('daw-stop', cleanup);
-        editor.removeEventListener('daw-pause', cleanup);
-      };
-      editor.addEventListener('daw-stop', cleanup);
-      editor.addEventListener('daw-pause', cleanup);
-    });
 
     // Editor events
     editor.addEventListener('daw-seek', (e) => addLog('seek: ' + e.detail.time.toFixed(3) + 's'));

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -164,12 +164,6 @@
       }
     });
 
-    // --- AudioContext latency info ---
-    const ctx = editor.audioContext;
-    addLog('outputLatency=' + ('outputLatency' in ctx ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
-           ' baseLatency=' + ('baseLatency' in ctx ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'N/A') +
-           ' sampleRate=' + ctx.sampleRate);
-
     // Editor events
     editor.addEventListener('daw-seek', (e) => addLog('seek: ' + e.detail.time.toFixed(3) + 's'));
     editor.addEventListener('daw-track-select', (e) => addLog('track-select: ' + e.detail.trackId));

--- a/packages/dawcore/dev/multiclip.html
+++ b/packages/dawcore/dev/multiclip.html
@@ -166,6 +166,9 @@
 
     // --- Safari AudioContext diagnostics ---
     const ctx = editor.audioContext;
+    addLog('outputLatency=' + ('outputLatency' in ctx ? (ctx.outputLatency * 1000).toFixed(1) + 'ms' : 'NOT SUPPORTED') +
+           ' baseLatency=' + ('baseLatency' in ctx ? (ctx.baseLatency * 1000).toFixed(1) + 'ms' : 'NOT SUPPORTED') +
+           ' sampleRate=' + ctx.sampleRate);
     editor.addEventListener('daw-play', () => {
       const t0 = performance.now();
       const ctxTime0 = ctx.currentTime;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -974,7 +974,7 @@ export class DawEditorElement extends LitElement {
     playhead.startAnimation(
       () => Math.max(0, engine.getCurrentTime() - outputLatency),
       this.effectiveSampleRate,
-      this.samplesPerPixel,
+      this.samplesPerPixel
     );
   }
   _stopPlayhead() {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -966,10 +966,15 @@ export class DawEditorElement extends LitElement {
     const playhead = this._getPlayhead();
     if (!playhead || !this._engine) return;
     const engine = this._engine;
+    // Subtract outputLatency so the playhead matches when audio reaches
+    // the speakers, not when it's processed. Safari reports ~15ms;
+    // Chrome ~3ms. Falls back to 0 if not supported.
+    const outputLatency =
+      'outputLatency' in this.audioContext ? (this.audioContext as AudioContext).outputLatency : 0;
     playhead.startAnimation(
-      () => engine.getCurrentTime(),
+      () => Math.max(0, engine.getCurrentTime() - outputLatency),
       this.effectiveSampleRate,
-      this.samplesPerPixel
+      this.samplesPerPixel,
     );
   }
   _stopPlayhead() {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -978,7 +978,7 @@ export class DawEditorElement extends LitElement {
         return Math.max(0, engine.getCurrentTime() - latency);
       },
       this.effectiveSampleRate,
-      this.samplesPerPixel,
+      this.samplesPerPixel
     );
   }
   _stopPlayhead() {

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -968,11 +968,12 @@ export class DawEditorElement extends LitElement {
     const engine = this._engine;
     // Subtract outputLatency so the playhead matches when audio reaches
     // the speakers, not when it's processed. Safari reports ~15ms;
-    // Chrome ~3ms. Read per-frame since outputLatency is a dynamic property
-    // (can change on device switch, Bluetooth codec change, etc.).
-    const ctx = this.audioContext;
+    // Chrome ~3ms. Both audioContext and outputLatency are read per-frame:
+    // audioContext can be replaced (setter), outputLatency is dynamic
+    // (device switch, Bluetooth codec change).
     playhead.startAnimation(
       () => {
+        const ctx = this.audioContext;
         const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
         return Math.max(0, engine.getCurrentTime() - latency);
       },
@@ -983,7 +984,12 @@ export class DawEditorElement extends LitElement {
   _stopPlayhead() {
     const playhead = this._getPlayhead();
     if (!playhead) return;
-    playhead.stopAnimation(this._currentTime, this.effectiveSampleRate, this.samplesPerPixel);
+    // Apply same outputLatency offset as _startPlayhead so the resting
+    // position matches the last animated position (no visual snap on stop).
+    const ctx = this.audioContext;
+    const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
+    const time = Math.max(0, this._currentTime - latency);
+    playhead.stopAnimation(time, this.effectiveSampleRate, this.samplesPerPixel);
   }
   private _getPlayhead(): DawPlayheadElement | null {
     return this.shadowRoot?.querySelector('daw-playhead') as DawPlayheadElement | null;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -968,11 +968,14 @@ export class DawEditorElement extends LitElement {
     const engine = this._engine;
     // Subtract outputLatency so the playhead matches when audio reaches
     // the speakers, not when it's processed. Safari reports ~15ms;
-    // Chrome ~3ms. Falls back to 0 if not supported.
-    const outputLatency =
-      'outputLatency' in this.audioContext ? (this.audioContext as AudioContext).outputLatency : 0;
+    // Chrome ~3ms. Read per-frame since outputLatency is a dynamic property
+    // (can change on device switch, Bluetooth codec change, etc.).
+    const ctx = this.audioContext;
     playhead.startAnimation(
-      () => Math.max(0, engine.getCurrentTime() - outputLatency),
+      () => {
+        const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
+        return Math.max(0, engine.getCurrentTime() - latency);
+      },
       this.effectiveSampleRate,
       this.samplesPerPixel
     );

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -968,28 +968,23 @@ export class DawEditorElement extends LitElement {
     const engine = this._engine;
     // Subtract outputLatency so the playhead matches when audio reaches
     // the speakers, not when it's processed. Safari reports ~15ms;
-    // Chrome ~3ms. Both audioContext and outputLatency are read per-frame:
-    // audioContext can be replaced (setter), outputLatency is dynamic
-    // (device switch, Bluetooth codec change).
+    // Chrome ~3ms. Read per-frame since outputLatency is a dynamic property
+    // (can change on device switch, Bluetooth codec change).
+    // Note: audioContext is captured once — it's stable after engine creation.
+    const ctx = this.audioContext;
     playhead.startAnimation(
       () => {
-        const ctx = this.audioContext;
         const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
         return Math.max(0, engine.getCurrentTime() - latency);
       },
       this.effectiveSampleRate,
-      this.samplesPerPixel
+      this.samplesPerPixel,
     );
   }
   _stopPlayhead() {
     const playhead = this._getPlayhead();
     if (!playhead) return;
-    // Apply same outputLatency offset as _startPlayhead so the resting
-    // position matches the last animated position (no visual snap on stop).
-    const ctx = this.audioContext;
-    const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
-    const time = Math.max(0, this._currentTime - latency);
-    playhead.stopAnimation(time, this.effectiveSampleRate, this.samplesPerPixel);
+    playhead.stopAnimation(this._currentTime, this.effectiveSampleRate, this.samplesPerPixel);
   }
   private _getPlayhead(): DawPlayheadElement | null {
     return this.shadowRoot?.querySelector('daw-playhead') as DawPlayheadElement | null;

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -146,7 +146,7 @@ Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (requir
 - **`_activeSources` cleanup** — ClipPlayer uses `ended` event listener for automatic cleanup. MetronomePlayer clicks are short one-shots.
 - **rAF exclusively** — no setTimeout/setInterval anywhere. The lookahead window (200ms) provides sufficient scheduling headroom.
 - **Scheduler lookahead ≠ perceptible latency** — The 200ms lookahead is scheduling headroom only. `source.start(when)` uses precise `AudioContext.currentTime` values, so audio plays at the exact right time. Recording latency compensation only needs `outputLatency`, not `outputLatency + lookahead`.
-- **Safari AudioContext Warmup** — `audioContext.resume()` resolves but Safari's audio thread may not be ready to output samples. `NativePlayoutAdapter.init()` waits for `currentTime` to advance past `outputLatency` before returning. Without this, clips scheduled at time 0 have audible start delay on Safari.
+- **Safari AudioContext Warmup** — `audioContext.resume()` resolves but Safari's audio thread may not be ready to output samples. `NativePlayoutAdapter.init()` waits for `currentTime` to advance past `outputLatency` (fallback 20ms) before returning, with a 2s timeout and `state === 'closed'` guard to prevent infinite hang. Without this, clips scheduled at time 0 have audible start delay on Safari.
 - **onPositionJump Strict Less-Than** — `ClipPlayer.onPositionJump` uses strict `<` (not `<=`) for clip start boundary: `clipStartSample < newSample`. Clips starting exactly AT the position are handled by `generate()`, not `onPositionJump`. Using `<=` causes double-scheduling (both produce the same clip).
 
 ## Critical Gotchas

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -135,7 +135,7 @@ When any track is soloed, all non-soloed tracks are muted via `TrackNode.setMute
 
 ## NativePlayoutAdapter
 
-Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (required + optional: `addTrack`, `removeTrack`, `updateTrack`). `init()` resumes suspended AudioContext. `transport` getter exposes the Transport for direct access to tempo, metronome, and effects hooks.
+Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (required + optional: `addTrack`, `removeTrack`, `updateTrack`). `init()` resumes suspended AudioContext and waits for Safari warmup (see Patterns). `transport` getter exposes the Transport for direct access to tempo, metronome, and effects hooks.
 
 ## Patterns
 

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -146,6 +146,8 @@ Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (requir
 - **`_activeSources` cleanup** — ClipPlayer uses `ended` event listener for automatic cleanup. MetronomePlayer clicks are short one-shots.
 - **rAF exclusively** — no setTimeout/setInterval anywhere. The lookahead window (200ms) provides sufficient scheduling headroom.
 - **Scheduler lookahead ≠ perceptible latency** — The 200ms lookahead is scheduling headroom only. `source.start(when)` uses precise `AudioContext.currentTime` values, so audio plays at the exact right time. Recording latency compensation only needs `outputLatency`, not `outputLatency + lookahead`.
+- **Safari AudioContext Warmup** — `audioContext.resume()` resolves but Safari's audio thread may not be ready to output samples. `NativePlayoutAdapter.init()` waits for `currentTime` to advance past `outputLatency` before returning. Without this, clips scheduled at time 0 have audible start delay on Safari.
+- **onPositionJump Strict Less-Than** — `ClipPlayer.onPositionJump` uses strict `<` (not `<=`) for clip start boundary: `clipStartSample < newSample`. Clips starting exactly AT the position are handled by `generate()`, not `onPositionJump`. Using `<=` causes double-scheduling (both produce the same clip).
 
 ## Critical Gotchas
 

--- a/packages/transport/src/__tests__/adapter.test.ts
+++ b/packages/transport/src/__tests__/adapter.test.ts
@@ -138,6 +138,85 @@ describe('NativePlayoutAdapter', () => {
     expect(ctx.resume).toHaveBeenCalled();
   });
 
+  it('init warmup loop polls until currentTime advances', async () => {
+    const ctx = mockAudioContext();
+    // Override: resume does NOT advance currentTime (simulates Safari warmup)
+    let rafCallback: ((time: number) => void) | null = null;
+    (ctx as any).resume = vi.fn(() => {
+      (ctx as any).state = 'running';
+      // currentTime stays at 0 — warmup loop must poll
+      return Promise.resolve();
+    });
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (time: number) => void) => {
+        rafCallback = cb;
+        return 1;
+      })
+    );
+
+    const adapter = new NativePlayoutAdapter(ctx);
+    let resolved = false;
+    const initPromise = adapter.init().then(() => {
+      resolved = true;
+    });
+
+    // Wait for resume() microtask to settle
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Warmup should be polling — not yet resolved
+    expect(resolved).toBe(false);
+    expect(rafCallback).not.toBeNull();
+
+    // Advance currentTime past warmup target and fire the rAF callback
+    (ctx as any).currentTime = 0.05;
+    rafCallback!(0);
+
+    await initPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it('init warmup times out after max wait', async () => {
+    const ctx = mockAudioContext();
+    (ctx as any).resume = vi.fn(() => {
+      (ctx as any).state = 'running';
+      return Promise.resolve();
+    });
+
+    // Mock performance.now to jump past timeout
+    const originalNow = performance.now;
+    let mockNow = 0;
+    vi.stubGlobal('performance', { now: () => mockNow });
+
+    let rafCallback: ((time: number) => void) | null = null;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (time: number) => void) => {
+        rafCallback = cb;
+        return 1;
+      })
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const adapter = new NativePlayoutAdapter(ctx);
+    const initPromise = adapter.init();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Jump past 2s timeout and fire callback
+    mockNow = 3000;
+    rafCallback!(0);
+
+    await initPromise;
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('warmup timed out'));
+
+    warnSpy.mockRestore();
+    vi.stubGlobal('performance', { now: originalNow });
+  });
+
   it('init skips resume for running AudioContext', async () => {
     const ctx = mockAudioContext();
     (ctx as any).state = 'running';

--- a/packages/transport/src/__tests__/adapter.test.ts
+++ b/packages/transport/src/__tests__/adapter.test.ts
@@ -37,7 +37,7 @@ function createMockPannerNode() {
 }
 
 function mockAudioContext(): AudioContext {
-  return {
+  const ctx = {
     sampleRate: 48000,
     currentTime: 0,
     state: 'suspended',
@@ -45,8 +45,14 @@ function mockAudioContext(): AudioContext {
     createGain: vi.fn(() => createMockGainNode()),
     createStereoPanner: vi.fn(() => createMockPannerNode()),
     createBufferSource: vi.fn(() => createMockSource()),
-    resume: vi.fn(() => Promise.resolve()),
-  } as unknown as AudioContext;
+    resume: vi.fn(() => {
+      // Simulate AudioContext advancing after resume (needed for warmup wait)
+      ctx.currentTime = 1.0;
+      ctx.state = 'running';
+      return Promise.resolve();
+    }),
+  };
+  return ctx as unknown as AudioContext;
 }
 
 function makeClip(overrides: Partial<AudioClip> = {}): AudioClip {

--- a/packages/transport/src/__tests__/clip-player.test.ts
+++ b/packages/transport/src/__tests__/clip-player.test.ts
@@ -259,6 +259,26 @@ describe('ClipPlayer', () => {
     expect(events[0].durationSamples).toBe(48000);
   });
 
+  it('onPositionJump does not schedule clips starting exactly at the jump position', () => {
+    // Clip starts at 0.5s (24000 samples), jump to exactly 0.5s (tick 960)
+    // onPositionJump uses strict < so clips starting AT the position are
+    // left for generate() — prevents double-scheduling.
+    const clip = makeClip({
+      startSample: 24000,
+      durationSamples: 48000, // 1s clip
+      offsetSamples: 0,
+    });
+    const track = makeTrack([clip]);
+    const trackNode = createMockTrackNode('track-1');
+    const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
+    player.setTracks([track], new Map([['track-1', trackNode]]));
+
+    // Jump to exactly where the clip starts (tick 960 = sample 24000)
+    player.onPositionJump(960 as Tick);
+    // No source should be created — the clip starts AT the position, not before
+    expect((ctx.createBufferSource as any).mock.results.length).toBe(0);
+  });
+
   it('mid-clip playback is handled by onPositionJump, not generate', () => {
     const clip = makeClip({
       startSample: 0,

--- a/packages/transport/src/adapter.ts
+++ b/packages/transport/src/adapter.ts
@@ -30,9 +30,26 @@ export class NativePlayoutAdapter implements PlayoutAdapter {
           ? (this._audioContext as AudioContext).outputLatency
           : 0.02; // 20ms fallback
       if (this._audioContext.currentTime < warmupTarget) {
+        const MAX_WARMUP_MS = 2000;
         await new Promise<void>((resolve) => {
+          const startMs = performance.now();
           const check = () => {
             if (this._audioContext.currentTime >= warmupTarget) {
+              resolve();
+            } else if (
+              this._audioContext.state === 'closed' ||
+              performance.now() - startMs > MAX_WARMUP_MS
+            ) {
+              console.warn(
+                '[waveform-playlist] AudioContext warmup timed out' +
+                  ' (currentTime=' +
+                  this._audioContext.currentTime +
+                  ', target=' +
+                  warmupTarget +
+                  ', state=' +
+                  this._audioContext.state +
+                  '). Proceeding without warmup.'
+              );
               resolve();
             } else {
               requestAnimationFrame(check);

--- a/packages/transport/src/adapter.ts
+++ b/packages/transport/src/adapter.ts
@@ -25,10 +25,10 @@ export class NativePlayoutAdapter implements PlayoutAdapter {
       // Safari's audio thread may not be ready to output audio immediately
       // after resume() resolves. Wait for currentTime to advance past the
       // output latency, indicating the hardware pipeline is warm.
-      const warmupTarget =
-        'outputLatency' in this._audioContext
-          ? (this._audioContext as AudioContext).outputLatency
-          : 0.02; // 20ms fallback
+      // Minimum warmup ensures the audio thread has time to spin up even
+      // when outputLatency reports 0 (Chrome on low-latency hardware).
+      const MIN_WARMUP = 0.02; // 20ms
+      const warmupTarget = Math.max(MIN_WARMUP, this._audioContext.outputLatency ?? MIN_WARMUP);
       if (this._audioContext.currentTime < warmupTarget) {
         const MAX_WARMUP_MS = 2000;
         await new Promise<void>((resolve) => {

--- a/packages/transport/src/adapter.ts
+++ b/packages/transport/src/adapter.ts
@@ -22,6 +22,25 @@ export class NativePlayoutAdapter implements PlayoutAdapter {
     }
     if (this._audioContext.state === 'suspended') {
       await this._audioContext.resume();
+      // Safari's audio thread may not be ready to output audio immediately
+      // after resume() resolves. Wait for currentTime to advance past the
+      // output latency, indicating the hardware pipeline is warm.
+      const warmupTarget =
+        'outputLatency' in this._audioContext
+          ? (this._audioContext as AudioContext).outputLatency
+          : 0.02; // 20ms fallback
+      if (this._audioContext.currentTime < warmupTarget) {
+        await new Promise<void>((resolve) => {
+          const check = () => {
+            if (this._audioContext.currentTime >= warmupTarget) {
+              resolve();
+            } else {
+              requestAnimationFrame(check);
+            }
+          };
+          requestAnimationFrame(check);
+        });
+      }
     }
   }
 

--- a/packages/transport/src/audio/clip-player.ts
+++ b/packages/transport/src/audio/clip-player.ts
@@ -79,9 +79,6 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
 
   generate(fromTick: Tick, toTick: Tick): ClipEvent[] {
     const events: ClipEvent[] = [];
-    // Only log when events are actually found (avoid flooding)
-    let loggedFrom = fromTick;
-    let loggedTo = toTick;
 
     const fromSample = this._sampleTimeline.ticksToSamples(fromTick);
     const toSample = this._sampleTimeline.ticksToSamples(toTick);
@@ -127,10 +124,6 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
       }
     }
 
-    if (events.length > 0) {
-      console.log('[clip-player] generate: from=' + loggedFrom + ' to=' + loggedTo + ' events=' + events.length + ' clips=[' + events.map(e => e.clipId).join(',') + ']');
-    }
-
     return events;
   }
 
@@ -171,8 +164,6 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
     // Convert tick → seconds → AudioContext.currentTime for scheduling
     const transportSeconds = this._tempoMap.ticksToSeconds(event.tick);
     const when = this._toAudioTime(transportSeconds);
-
-    console.log('[clip-player] consume: clip=' + event.clipId + ' tick=' + event.tick + ' when=' + when.toFixed(4) + ' ctx.now=' + this._audioContext.currentTime.toFixed(4) + ' delta=' + ((when - this._audioContext.currentTime) * 1000).toFixed(1) + 'ms sources=' + this._activeSources.size);
 
     // Create a gain node for per-clip gain and fades
     const gainNode = this._audioContext.createGain();
@@ -220,7 +211,6 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
   }
 
   onPositionJump(newTick: Tick): void {
-    console.log('[clip-player] onPositionJump: newTick=' + newTick + ' ctx.now=' + this._audioContext.currentTime.toFixed(4));
     this.silence();
 
     const newSample = this._sampleTimeline.ticksToSamples(newTick);

--- a/packages/transport/src/audio/clip-player.ts
+++ b/packages/transport/src/audio/clip-player.ts
@@ -79,6 +79,9 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
 
   generate(fromTick: Tick, toTick: Tick): ClipEvent[] {
     const events: ClipEvent[] = [];
+    // Only log when events are actually found (avoid flooding)
+    let loggedFrom = fromTick;
+    let loggedTo = toTick;
 
     const fromSample = this._sampleTimeline.ticksToSamples(fromTick);
     const toSample = this._sampleTimeline.ticksToSamples(toTick);
@@ -124,6 +127,10 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
       }
     }
 
+    if (events.length > 0) {
+      console.log('[clip-player] generate: from=' + loggedFrom + ' to=' + loggedTo + ' events=' + events.length + ' clips=[' + events.map(e => e.clipId).join(',') + ']');
+    }
+
     return events;
   }
 
@@ -164,6 +171,8 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
     // Convert tick → seconds → AudioContext.currentTime for scheduling
     const transportSeconds = this._tempoMap.ticksToSeconds(event.tick);
     const when = this._toAudioTime(transportSeconds);
+
+    console.log('[clip-player] consume: clip=' + event.clipId + ' tick=' + event.tick + ' when=' + when.toFixed(4) + ' ctx.now=' + this._audioContext.currentTime.toFixed(4) + ' delta=' + ((when - this._audioContext.currentTime) * 1000).toFixed(1) + 'ms sources=' + this._activeSources.size);
 
     // Create a gain node for per-clip gain and fades
     const gainNode = this._audioContext.createGain();
@@ -211,6 +220,7 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
   }
 
   onPositionJump(newTick: Tick): void {
+    console.log('[clip-player] onPositionJump: newTick=' + newTick + ' ctx.now=' + this._audioContext.currentTime.toFixed(4));
     this.silence();
 
     const newSample = this._sampleTimeline.ticksToSamples(newTick);
@@ -224,8 +234,10 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
         const clipStartSample = clip.startSample;
         const clipEndSample = clipStartSample + clip.durationSamples;
 
-        // Check if clip spans the new position
-        if (clipStartSample <= newSample && clipEndSample > newSample) {
+        // Check if clip spans the new position (started BEFORE, still playing).
+        // Clips starting exactly AT the new position are handled by generate(),
+        // not here — strict < prevents double-scheduling.
+        if (clipStartSample < newSample && clipEndSample > newSample) {
           const offsetIntoClipSamples = newSample - clipStartSample;
           const offsetSamples = clip.offsetSamples + offsetIntoClipSamples;
           let durationSamples = clipEndSample - newSample;

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -160,6 +160,7 @@ export class Transport {
     this._scheduler.reset(currentTime);
 
     this._endTime = endTime;
+
     this._clock.start();
 
     // Re-create sources for clips spanning the current position.


### PR DESCRIPTION
## Summary

- Wait for `audioContext.currentTime` to advance past `outputLatency` after `resume()` in `adapter.init()`. Safari's audio thread needs warmup time — without this, clips scheduled at time 0 have audible start delay.
- Offset playhead position by `outputLatency` so it matches when audio reaches speakers, not when it's processed (Safari reports ~15ms vs Chrome's ~3ms).
- Fix `onPositionJump` to use strict `<` (not `<=`) for clip start boundary, preventing double-scheduling of clips starting exactly at the play position.

## Test plan

- [ ] Safari: press play on multiclip page — audio should start immediately with playhead
- [ ] Chrome/Firefox: verify no regression (warmup skip when context already running)
- [ ] `cd packages/transport && npx vitest run` — 211 tests pass

## Browsers tested

- Safari 18 (macOS) — `outputLatency=15.6ms`, `baseLatency=2.7ms`
- Chrome — no change needed (`outputLatency` ~3ms, warmup instant)