### PR TITLE
chore(examples): link midi.html from dawcore-tone index

### DIFF
--- a/examples/dawcore-tone/index.html
+++ b/examples/dawcore-tone/index.html
@@ -76,6 +76,10 @@
       <a href="programmatic.html">programmatic</a>
       <div class="desc">Imperative addTrack/addClip/updateClip/removeClip + declarative DOM mutation, side-by-side</div>
     </li>
+    <li>
+      <a href="midi.html">midi</a>
+      <div class="desc">Programmatic MIDI clips with piano-roll render mode and Tone.js PolySynth</div>
+    </li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary

`examples/dawcore-tone/midi.html` existed but wasn't linked from `examples/dawcore-tone/index.html`, so the MIDI demo was only discoverable by typing the URL directly. Added a list entry after `programmatic` — both share the imperative-API character, and `midi` is Tone-only since it relies on Tone's PolySynth.

## Test plan

- [ ] `pnpm example:dawcore-tone` → index loads, MIDI entry visible, link navigates to `midi.html`