### PR TITLE
fix(website): add onTracksChange and parallel file decode to examples

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -51,6 +51,7 @@ Each example page should have OG/Twitter meta tags with a social image. Pattern:
 - **Multi-track examples must use `deferEngineRebuild={loading}`** — Without it, the engine rebuilds on every track decode (up to N times for N tracks), creating race conditions that cause duplicate audio on play/pause/play cycles.
 - **Tone.js in example components must use dynamic import** — `import * as Tone from 'tone'` triggers AudioWorklet errors on page load. Use `import type * as ToneNs from 'tone'` for types, then `const Tone = await import('tone')` inside effects after `AudioContext.state === 'running'`.
 - **Examples must pass `onTracksChange` to `WaveformPlaylistProvider`** — Without it, engine track mutations (from statechange) trigger "UI will revert on next render" warning. On the next React render, old tracks are passed back, causing engine rebuild mid-playback (audio interruption, playhead jitter). The only exception is truly read-only examples with no interactive clips or track mutations.
+- **Use `decodeAudioFiles()` for file drop** — `website/src/utils/decodeAudioFiles.ts` decodes files in parallel and returns `ClipTrack[]`. Accepts `trackDefaults` for per-example options. Do not write sequential `for-await` decode loops — they cause N engine rebuilds for N dropped files.
 
 ## Guide Documentation Drift
 

--- a/website/src/components/examples/AnnotationsExample.tsx
+++ b/website/src/components/examples/AnnotationsExample.tsx
@@ -5,6 +5,7 @@ import { DragDropProvider } from '@dnd-kit/react';
 import { RestrictToHorizontalAxis } from '@dnd-kit/abstract/modifiers';
 import * as Tone from 'tone';
 import { createTrack, createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
+import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 import {
   WaveformPlaylistProvider,
   PlayButton,
@@ -463,57 +464,19 @@ const AnnotationsAppContent: React.FC<AnnotationsAppContentProps> = ({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [addAnnotationAtPlayhead]);
 
-  // Load audio files PROGRESSIVELY - each track appears as it loads
-  const loadAudioFiles = async (files: File[]) => {
-    setIsLoadingAudio(true);
-    const audioContext = Tone.getContext().rawContext as AudioContext;
-    const audioFiles = Array.from(files).filter((file) =>
-      file.type.startsWith('audio/')
-    );
-
-    // Load each file independently (not Promise.all) so tracks appear one by one
-    audioFiles.forEach(async (file) => {
-      try {
-        const arrayBuffer = await file.arrayBuffer();
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-        const clip = createClipFromSeconds({
-          audioBuffer,
-          startTime: 0,
-          duration: audioBuffer.duration,
-          offset: 0,
-          name: file.name.replace(/\.[^/.]+$/, ''),
-        });
-
-        const newTrack = createTrack({
-          name: file.name.replace(/\.[^/.]+$/, ''),
-          clips: [clip],
-          muted: false,
-          soloed: false,
-          volume: 1,
-          pan: 0,
-        });
-
-        // Add this track immediately - use callback form to get latest tracks
-        onTracksChange(prevTracks => [...prevTracks, newTrack]);
-      } catch (error) {
-        console.error('Error loading audio file:', file.name, error);
-      }
-    });
-
-    // Clear loading state after a short delay (files load asynchronously)
-    setTimeout(() => setIsLoadingAudio(false), 500);
-  };
-
   // Handle dropped/selected audio files
   const handleFiles = useCallback(
-    (files: File[]) => {
+    async (files: File[]) => {
       const audioFiles = files.filter((f) => f.type.startsWith('audio/'));
-      if (audioFiles.length > 0) {
-        loadAudioFiles(audioFiles);
-      }
+      if (audioFiles.length === 0) return;
+
+      setIsLoadingAudio(true);
+      const audioContext = Tone.getContext().rawContext as AudioContext;
+      const newTracks = await decodeAudioFiles(audioContext, audioFiles);
+      if (newTracks.length > 0) onTracksChange(prevTracks => [...prevTracks, ...newTracks]);
+      setIsLoadingAudio(false);
     },
-    [tracks]
+    [onTracksChange]
   );
 
   // Handle JSON upload

--- a/website/src/components/examples/EffectsExample.tsx
+++ b/website/src/components/examples/EffectsExample.tsx
@@ -4,6 +4,7 @@ import { FileDropZone } from '../FileDropZone';
 
 import JSZip from 'jszip';
 import { type ClipTrack } from '@waveform-playlist/core';
+import { getGlobalAudioContext } from '@waveform-playlist/playout';
 import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 import {
   WaveformPlaylistProvider,
@@ -507,7 +508,7 @@ const EffectsControls: React.FC<EffectsControlsProps> = ({
     const audioFiles = files.filter(file => file.type.startsWith('audio/'));
     if (audioFiles.length === 0) return;
 
-    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const audioContext = getGlobalAudioContext();
     const newTracks = await decodeAudioFiles(audioContext, audioFiles);
     if (newTracks.length > 0) onAddTracks(newTracks);
   }, [onAddTracks]);

--- a/website/src/components/examples/EffectsExample.tsx
+++ b/website/src/components/examples/EffectsExample.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 import { FileDropZone } from '../FileDropZone';
 
 import JSZip from 'jszip';
-import { createTrack, createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
+import { type ClipTrack } from '@waveform-playlist/core';
+import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 import {
   WaveformPlaylistProvider,
   Waveform,
@@ -507,37 +508,8 @@ const EffectsControls: React.FC<EffectsControlsProps> = ({
     if (audioFiles.length === 0) return;
 
     const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
-    const newTracks: ClipTrack[] = [];
-
-    for (const file of audioFiles) {
-      try {
-        const arrayBuffer = await file.arrayBuffer();
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-        const clip = createClipFromSeconds({
-          audioBuffer,
-          startTime: 0,
-          name: file.name,
-        });
-
-        const newTrack = createTrack({
-          name: file.name.replace(/\.[^/.]+$/, ''),
-          clips: [clip],
-          muted: false,
-          soloed: false,
-          volume: 1.0,
-          pan: 0,
-        });
-
-        newTracks.push(newTrack);
-      } catch (error) {
-        console.error('Error loading audio file:', file.name, error);
-      }
-    }
-
-    if (newTracks.length > 0) {
-      onAddTracks(newTracks);
-    }
+    const newTracks = await decodeAudioFiles(audioContext, audioFiles);
+    if (newTracks.length > 0) onAddTracks(newTracks);
   }, [onAddTracks]);
 
   return (
@@ -766,6 +738,7 @@ export function EffectsExample() {
       <WaveformPlaylistProvider
         tracks={tracksWithEffects}
         sampleRate={48000}
+        onTracksChange={setTracks}
         samplesPerPixel={512}
         zoomLevels={[256, 512, 1024, 2048, 4096]}
         waveHeight={100}

--- a/website/src/components/examples/MidiExample.tsx
+++ b/website/src/components/examples/MidiExample.tsx
@@ -21,11 +21,11 @@ import {
   usePlaylistControls,
 } from '@waveform-playlist/browser';
 import type { WaveformPlaylistTheme } from '@waveform-playlist/ui-components';
-import { createTrack, createClipFromSeconds } from '@waveform-playlist/core';
 import type { ClipTrack } from '@waveform-playlist/core';
 import { useMidiTracks } from '@waveform-playlist/midi';
 import type { MidiTrackConfig } from '@waveform-playlist/midi';
 import { SoundFontCache, getGlobalAudioContext } from '@waveform-playlist/playout';
+import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 import { useDocusaurusTheme } from '../../hooks/useDocusaurusTheme';
 import { FileDropZone } from '../FileDropZone';
 
@@ -320,21 +320,8 @@ export function MidiExample() {
 
   const addAudioFiles = React.useCallback(async (files: File[]) => {
     const audioContext = Tone.getContext().rawContext as AudioContext;
-    for (const file of files) {
-      const arrayBuffer = await file.arrayBuffer();
-      const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-      const clip = createClipFromSeconds({
-        audioBuffer,
-        startTime: 0,
-        duration: audioBuffer.duration,
-        offset: 0,
-      });
-      const newTrack = createTrack({
-        name: file.name.replace(/\.[^/.]+$/, ''),
-        clips: [clip],
-      });
-      setUserAudioTracks((prev) => [...prev, newTrack]);
-    }
+    const newTracks = await decodeAudioFiles(audioContext, files);
+    if (newTracks.length > 0) setUserAudioTracks((prev) => [...prev, ...newTracks]);
   }, []);
 
   const handleFiles = React.useCallback(
@@ -365,6 +352,14 @@ export function MidiExample() {
     setUserAudioTracks([]);
     setRemovedTrackIds(new Set());
   }, []);
+
+  // Mirror engine mutations back to userAudioTracks state.
+  // MIDI tracks (in allTracks) are managed by useMidiTracks; only audio tracks are updated.
+  const handleTracksChange = React.useCallback((updatedTracks: ClipTrack[]) => {
+    const midiTrackIds = new Set(allTracks.map((t) => t.id));
+    const updatedAudioTracks = updatedTracks.filter((t) => !midiTrackIds.has(t.id));
+    setUserAudioTracks(updatedAudioTracks);
+  }, [allTracks]);
 
   if (error) {
     return (
@@ -409,6 +404,7 @@ export function MidiExample() {
         <WaveformPlaylistProvider
           tracks={filteredTracks}
           sampleRate={48000}
+          onTracksChange={handleTracksChange}
           samplesPerPixel={2048}
           mono
           theme={{ ...theme, ...gradientTheme }}

--- a/website/src/components/examples/MirSpectrogramExample.tsx
+++ b/website/src/components/examples/MirSpectrogramExample.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import * as Tone from 'tone';
 import {
@@ -94,10 +94,12 @@ export function MirSpectrogramExample() {
   const { tracks: baseTracks, loading, error } = useAudioTracks(AUDIO_CONFIGS, { immediate: true });
 
   // Seed tracks from baseTracks when loading completes (once)
-  if (!loading && baseTracks.length > 0 && !baseTracksLoadedRef.current) {
-    baseTracksLoadedRef.current = true;
-    setTracks(baseTracks);
-  }
+  useEffect(() => {
+    if (!loading && baseTracks.length > 0 && !baseTracksLoadedRef.current) {
+      baseTracksLoadedRef.current = true;
+      setTracks(baseTracks);
+    }
+  }, [loading, baseTracks]);
 
   const handleRemoveTrack = useCallback((index: number) => {
     setTracks(prev => prev.filter((_, i) => i !== index));

--- a/website/src/components/examples/MirSpectrogramExample.tsx
+++ b/website/src/components/examples/MirSpectrogramExample.tsx
@@ -17,11 +17,11 @@ import {
   KeyboardShortcuts,
 } from '@waveform-playlist/browser';
 import type { SpectrogramConfig, RenderMode, ClipTrack } from '@waveform-playlist/core';
-import { createTrack, createClipFromSeconds } from '@waveform-playlist/core';
 import { SpectrogramProvider } from '@waveform-playlist/spectrogram';
 import type { AudioTrackConfig } from '@waveform-playlist/browser';
 import { useDocusaurusTheme } from '../../hooks/useDocusaurusTheme';
 import { FileDropZone } from '../FileDropZone';
+import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 
 const Container = styled.div`
   max-width: 1400px;
@@ -109,37 +109,9 @@ export function MirSpectrogramExample() {
 
   const addFiles = async (files: File[]) => {
     const audioContext = Tone.getContext().rawContext as AudioContext;
-    // Decode all files in parallel, then add all tracks at once
-    // (avoids N engine rebuilds for N dropped files)
-    const results = await Promise.allSettled(
-      files.map(async (file) => {
-        const arrayBuffer = await file.arrayBuffer();
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-        const clip = createClipFromSeconds({
-          audioBuffer,
-          startTime: 0,
-          duration: audioBuffer.duration,
-          offset: 0,
-          name: file.name.replace(/\.[^/.]+$/, ''),
-        });
-        return createTrack({
-          name: file.name.replace(/\.[^/.]+$/, ''),
-          clips: [clip],
-          muted: false,
-          soloed: false,
-          volume: 1,
-          pan: 0,
-          spectrogramConfig: DEFAULT_SPECTROGRAM_CONFIG,
-        });
-      })
-    );
-    const newTracks = results
-      .filter((r): r is PromiseFulfilledResult<ClipTrack> => r.status === 'fulfilled')
-      .map((r) => r.value);
-    const failed = results.filter((r) => r.status === 'rejected');
-    for (const f of failed) {
-      console.error('Error loading audio file:', (f as PromiseRejectedResult).reason);
-    }
+    const newTracks = await decodeAudioFiles(audioContext, files, {
+      trackDefaults: { spectrogramConfig: DEFAULT_SPECTROGRAM_CONFIG },
+    });
     if (newTracks.length > 0) {
       setTracks((prev) => [...prev, ...newTracks]);
     }

--- a/website/src/components/examples/MirSpectrogramExample.tsx
+++ b/website/src/components/examples/MirSpectrogramExample.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import * as Tone from 'tone';
 import {
@@ -88,26 +88,24 @@ const AUDIO_CONFIGS: AudioTrackConfig[] = TRACK_CONFIGS.map((tc) => ({
 
 export function MirSpectrogramExample() {
   const { theme } = useDocusaurusTheme();
-  const [userTracks, setUserTracks] = useState<ClipTrack[]>([]);
-  const [removedBaseIds, setRemovedBaseIds] = useState<Set<string>>(new Set());
+  const [tracks, setTracks] = useState<ClipTrack[]>([]);
+  const baseTracksLoadedRef = useRef(false);
 
   const { tracks: baseTracks, loading, error } = useAudioTracks(AUDIO_CONFIGS, { immediate: true });
 
-  const filteredBaseTracks = baseTracks.filter(t => !removedBaseIds.has(t.id));
-  const allTracks = [...filteredBaseTracks, ...userTracks];
+  // Seed tracks from baseTracks when loading completes (once)
+  if (!loading && baseTracks.length > 0 && !baseTracksLoadedRef.current) {
+    baseTracksLoadedRef.current = true;
+    setTracks(baseTracks);
+  }
 
   const handleRemoveTrack = useCallback((index: number) => {
-    if (index < filteredBaseTracks.length) {
-      setRemovedBaseIds(prev => new Set([...prev, filteredBaseTracks[index].id]));
-    } else {
-      setUserTracks(prev => prev.filter((_, i) => i !== index - filteredBaseTracks.length));
-    }
-  }, [filteredBaseTracks]);
+    setTracks(prev => prev.filter((_, i) => i !== index));
+  }, []);
 
   const handleClearAll = useCallback(() => {
-    setUserTracks([]);
-    setRemovedBaseIds(new Set(baseTracks.map(t => t.id)));
-  }, [baseTracks]);
+    setTracks([]);
+  }, []);
 
   const addFiles = async (files: File[]) => {
     const audioContext = Tone.getContext().rawContext as AudioContext;
@@ -131,7 +129,7 @@ export function MirSpectrogramExample() {
           pan: 0,
           spectrogramConfig: DEFAULT_SPECTROGRAM_CONFIG,
         });
-        setUserTracks(prev => [...prev, newTrack]);
+        setTracks(prev => [...prev, newTrack]);
       } catch (err) {
         console.error('Error loading audio file:', file.name, err);
       }
@@ -153,9 +151,10 @@ export function MirSpectrogramExample() {
 
       {loading && <div style={{ padding: '1rem', opacity: 0.7 }}>Loading tracks...</div>}
 
-      {allTracks.length > 0 && (
+      {tracks.length > 0 && (
         <WaveformPlaylistProvider
-          tracks={allTracks}
+          tracks={tracks}
+          onTracksChange={setTracks}
           sampleRate={48000}
           theme={theme}
           timescale

--- a/website/src/components/examples/MirSpectrogramExample.tsx
+++ b/website/src/components/examples/MirSpectrogramExample.tsx
@@ -109,8 +109,10 @@ export function MirSpectrogramExample() {
 
   const addFiles = async (files: File[]) => {
     const audioContext = Tone.getContext().rawContext as AudioContext;
-    for (const file of files) {
-      try {
+    // Decode all files in parallel, then add all tracks at once
+    // (avoids N engine rebuilds for N dropped files)
+    const results = await Promise.allSettled(
+      files.map(async (file) => {
         const arrayBuffer = await file.arrayBuffer();
         const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
         const clip = createClipFromSeconds({
@@ -120,7 +122,7 @@ export function MirSpectrogramExample() {
           offset: 0,
           name: file.name.replace(/\.[^/.]+$/, ''),
         });
-        const newTrack = createTrack({
+        return createTrack({
           name: file.name.replace(/\.[^/.]+$/, ''),
           clips: [clip],
           muted: false,
@@ -129,10 +131,17 @@ export function MirSpectrogramExample() {
           pan: 0,
           spectrogramConfig: DEFAULT_SPECTROGRAM_CONFIG,
         });
-        setTracks(prev => [...prev, newTrack]);
-      } catch (err) {
-        console.error('Error loading audio file:', file.name, err);
-      }
+      })
+    );
+    const newTracks = results
+      .filter((r): r is PromiseFulfilledResult<ClipTrack> => r.status === 'fulfilled')
+      .map((r) => r.value);
+    const failed = results.filter((r) => r.status === 'rejected');
+    for (const f of failed) {
+      console.error('Error loading audio file:', (f as PromiseRejectedResult).reason);
+    }
+    if (newTracks.length > 0) {
+      setTracks((prev) => [...prev, ...newTracks]);
     }
   };
 

--- a/website/src/components/examples/RecordingExample.tsx
+++ b/website/src/components/examples/RecordingExample.tsx
@@ -14,8 +14,9 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import styled from 'styled-components';
 import { Theme, Button, Text } from '@radix-ui/themes';
 import '@radix-ui/themes/styles.css';
-import { createTrack, createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
+import { createTrack, type ClipTrack } from '@waveform-playlist/core';
 import { getGlobalAudioContext } from '@waveform-playlist/playout';
+import { decodeAudioFiles } from '../../utils/decodeAudioFiles';
 import {
   WaveformPlaylistProvider,
   Waveform,
@@ -389,30 +390,10 @@ const RecordingControlsInner: React.FC<RecordingControlsInnerProps> = ({
       if (audioFiles.length === 0) return;
 
       const audioContext = getGlobalAudioContext();
-
-      for (const file of audioFiles) {
-        const arrayBuffer = await file.arrayBuffer();
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-        const clip = createClipFromSeconds({
-          audioBuffer,
-          startTime: 0,
-          name: file.name,
-        });
-
-        const newTrack = createTrack({
-          name: file.name,
-          clips: [clip],
-          muted: false,
-          soloed: false,
-          volume: 1.0,
-          pan: 0,
-        });
-
-        setTracks([...tracks, newTrack]);
-      }
+      const newTracks = await decodeAudioFiles(audioContext, audioFiles);
+      if (newTracks.length > 0) setTracks(prev => [...prev, ...newTracks]);
     },
-    [tracks, setTracks]
+    [setTracks]
   );
 
   const handleRemoveTrack = useCallback(

--- a/website/src/utils/decodeAudioFiles.ts
+++ b/website/src/utils/decodeAudioFiles.ts
@@ -1,0 +1,55 @@
+import { createTrack, createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
+
+export interface DecodeOptions {
+  /** Extra properties merged into each createTrack call (e.g., spectrogramConfig). */
+  trackDefaults?: Partial<ClipTrack>;
+}
+
+/**
+ * Decode audio files in parallel and return an array of ClipTracks.
+ * Failed decodes are logged and skipped — only successful tracks are returned.
+ *
+ * Usage:
+ *   const newTracks = await decodeAudioFiles(audioContext, files);
+ *   setTracks(prev => [...prev, ...newTracks]);
+ */
+export async function decodeAudioFiles(
+  audioContext: AudioContext,
+  files: File[],
+  options?: DecodeOptions,
+): Promise<ClipTrack[]> {
+  const results = await Promise.allSettled(
+    files.map(async (file) => {
+      const arrayBuffer = await file.arrayBuffer();
+      const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+      const name = file.name.replace(/\.[^/.]+$/, '');
+      const clip = createClipFromSeconds({
+        audioBuffer,
+        startTime: 0,
+        duration: audioBuffer.duration,
+        offset: 0,
+        name,
+      });
+      return createTrack({
+        name,
+        clips: [clip],
+        muted: false,
+        soloed: false,
+        volume: 1,
+        pan: 0,
+        ...options?.trackDefaults,
+      });
+    }),
+  );
+
+  const tracks = results
+    .filter((r): r is PromiseFulfilledResult<ClipTrack> => r.status === 'fulfilled')
+    .map((r) => r.value);
+
+  const failed = results.filter((r) => r.status === 'rejected');
+  for (const f of failed) {
+    console.error('[waveform-playlist] Error decoding audio file:', (f as PromiseRejectedResult).reason);
+  }
+
+  return tracks;
+}

--- a/website/src/utils/decodeAudioFiles.ts
+++ b/website/src/utils/decodeAudioFiles.ts
@@ -46,10 +46,16 @@ export async function decodeAudioFiles(
     .filter((r): r is PromiseFulfilledResult<ClipTrack> => r.status === 'fulfilled')
     .map((r) => r.value);
 
-  const failed = results.filter((r) => r.status === 'rejected');
-  for (const f of failed) {
-    console.error('[waveform-playlist] Error decoding audio file:', (f as PromiseRejectedResult).reason);
-  }
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') {
+      console.error(
+        '[waveform-playlist] Error decoding audio file: ' +
+          files[i].name +
+          ' — ' +
+          String(r.reason),
+      );
+    }
+  });
 
   return tracks;
 }


### PR DESCRIPTION
## Summary

- Extract shared `decodeAudioFiles()` utility for parallel file loading
- Add `onTracksChange` to examples that were missing it (prevents engine rebuild warnings and playback jitter)
- Replace sequential `for-await` decode loops with parallel `Promise.allSettled`

### Examples updated

| Example | `onTracksChange` | Parallel decode |
|---------|:-:|:-:|
| MirSpectrogramExample | Added | Yes |
| EffectsExample | Added | Yes |
| MidiExample | Added (MIDI-aware) | Yes |
| RecordingExample | Already had | Yes |
| AnnotationsExample | Already had | Yes |

### Shared utility

`website/src/utils/decodeAudioFiles.ts` — decodes files in parallel, returns `ClipTrack[]`. Accepts `trackDefaults` for per-example options (e.g., `spectrogramConfig`).

### Not changed

- NewTracksExample — uses `useDynamicTracks` (no external `setTracks`)
- StemTracksExample / WaveformDataExample — no file drop handler
- MultiClipExample / BeatsAndBarsExample / FlexibleApiExample — already correct

## Test plan

- [ ] `pnpm --filter website build` passes
- [ ] Drop multiple audio files on MIR example — all load at once (not one by one)
- [ ] Play/pause on MIR example — no "onTracksChange not set" warning in console
- [ ] Effects example — file drop works, no engine rebuild warning
- [ ] MIDI example — file drop works alongside MIDI tracks