### PR TITLE
test(recording): unmount inside act() to fix React 19 teardown flake

### DIFF
--- a/packages/recording/src/__tests__/useRecording.test.tsx
+++ b/packages/recording/src/__tests__/useRecording.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 interface MockWorkletNode {
@@ -108,7 +108,14 @@ beforeEach(() => {
   };
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Unmount inside act() so React's concurrent scheduler flushes commit work
+  // (e.g. final renders triggered by useEffect cleanups, pending rAF→setState
+  // ticks) before vitest tears down jsdom. Without this, scheduler tasks fire
+  // post-teardown and throw "window is not defined" — flaky on React 19 CI.
+  await act(async () => {
+    cleanup();
+  });
   vi.clearAllMocks();
 });
 


### PR DESCRIPTION
## Summary

`useRecording.test.tsx` intermittently logged an uncaught `ReferenceError: window is not defined` from React's concurrent commit phase (`prepareForCommit → getActiveElementDeep → window`). All tests reported `passed` but the leaked exception failed the React 19 CI matrix job.

**Root cause:** RTL's auto-installed `afterEach(cleanup)` unmounts components *outside* of `act()`. The hook's `startDurationLoop` schedules a `requestAnimationFrame` that jsdom backs with `setTimeout`; if that tick (or any other queued setState) fires after the test returns but before vitest tears down jsdom, React's scheduler runs a commit on a missing `window`. React 19's scheduler is more aggressive about queueing work via `setImmediate`/`MessageChannel`, which is why this surfaced reliably there. Reproduced locally on React 18 as well — same root cause.

**Fix:** Import `cleanup` explicitly and run it inside `await act(...)` in `afterEach`. Vitest runs `afterEach` hooks LIFO, so our manual cleanup fires *before* RTL's auto-cleanup (which then no-ops on the already-unmounted tree). This guarantees React flushes all unmount-related commit work — including effect cleanups and any pending rAF→setState ticks — inside the test runner's active phase.

```ts
afterEach(async () => {
  await act(async () => {
    cleanup();
  });
  vi.clearAllMocks();
});
```

The fix is test-only — no change to `useRecording.ts`. It's a pattern worth adopting in any future RTL `renderHook` tests in this repo.

## Test plan

- [x] `cd packages/recording && npx vitest run src/__tests__/useRecording.test.tsx` — 5 consecutive clean runs, no "Uncaught Exception"
- [x] `cd packages/recording && npx vitest run` — all 30 package tests pass
- [x] `pnpm lint` — 0 errors
- [ ] CI React 18 + React 19 matrix jobs both pass on this PR