### PR TITLE
chore: bump to v12.0.0, dawcore to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waveform-playlist-monorepo",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "private": true,
   "description": "Multiple track web audio editor and player with waveform preview",
   "author": "Naomi Aro",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/annotations",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Annotation support for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/browser",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Browser bundle for waveform-playlist with React",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/core",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Core types, interfaces and utilities for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@waveform-playlist/engine": ">=12.0.0",
     "@waveform-playlist/core": ">=12.0.0",
-    "@dawcore/transport": ">=0.0.1",
+    "@dawcore/transport": ">=0.0.6",
     "@waveform-playlist/worklets": ">=12.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawcore/components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Web Components for multi-track audio editing — framework-agnostic",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -29,16 +29,12 @@
     "waveform-data": "^4.5.2"
   },
   "peerDependencies": {
-    "@waveform-playlist/engine": ">=7.0.0",
-    "@waveform-playlist/core": ">=7.0.0",
+    "@waveform-playlist/engine": ">=12.0.0",
+    "@waveform-playlist/core": ">=12.0.0",
     "@dawcore/transport": ">=0.0.1",
-    "@waveform-playlist/worklets": ">=7.0.0",
-    "@waveform-playlist/recording": ">=7.0.0"
+    "@waveform-playlist/worklets": ">=12.0.0"
   },
   "peerDependenciesMeta": {
-    "@waveform-playlist/recording": {
-      "optional": true
-    },
     "@waveform-playlist/worklets": {
       "optional": true
     }
@@ -48,7 +44,6 @@
     "@waveform-playlist/core": "workspace:*",
     "@dawcore/transport": "workspace:*",
     "@waveform-playlist/worklets": "workspace:*",
-    "@waveform-playlist/recording": "workspace:*",
     "happy-dom": "^17.0.0",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/engine",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Framework-agnostic engine for waveform-playlist — pure operations and stateful timeline management",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/loaders",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Audio loaders for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/media-element-playout/package.json
+++ b/packages/media-element-playout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/media-element-playout",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "HTMLMediaElement-based playout engine for waveform-playlist with pitch-preserving playback rate",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/midi/package.json
+++ b/packages/midi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/midi",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "MIDI file loading and parsing for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/playout/package.json
+++ b/packages/playout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/playout",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Playout engine for waveform-playlist using Tone.js",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/recording/package.json
+++ b/packages/recording/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/recording",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Audio recording support for waveform-playlist using AudioWorklet",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/spectrogram",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Spectrogram computation and UI for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/ui-components",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "React UI components for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/webaudio-peaks/package.json
+++ b/packages/webaudio-peaks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/webaudio-peaks",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "Small library to extract peaks from an array of audio samples or an AudioBuffer from the WebAudio API.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/worklets/package.json
+++ b/packages/worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/worklets",
-  "version": "11.3.1",
+  "version": "12.0.0",
   "description": "AudioWorklet processors for waveform-playlist (metering, recording)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,6 @@ importers:
       '@waveform-playlist/engine':
         specifier: workspace:*
         version: link:../engine
-      '@waveform-playlist/recording':
-        specifier: workspace:*
-        version: link:../recording
       '@waveform-playlist/worklets':
         specifier: workspace:*
         version: link:../worklets


### PR DESCRIPTION
## Summary

- Bump all `@waveform-playlist/*` packages from 11.3.1 to 12.0.0
- Bump `@dawcore/components` from 0.0.9 to 0.0.10
- `@dawcore/transport` stays at 0.0.6 (no changes)
- Remove `@waveform-playlist/recording` from dawcore peer/dev deps (no longer imported)
- Update dawcore peer dep ranges to `>=12.0.0`

## Breaking Changes (v12)

See PR #376 for details — cross-package re-exports removed, recording utils moved to core.

## Test plan

- [x] Full monorepo build passes
- [x] Lint passes (0 errors)
- [x] Lockfile unchanged (no new deps)