### PR TITLE
refactor(browser): consolidate rAF loops into single animation frame registry

### DIFF
--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -125,23 +125,17 @@ const rebuildChain = useCallback(() => {
 
 **Problem:** React state updates during playback cause flickering. Components need 60fps updates.
 
-**Solution:** `requestAnimationFrame` + direct DOM manipulation via refs. Read time via `getPlaybackTime()` which delegates to `Transport.seconds` for perfect audio sync. No `setState` in the loop.
+**Solution:** Single `requestAnimationFrame` loop in `WaveformPlaylistContext` drives all visual updates via the **Animation Frame Registry**. Components register per-frame callbacks via `registerFrameCallback(id, cb)` / `unregisterFrameCallback(id)` from `usePlaybackAnimation()`. Direct DOM manipulation via refs — no `setState` in the loop.
 
-**Key points:** Use `getPlaybackTime()` (from `usePlaybackAnimation()`) — delegates to `engine.getCurrentTime()` which reads `Transport.seconds` (auto-wraps at loop boundaries). Fallback: manual elapsed calculation from `audioContext.currentTime`. Update DOM directly. Cancel animation frame on cleanup.
+**FrameData:** The animation loop computes `FrameData { time, visualTime, sampleRate, samplesPerPixel }` once per frame and passes it to all registered callbacks. Callbacks must read `sampleRate`/`samplesPerPixel` from `FrameData`, not from closed-over render values — avoids stale closures during zoom changes.
 
-**Reference implementation:** `AnimatedPlayhead` component. Also used by `ChannelWithProgress`, `AudioPosition`, `PlayheadWithMarker`.
+**Consumers:** `AnimatedPlayhead` (id: `'playhead'`), `ChannelWithProgress` (id: `useId()` — unique per instance), `AudioPosition` (id: `'audio-position'`). Auto-scroll uses `visualTime` directly in the loop body. MediaElement provider is excluded — has its own separate animation pattern.
+
+**Do NOT add new rAF loops for visual playback updates.** Register a frame callback instead. Use `visualTime` for DOM positioning, `time` for state/logic.
 
 **Loop handling:** Looping is handled natively by Tone.js Transport (`Transport.loop`/`loopStart`/`loopEnd`). The animation loop does NOT detect loop boundaries — `Transport.seconds` auto-wraps, so `getPlaybackTime()` returns the correct position. Selection/annotation playback disables Transport loop; `stop()` disables it before stopping.
 
 **AudioContext Init Pattern:** `audioInitializedRef` guards `engine.init()` (AudioContext resume via `Tone.start()`). Only the first play call awaits init; subsequent plays skip it entirely — no microtask yield. Reset to `false` when engine is rebuilt in `loadAudio`. This keeps the stop→play path fully synchronous after first play, preventing audio layering race conditions.
-
-## Animation Frame Registry
-
-**Single rAF loop drives all visual updates during playback.** Components register per-frame callbacks via `registerFrameCallback(id, cb)` / `unregisterFrameCallback(id)` from `usePlaybackAnimation()`. The animation loop in `WaveformPlaylistContext` computes `FrameData { time, visualTime, sampleRate, samplesPerPixel }` once per frame and calls all registered callbacks.
-
-**Consumers:** `AnimatedPlayhead` (id: `'playhead'`), `ChannelWithProgress` (id: `'progress-{startSample}-{duration}'`), `AudioPosition` (id: `'audio-position'`). Auto-scroll uses `visualTime` directly in the loop body.
-
-**Do NOT add new rAF loops for visual playback updates.** Register a frame callback instead. Use `visualTime` for DOM positioning, `time` for state/logic.
 
 ## Playhead outputLatency Compensation
 

--- a/packages/browser/CLAUDE.md
+++ b/packages/browser/CLAUDE.md
@@ -135,14 +135,17 @@ const rebuildChain = useCallback(() => {
 
 **AudioContext Init Pattern:** `audioInitializedRef` guards `engine.init()` (AudioContext resume via `Tone.start()`). Only the first play call awaits init; subsequent plays skip it entirely — no microtask yield. Reset to `false` when engine is rebuilt in `loadAudio`. This keeps the stop→play path fully synchronous after first play, preventing audio layering race conditions.
 
+## Animation Frame Registry
+
+**Single rAF loop drives all visual updates during playback.** Components register per-frame callbacks via `registerFrameCallback(id, cb)` / `unregisterFrameCallback(id)` from `usePlaybackAnimation()`. The animation loop in `WaveformPlaylistContext` computes `FrameData { time, visualTime, sampleRate, samplesPerPixel }` once per frame and calls all registered callbacks.
+
+**Consumers:** `AnimatedPlayhead` (id: `'playhead'`), `ChannelWithProgress` (id: `'progress-{startSample}-{duration}'`), `AudioPosition` (id: `'audio-position'`). Auto-scroll uses `visualTime` directly in the loop body.
+
+**Do NOT add new rAF loops for visual playback updates.** Register a frame callback instead. Use `visualTime` for DOM positioning, `time` for state/logic.
+
 ## Playhead outputLatency Compensation
 
-`getPlaybackTime()` returns **raw engine time** — no latency subtraction. Compensation is applied at the visual layer only, in each consumer's rAF callback during playback (`isPlaying` guard):
-- `AnimatedPlayhead` — subtracts `outputLatency` for playhead position
-- `ChannelWithProgress` — subtracts `outputLatency` for progress overlay
-- Auto-scroll (in animation loop) — subtracts `outputLatency` for scroll target
-
-**All three must stay aligned.** If any visual consumer uses raw time while others compensate, they disagree by `outputLatency` pixels per frame, causing jitter.
+`getPlaybackTime()` returns **raw engine time** — no latency subtraction. The animation loop computes `visualTime = Math.max(0, time - outputLatency)` once per frame. All registered frame callbacks receive `visualTime` via `FrameData`. Auto-scroll also uses `visualTime`.
 
 **Do NOT compensate `currentTimeRef` or pause position** — state storage must use raw engine time. Subtracting `outputLatency` from stored positions shifts the next `play()` start time and compounds on every pause/resume cycle.
 

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -84,11 +84,11 @@ export interface TrackState {
 /** Per-frame data passed to registered animation callbacks. */
 export interface FrameData {
   /** Raw engine time (for state/logic — NOT for visual positioning). */
-  time: number;
+  readonly time: number;
   /** time - outputLatency (for DOM positioning — matches speaker output). */
-  visualTime: number;
-  sampleRate: number;
-  samplesPerPixel: number;
+  readonly visualTime: number;
+  readonly sampleRate: number;
+  readonly samplesPerPixel: number;
 }
 
 export interface PlaybackAnimationContextValue {
@@ -1032,6 +1032,10 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
 
   // Animation loop
   const startAnimationLoop = useCallback(() => {
+    // Cache AudioContext at loop start — stable for the lifetime of this playback session.
+    // outputLatency is read per-frame since it's a dynamic property.
+    const audioCtx = getGlobalAudioContext();
+
     const updateTime = () => {
       // Get current time from engine (auto-wraps at loop boundaries via Transport.seconds)
       const time = getPlaybackTime();
@@ -1039,9 +1043,22 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
 
       // Compute visual time once — all visual consumers use this same value.
       // Subtracts outputLatency so DOM positions match speaker output.
-      const ctx = getGlobalAudioContext();
-      const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
+      const latency = 'outputLatency' in audioCtx ? (audioCtx as AudioContext).outputLatency : 0;
       const visualTime = Math.max(0, time - latency);
+
+      // Drive registered per-frame callbacks BEFORE stop checks so the
+      // final frame renders at the correct stop position (not one frame behind).
+      const sr = sampleRateRef.current;
+      const spp = samplesPerPixelRef.current;
+      const frameData: FrameData = {
+        time,
+        visualTime,
+        sampleRate: sr,
+        samplesPerPixel: spp,
+      };
+      for (const cb of frameCallbacksRef.current.values()) {
+        cb(frameData);
+      }
 
       // Handle annotation playback based on continuous play mode
       const currentAnnotations = annotationsRef.current;
@@ -1087,8 +1104,7 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       // Handle automatic scroll — uses shared visualTime for alignment with playhead
       if (isAutomaticScrollRef.current && scrollContainerRef.current && duration > 0) {
         const container = scrollContainerRef.current;
-        const sr = sampleRateRef.current;
-        const pixelPosition = (visualTime * sr) / samplesPerPixelRef.current;
+        const pixelPosition = (visualTime * sr) / spp;
         const containerWidth = container.clientWidth;
 
         // Continuously scroll to keep playhead centered.
@@ -1125,14 +1141,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         setActiveAnnotationId(null);
         return;
       }
-      // Drive registered per-frame callbacks (playhead, progress overlays, time display)
-      const sr = sampleRateRef.current;
-      const spp = samplesPerPixelRef.current;
-      const frameData: FrameData = { time, visualTime, sampleRate: sr, samplesPerPixel: spp };
-      for (const cb of frameCallbacksRef.current.values()) {
-        cb(frameData);
-      }
-
       startAnimationFrameLoop(updateTime);
     };
     startAnimationFrameLoop(updateTime);

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -1092,10 +1092,13 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         const containerWidth = container.clientWidth;
 
         // Continuously scroll to keep playhead centered.
-        // Math.round prevents sub-pixel jitter — browsers round scrollLeft to
-        // integers, so alternating between N.4 and N.6 causes 1px wobble.
         const targetScrollLeft = Math.round(Math.max(0, pixelPosition - containerWidth / 2));
+        const prevScroll = container.scrollLeft;
         container.scrollLeft = targetScrollLeft;
+        const actualScroll = container.scrollLeft;
+        if (actualScroll < prevScroll) {
+          console.log('[scroll-debug] BACKWARDS: prev=' + prevScroll + ' target=' + targetScrollLeft + ' actual=' + actualScroll + ' visualTime=' + visualTime.toFixed(4));
+        }
       }
 
       // Check if we've reached the playback end time (for selection playback)

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -1092,13 +1092,9 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         const containerWidth = container.clientWidth;
 
         // Continuously scroll to keep playhead centered.
+        // Math.round prevents sub-pixel jitter from browser integer rounding.
         const targetScrollLeft = Math.round(Math.max(0, pixelPosition - containerWidth / 2));
-        const prevScroll = container.scrollLeft;
         container.scrollLeft = targetScrollLeft;
-        const actualScroll = container.scrollLeft;
-        if (actualScroll < prevScroll) {
-          console.log('[scroll-debug] BACKWARDS: prev=' + prevScroll + ' target=' + targetScrollLeft + ' actual=' + actualScroll + ' visualTime=' + visualTime.toFixed(4));
-        }
       }
 
       // Check if we've reached the playback end time (for selection playback)

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -1091,8 +1091,10 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         const pixelPosition = (visualTime * sr) / samplesPerPixelRef.current;
         const containerWidth = container.clientWidth;
 
-        // Continuously scroll to keep playhead centered
-        const targetScrollLeft = Math.max(0, pixelPosition - containerWidth / 2);
+        // Continuously scroll to keep playhead centered.
+        // Math.round prevents sub-pixel jitter — browsers round scrollLeft to
+        // integers, so alternating between N.4 and N.6 causes 1px wobble.
+        const targetScrollLeft = Math.round(Math.max(0, pixelPosition - containerWidth / 2));
         container.scrollLeft = targetScrollLeft;
       }
 

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -81,6 +81,16 @@ export interface TrackState {
 // Split contexts for performance optimization
 // Animation context contains playback state and timing refs — no per-frame state updates
 
+/** Per-frame data passed to registered animation callbacks. */
+export interface FrameData {
+  /** Raw engine time (for state/logic — NOT for visual positioning). */
+  time: number;
+  /** time - outputLatency (for DOM positioning — matches speaker output). */
+  visualTime: number;
+  sampleRate: number;
+  samplesPerPixel: number;
+}
+
 export interface PlaybackAnimationContextValue {
   isPlaying: boolean;
   currentTime: number;
@@ -90,6 +100,10 @@ export interface PlaybackAnimationContextValue {
   audioStartPositionRef: React.RefObject<number>; // Audio position when playback started
   /** Returns current playback time from engine (auto-wraps at loop boundaries). */
   getPlaybackTime: () => number;
+  /** Register a per-frame callback driven by the single animation loop. */
+  registerFrameCallback: (id: string, cb: (data: FrameData) => void) => void;
+  /** Unregister a per-frame callback. */
+  unregisterFrameCallback: (id: string) => void;
 }
 
 export interface PlaylistStateContextValue {
@@ -360,6 +374,10 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
   const playbackEndTimeRef = useRef<number | null>(null); // Audio position where playback should stop (for selections)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const isAutomaticScrollRef = useRef<boolean>(false);
+  // Animation frame callback registry — components register per-frame DOM update
+  // callbacks instead of running their own rAF loops. Single loop drives all.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const frameCallbacksRef = useRef<Map<string, (data: FrameData) => void>>(new Map());
   const continuousPlayRef = useRef<boolean>(annotationList?.isContinuousPlay ?? false);
   const activeAnnotationIdRef = useRef<string | null>(null);
   // Engine clip operations guard: tracks reference from the last engine statechange.
@@ -1004,12 +1022,26 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
     return (audioStartPositionRef.current ?? 0) + elapsed;
   }, []);
 
+  const registerFrameCallback = useCallback((id: string, cb: (data: FrameData) => void) => {
+    frameCallbacksRef.current.set(id, cb);
+  }, []);
+
+  const unregisterFrameCallback = useCallback((id: string) => {
+    frameCallbacksRef.current.delete(id);
+  }, []);
+
   // Animation loop
   const startAnimationLoop = useCallback(() => {
     const updateTime = () => {
       // Get current time from engine (auto-wraps at loop boundaries via Transport.seconds)
       const time = getPlaybackTime();
       currentTimeRef.current = time;
+
+      // Compute visual time once — all visual consumers use this same value.
+      // Subtracts outputLatency so DOM positions match speaker output.
+      const ctx = getGlobalAudioContext();
+      const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
+      const visualTime = Math.max(0, time - latency);
 
       // Handle annotation playback based on continuous play mode
       const currentAnnotations = annotationsRef.current;
@@ -1052,15 +1084,10 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         }
       }
 
-      // Handle automatic scroll - continuously center the playhead.
-      // Use outputLatency-compensated time so scroll aligns with the visual
-      // playhead position (AnimatedPlayhead applies the same offset).
+      // Handle automatic scroll — uses shared visualTime for alignment with playhead
       if (isAutomaticScrollRef.current && scrollContainerRef.current && duration > 0) {
         const container = scrollContainerRef.current;
         const sr = sampleRateRef.current;
-        const ctx = getGlobalAudioContext();
-        const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
-        const visualTime = Math.max(0, time - latency);
         const pixelPosition = (visualTime * sr) / samplesPerPixelRef.current;
         const containerWidth = container.clientWidth;
 
@@ -1097,6 +1124,14 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
         setActiveAnnotationId(null);
         return;
       }
+      // Drive registered per-frame callbacks (playhead, progress overlays, time display)
+      const sr = sampleRateRef.current;
+      const spp = samplesPerPixelRef.current;
+      const frameData: FrameData = { time, visualTime, sampleRate: sr, samplesPerPixel: spp };
+      for (const cb of frameCallbacksRef.current.values()) {
+        cb(frameData);
+      }
+
       startAnimationFrameLoop(updateTime);
     };
     startAnimationFrameLoop(updateTime);
@@ -1405,6 +1440,8 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       playbackStartTimeRef,
       audioStartPositionRef,
       getPlaybackTime,
+      registerFrameCallback,
+      unregisterFrameCallback,
     }),
     [
       isPlaying,
@@ -1413,6 +1450,8 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
       playbackStartTimeRef,
       audioStartPositionRef,
       getPlaybackTime,
+      registerFrameCallback,
+      unregisterFrameCallback,
     ]
   );
 

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -376,7 +376,6 @@ export const WaveformPlaylistProvider: React.FC<WaveformPlaylistProviderProps> =
   const isAutomaticScrollRef = useRef<boolean>(false);
   // Animation frame callback registry — components register per-frame DOM update
   // callbacks instead of running their own rAF loops. Single loop drives all.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const frameCallbacksRef = useRef<Map<string, (data: FrameData) => void>>(new Map());
   const continuousPlayRef = useRef<boolean>(annotationList?.isContinuousPlay ?? false);
   const activeAnnotationIdRef = useRef<string | null>(null);

--- a/packages/browser/src/components/AnimatedPlayhead.tsx
+++ b/packages/browser/src/components/AnimatedPlayhead.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { usePlaybackAnimation, usePlaylistData } from '../WaveformPlaylistContext';
-import { getGlobalAudioContext } from '@waveform-playlist/playout';
 
 const PlayheadLine = styled.div.attrs<{ $color: string; $width: number }>((props) => ({
   style: {
@@ -23,53 +22,31 @@ interface AnimatedPlayheadProps {
 }
 
 /**
- * Animated playhead that updates position via direct DOM manipulation.
- * Reads playback time from the engine via getPlaybackTime() for Transport-synced positioning.
- * Uses requestAnimationFrame for smooth 60fps animation without React re-renders.
+ * Animated playhead that updates position via the shared animation frame registry.
+ * No own rAF loop — the WaveformPlaylistContext animation loop drives all visual updates.
  */
 export const AnimatedPlayhead: React.FC<AnimatedPlayheadProps> = ({ color = '#ff0000' }) => {
   const playheadRef = useRef<HTMLDivElement>(null);
-  const animationFrameRef = useRef<number | null>(null);
 
-  const { isPlaying, currentTimeRef, getPlaybackTime } = usePlaybackAnimation();
+  const { isPlaying, currentTimeRef, registerFrameCallback, unregisterFrameCallback } =
+    usePlaybackAnimation();
   const { samplesPerPixel, sampleRate, progressBarWidth } = usePlaylistData();
 
+  // Register per-frame callback during playback
   useEffect(() => {
-    const updatePosition = () => {
-      if (playheadRef.current) {
-        let time = isPlaying ? getPlaybackTime() : (currentTimeRef.current ?? 0);
-        // Subtract outputLatency during playback so playhead matches when audio
-        // reaches speakers. Do NOT compensate when stopped (currentTimeRef must
-        // stay raw — shifting it would cause play() to start from the wrong time).
-        if (isPlaying) {
-          const ctx = getGlobalAudioContext();
-          const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
-          time = Math.max(0, time - latency);
-        }
-        const position = (time * sampleRate) / samplesPerPixel;
-        playheadRef.current.style.transform = `translate3d(${position}px, 0, 0)`;
-      }
-
-      if (isPlaying) {
-        animationFrameRef.current = requestAnimationFrame(updatePosition);
-      }
-    };
-
+    const id = 'playhead';
     if (isPlaying) {
-      animationFrameRef.current = requestAnimationFrame(updatePosition);
-    } else {
-      updatePosition();
+      registerFrameCallback(id, ({ visualTime }) => {
+        if (playheadRef.current) {
+          const px = (visualTime * sampleRate) / samplesPerPixel;
+          playheadRef.current.style.transform = `translate3d(${px}px, 0, 0)`;
+        }
+      });
     }
+    return () => unregisterFrameCallback(id);
+  }, [isPlaying, sampleRate, samplesPerPixel, registerFrameCallback, unregisterFrameCallback]);
 
-    return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
-    };
-  }, [isPlaying, sampleRate, samplesPerPixel, currentTimeRef, getPlaybackTime]);
-
-  // Also update position when not playing (for seeks, stops, etc.)
+  // Update position when not playing (seeks, stops, etc.) — no rAF needed
   useEffect(() => {
     if (!isPlaying && playheadRef.current) {
       const time = currentTimeRef.current ?? 0;

--- a/packages/browser/src/components/AnimatedPlayhead.tsx
+++ b/packages/browser/src/components/AnimatedPlayhead.tsx
@@ -36,15 +36,15 @@ export const AnimatedPlayhead: React.FC<AnimatedPlayheadProps> = ({ color = '#ff
   useEffect(() => {
     const id = 'playhead';
     if (isPlaying) {
-      registerFrameCallback(id, ({ visualTime }) => {
+      registerFrameCallback(id, ({ visualTime, sampleRate: sr, samplesPerPixel: spp }) => {
         if (playheadRef.current) {
-          const px = (visualTime * sampleRate) / samplesPerPixel;
+          const px = (visualTime * sr) / spp;
           playheadRef.current.style.transform = `translate3d(${px}px, 0, 0)`;
         }
       });
     }
     return () => unregisterFrameCallback(id);
-  }, [isPlaying, sampleRate, samplesPerPixel, registerFrameCallback, unregisterFrameCallback]);
+  }, [isPlaying, registerFrameCallback, unregisterFrameCallback]);
 
   // Update position when not playing (seeks, stops, etc.) — no rAF needed
   useEffect(() => {

--- a/packages/browser/src/components/ChannelWithProgress.tsx
+++ b/packages/browser/src/components/ChannelWithProgress.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useId, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import {
   clipPixelWidth as computeClipPixelWidth,
@@ -98,6 +98,7 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
   ...smartChannelProps
 }) => {
   const progressRef = useRef<HTMLDivElement>(null);
+  const callbackId = useId();
   const theme = useTheme() as WaveformPlaylistTheme;
   const { waveHeight } = usePlaylistInfo();
 
@@ -117,9 +118,8 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
 
   // Register per-frame callback during playback — no own rAF loop
   useEffect(() => {
-    const id = 'progress-' + clipStartSample + '-' + clipDurationSamples;
     if (isPlaying) {
-      registerFrameCallback(id, ({ visualTime }) => {
+      registerFrameCallback(callbackId, ({ visualTime }) => {
         if (progressRef.current) {
           const currentSample = visualTime * sampleRate;
           const clipEndSample = clipStartSample + clipDurationSamples;
@@ -139,12 +139,13 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
         }
       });
     }
-    return () => unregisterFrameCallback(id);
+    return () => unregisterFrameCallback(callbackId);
   }, [
     isPlaying,
     sampleRate,
     clipStartSample,
     clipDurationSamples,
+    callbackId,
     registerFrameCallback,
     unregisterFrameCallback,
   ]);

--- a/packages/browser/src/components/ChannelWithProgress.tsx
+++ b/packages/browser/src/components/ChannelWithProgress.tsx
@@ -4,7 +4,6 @@ import {
   clipPixelWidth as computeClipPixelWidth,
   type MidiNoteData,
 } from '@waveform-playlist/core';
-import { getGlobalAudioContext } from '@waveform-playlist/playout';
 import {
   SmartChannel,
   type SmartChannelProps,
@@ -99,11 +98,11 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
   ...smartChannelProps
 }) => {
   const progressRef = useRef<HTMLDivElement>(null);
-  const animationFrameRef = useRef<number | null>(null);
   const theme = useTheme() as WaveformPlaylistTheme;
   const { waveHeight } = usePlaylistInfo();
 
-  const { isPlaying, currentTimeRef, getPlaybackTime } = usePlaybackAnimation();
+  const { isPlaying, currentTimeRef, registerFrameCallback, unregisterFrameCallback } =
+    usePlaybackAnimation();
   const { samplesPerPixel, sampleRate } = usePlaylistData();
 
   const progressColor = theme?.waveProgressColor || 'rgba(0, 0, 0, 0.1)';
@@ -116,58 +115,38 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
     samplesPerPixel
   );
 
+  // Register per-frame callback during playback — no own rAF loop
   useEffect(() => {
-    const updateProgress = () => {
-      if (progressRef.current) {
-        let currentTime = isPlaying ? getPlaybackTime() : (currentTimeRef.current ?? 0);
-        // Subtract outputLatency during playback so progress matches speaker output
-        if (isPlaying) {
-          const ctx = getGlobalAudioContext();
-          const latency = 'outputLatency' in ctx ? (ctx as AudioContext).outputLatency : 0;
-          currentTime = Math.max(0, currentTime - latency);
-        }
-        const currentSample = currentTime * sampleRate;
-        const clipEndSample = clipStartSample + clipDurationSamples;
-
-        let ratio = 0;
-        if (currentSample <= clipStartSample) {
-          ratio = 0;
-        } else if (currentSample >= clipEndSample) {
-          ratio = 1;
-        } else {
-          const playedSamples = currentSample - clipStartSample;
-          ratio = playedSamples / clipDurationSamples;
-        }
-
-        // scaleX is composite-only — no layout reflow, GPU-accelerated
-        progressRef.current.style.transform = `scaleX(${ratio})`;
-      }
-
-      if (isPlaying) {
-        animationFrameRef.current = requestAnimationFrame(updateProgress);
-      }
-    };
-
+    const id = 'progress-' + clipStartSample + '-' + clipDurationSamples;
     if (isPlaying) {
-      animationFrameRef.current = requestAnimationFrame(updateProgress);
-    } else {
-      updateProgress();
-    }
+      registerFrameCallback(id, ({ visualTime }) => {
+        if (progressRef.current) {
+          const currentSample = visualTime * sampleRate;
+          const clipEndSample = clipStartSample + clipDurationSamples;
 
-    return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
-    };
+          let ratio = 0;
+          if (currentSample <= clipStartSample) {
+            ratio = 0;
+          } else if (currentSample >= clipEndSample) {
+            ratio = 1;
+          } else {
+            const playedSamples = currentSample - clipStartSample;
+            ratio = playedSamples / clipDurationSamples;
+          }
+
+          // scaleX is composite-only — no layout reflow, GPU-accelerated
+          progressRef.current.style.transform = `scaleX(${ratio})`;
+        }
+      });
+    }
+    return () => unregisterFrameCallback(id);
   }, [
     isPlaying,
     sampleRate,
     clipStartSample,
     clipDurationSamples,
-    clipPixelWidth,
-    currentTimeRef,
-    getPlaybackTime,
+    registerFrameCallback,
+    unregisterFrameCallback,
   ]);
 
   // Also update when not playing (for seeks, stops, etc.)

--- a/packages/browser/src/components/ChannelWithProgress.tsx
+++ b/packages/browser/src/components/ChannelWithProgress.tsx
@@ -87,7 +87,7 @@ export interface ChannelWithProgressProps extends SmartChannelProps {
 /**
  * SmartChannel wrapper that adds an animated progress overlay.
  * The progress overlay shows the "played" portion of the waveform.
- * Uses requestAnimationFrame for smooth 60fps animation without React re-renders.
+ * Updates via the shared animation frame registry — no own rAF loop.
  */
 export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
   clipStartSample,
@@ -119,9 +119,9 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
   // Register per-frame callback during playback — no own rAF loop
   useEffect(() => {
     if (isPlaying) {
-      registerFrameCallback(callbackId, ({ visualTime }) => {
+      registerFrameCallback(callbackId, ({ visualTime, sampleRate: sr }) => {
         if (progressRef.current) {
-          const currentSample = visualTime * sampleRate;
+          const currentSample = visualTime * sr;
           const clipEndSample = clipStartSample + clipDurationSamples;
 
           let ratio = 0;
@@ -142,7 +142,6 @@ export const ChannelWithProgress: React.FC<ChannelWithProgressProps> = ({
     return () => unregisterFrameCallback(callbackId);
   }, [
     isPlaying,
-    sampleRate,
     clipStartSample,
     clipDurationSamples,
     callbackId,

--- a/packages/browser/src/components/ContextualControls.tsx
+++ b/packages/browser/src/components/ContextualControls.tsx
@@ -55,35 +55,22 @@ const PositionDisplay = styled.span`
  */
 export const AudioPosition: React.FC<{ className?: string }> = ({ className }) => {
   const timeRef = useRef<HTMLSpanElement>(null);
-  const animationFrameRef = useRef<number | null>(null);
-  const { isPlaying, currentTimeRef, getPlaybackTime } = usePlaybackAnimation();
+  const { isPlaying, currentTimeRef, registerFrameCallback, unregisterFrameCallback } =
+    usePlaybackAnimation();
   const { timeFormat: format } = usePlaylistData();
 
+  // Register per-frame callback during playback — uses raw time for display
   useEffect(() => {
-    const updateTime = () => {
-      if (timeRef.current) {
-        const time = isPlaying ? getPlaybackTime() : (currentTimeRef.current ?? 0);
-        timeRef.current.textContent = formatTime(time, format);
-      }
-
-      if (isPlaying) {
-        animationFrameRef.current = requestAnimationFrame(updateTime);
-      }
-    };
-
+    const id = 'audio-position';
     if (isPlaying) {
-      animationFrameRef.current = requestAnimationFrame(updateTime);
-    } else {
-      updateTime();
+      registerFrameCallback(id, ({ time }) => {
+        if (timeRef.current) {
+          timeRef.current.textContent = formatTime(time, format);
+        }
+      });
     }
-
-    return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
-    };
-  }, [isPlaying, format, currentTimeRef, getPlaybackTime]);
+    return () => unregisterFrameCallback(id);
+  }, [isPlaying, format, registerFrameCallback, unregisterFrameCallback]);
 
   // Update when stopped (for seeks)
   useEffect(() => {

--- a/packages/browser/src/components/ContextualControls.tsx
+++ b/packages/browser/src/components/ContextualControls.tsx
@@ -50,7 +50,7 @@ const PositionDisplay = styled.span`
 
 /**
  * Audio position display that uses the playlist context.
- * Uses requestAnimationFrame for smooth 60fps updates during playback.
+ * Updates via the shared animation frame registry — no own rAF loop.
  * Direct DOM manipulation avoids React re-renders.
  */
 export const AudioPosition: React.FC<{ className?: string }> = ({ className }) => {

--- a/packages/browser/src/index.tsx
+++ b/packages/browser/src/index.tsx
@@ -13,7 +13,7 @@ export {
   usePlaylistControls,
   usePlaylistData,
 } from './WaveformPlaylistContext';
-export type { WaveformTrack, TrackState } from './WaveformPlaylistContext';
+export type { WaveformTrack, TrackState, FrameData } from './WaveformPlaylistContext';
 
 // Export MediaElement-based provider (single-track with playback rate control)
 export {

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -50,6 +50,7 @@ Each example page should have OG/Twitter meta tags with a social image. Pattern:
 
 - **Multi-track examples must use `deferEngineRebuild={loading}`** — Without it, the engine rebuilds on every track decode (up to N times for N tracks), creating race conditions that cause duplicate audio on play/pause/play cycles.
 - **Tone.js in example components must use dynamic import** — `import * as Tone from 'tone'` triggers AudioWorklet errors on page load. Use `import type * as ToneNs from 'tone'` for types, then `const Tone = await import('tone')` inside effects after `AudioContext.state === 'running'`.
+- **Examples must pass `onTracksChange` to `WaveformPlaylistProvider`** — Without it, engine track mutations (from statechange) trigger "UI will revert on next render" warning. On the next React render, old tracks are passed back, causing engine rebuild mid-playback (audio interruption, playhead jitter). The only exception is truly read-only examples with no interactive clips or track mutations.
 
 ## Guide Documentation Drift
 


### PR DESCRIPTION
## Summary

- Replace 4+ independent rAF loops with a single animation frame registry
- Components register per-frame callbacks instead of running their own loops
- `FrameData` provides `time` (raw) and `visualTime` (latency-compensated) computed once per frame

### Before
- 1 playhead rAF + N progress overlay rAFs + 1 audio position rAF = N+2 loops during playback
- Each loop independently calls `getPlaybackTime()` and computes `outputLatency`

### After
- 1 animation loop drives all visual updates via callback registry
- `registerFrameCallback(id, cb)` / `unregisterFrameCallback(id)` on `PlaybackAnimationContextValue`

### Components updated
- `AnimatedPlayhead` — registers callback, removes own rAF
- `ChannelWithProgress` — registers callback per clip, removes own rAF
- `AudioPosition` — registers callback, removes own rAF
- Auto-scroll — uses shared `visualTime` instead of computing its own

### Known issue
- Canvas boundary jitter during auto-scroll is pre-existing and not fully resolved by this change
- Likely caused by ViewportStore's 2-frame rAF pipeline (scroll → measure → notify)

## Test plan
- [ ] `cd packages/browser && npx vitest run` — 194 tests pass
- [ ] Playhead tracks audio during playback
- [ ] Progress overlays update correctly
- [ ] Time display updates during playback
- [ ] Auto-scroll centers playhead
- [ ] Stop/seek positions correctly (no drift from outputLatency)