### PR TITLE
perf(ui-components): skip redrawing already-drawn canvas chunks

### DIFF
--- a/packages/ui-components/CLAUDE.md
+++ b/packages/ui-components/CLAUDE.md
@@ -89,6 +89,10 @@
 
 **Why:** `useEffect` runs after browser paint. Since canvas drawing calls `clearRect` first, users see one frame of blank canvas before the redraw. This causes visible flicker on initial load, zoom changes, and during recording (~60fps peak updates). Layout thrashing is not a concern because ClipContainer and channel Wrapper both set explicit `width`/`height` via `.attrs()` — the browser knows container dimensions before canvases mount.
 
+## Canvas Draw Version Stamping
+
+`Channel.tsx` stamps each canvas with `canvas.dataset.drawVersion` after drawing. The `useLayoutEffect` skips canvases whose stamp matches the current `drawVersion` fingerprint (derived from data, bits, colors, dimensions, drawMode). Only newly mounted canvases (no stamp) or canvases after a parameter change (stamp mismatch) get redrawn. Without this, changing `visibleChunkIndices` redraws ALL mounted chunks — causing 23ms+ spikes with multiple tracks at fine zoom.
+
 ## Horizontal Virtual Scrolling (Phase 4)
 
 **Decision:** Viewport-aware canvas rendering — only mount canvas chunks visible in the scroll container + buffer.

--- a/packages/ui-components/src/components/Channel.tsx
+++ b/packages/ui-components/src/components/Channel.tsx
@@ -154,7 +154,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
   // all chunks need redrawing. When only visibleChunkIndices changes,
   // existing chunks can be skipped (only new mounts need drawing).
   const drawVersion =
-    `${dataVersionRef.current}-${bits}-${waveHeight}-${devicePixelRatio}-${length}-${barWidth}-${barGap}-${drawMode}-${index}` +
+    `${dataVersionRef.current}-${bits}-${waveHeight}-${devicePixelRatio}-${length}-${barWidth}-${barGap}-${drawMode}` +
     `-${waveformColorToCss(waveOutlineColor)}-${waveformColorToCss(waveFillColor)}`;
 
   useLayoutEffect(() => {

--- a/packages/ui-components/src/components/Channel.tsx
+++ b/packages/ui-components/src/components/Channel.tsx
@@ -140,10 +140,23 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
   // visibleChunkIndices changes only when chunks mount/unmount, not on every scroll pixel.
   // useLayoutEffect so canvas drawing completes before the browser paints —
   // prevents flicker from clearRect being visible for one frame.
+  // Compute a fingerprint of the drawing parameters — when this changes,
+  // all chunks need redrawing. When only visibleChunkIndices changes,
+  // existing chunks can be skipped (only new mounts need drawing).
+  // Include data identity in fingerprint (length + first sample as proxy)
+  const dataId = data ? `${data.length}-${data[0]}` : 'empty';
+  const drawVersion =
+    `${dataId}-${bits}-${waveHeight}-${devicePixelRatio}-${length}-${barWidth}-${barGap}-${drawMode}-${index}` +
+    `-${waveformColorToCss(waveOutlineColor)}-${waveformColorToCss(waveFillColor)}`;
+
   useLayoutEffect(() => {
     const step = barWidth + barGap;
 
     for (const [canvasIdx, canvas] of canvasMapRef.current.entries()) {
+      // Skip chunks already drawn with the current parameters.
+      // data-draw-version is stamped after drawing; cleared when the
+      // canvas remounts (new DOM element) or when drawVersion changes.
+      if (canvas.dataset.drawVersion === drawVersion) continue;
       const globalPixelOffset = canvasIdx * MAX_CANVAS_WIDTH;
 
       const ctx = canvas.getContext('2d');
@@ -194,6 +207,8 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
             }
           }
         }
+
+        canvas.dataset.drawVersion = drawVersion;
       }
     }
   }, [
@@ -207,6 +222,7 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
     length,
     barWidth,
     barGap,
+    drawVersion,
     drawMode,
     visibleChunkIndices,
     index,

--- a/packages/ui-components/src/components/Channel.tsx
+++ b/packages/ui-components/src/components/Channel.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useLayoutEffect } from 'react';
+import React, { FunctionComponent, useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 import type { Peaks, Bits } from '@waveform-playlist/core';
 import {
@@ -140,13 +140,21 @@ export const Channel: FunctionComponent<ChannelProps> = (props) => {
   // visibleChunkIndices changes only when chunks mount/unmount, not on every scroll pixel.
   // useLayoutEffect so canvas drawing completes before the browser paints —
   // prevents flicker from clearRect being visible for one frame.
+  // Track data reference changes with a monotonic counter — typed arrays
+  // with the same length/values but different references must trigger a
+  // redraw (e.g., trim produces new array with same length + first sample).
+  const dataVersionRef = useRef(0);
+  const prevDataRef = useRef(data);
+  if (prevDataRef.current !== data) {
+    dataVersionRef.current += 1;
+    prevDataRef.current = data;
+  }
+
   // Compute a fingerprint of the drawing parameters — when this changes,
   // all chunks need redrawing. When only visibleChunkIndices changes,
   // existing chunks can be skipped (only new mounts need drawing).
-  // Include data identity in fingerprint (length + first sample as proxy)
-  const dataId = data ? `${data.length}-${data[0]}` : 'empty';
   const drawVersion =
-    `${dataId}-${bits}-${waveHeight}-${devicePixelRatio}-${length}-${barWidth}-${barGap}-${drawMode}-${index}` +
+    `${dataVersionRef.current}-${bits}-${waveHeight}-${devicePixelRatio}-${length}-${barWidth}-${barGap}-${drawMode}-${index}` +
     `-${waveformColorToCss(waveOutlineColor)}-${waveformColorToCss(waveFillColor)}`;
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary

When canvas chunks enter/exit the virtual scrolling viewport, the drawing `useLayoutEffect` was redrawing **all** mounted canvases — clearing and re-rendering every chunk even though only 1 new chunk needed drawing.

### Before
- 4 tracks × 2 channels × 6 chunks = **48 canvas redraws** per chunk transition
- **23ms+ spikes** in `useLayoutEffect` (visible jitter at 120fps)

### After
- Only newly mounted canvases are drawn: **drew=1/6** per transition
- **0-1ms** per draw, no spikes

### How it works
- Compute a `drawVersion` fingerprint from all drawing parameters (data, bits, colors, dimensions, etc.)
- After drawing a canvas, stamp it with `canvas.dataset.drawVersion = drawVersion`
- On the next `useLayoutEffect` run, skip canvases whose stamp matches the current version
- Stamp naturally clears when a canvas remounts (new DOM element) or when any drawing parameter changes

## Test plan
- [ ] `cd packages/ui-components && npx vitest run` — 109 tests pass
- [ ] Auto-scroll playback at fine zoom — no jitter at canvas boundaries
- [ ] Zoom in/out — all chunks redraw correctly (drawVersion changes)
- [ ] Load new tracks — waveforms render correctly