### PR TITLE
fix(spectrogram): dedup viewport-ready events per (generation, trackId)

### DIFF
--- a/examples/dawcore-native/spectrogram.html
+++ b/examples/dawcore-native/spectrogram.html
@@ -52,9 +52,12 @@
         font-family: monospace;
         font-size: 0.75rem;
         color: #888;
-        max-height: 80px;
+        max-height: 240px;
         overflow-y: auto;
         margin-top: 12px;
+      }
+      #status div {
+        white-space: pre;
       }
     </style>
   </head>
@@ -140,12 +143,23 @@
       editor.spectrogramColorMap = 'magma';
 
       const status = document.getElementById('status');
-      editor.addEventListener('daw-spectrogram-ready', (e) => {
+      const EVENT_COLOR = {
+        'track-ready': '#63C75F',         // green — audio decoded + peaks rendered
+        'spectrogram-ready': '#d08070',   // red — FFT viewport tier rendered
+      };
+      function logEvent(kind, trackId) {
         const line = document.createElement('div');
-        line.textContent = 'ready: track ' + e.detail.trackId;
+        const tag = document.createElement('span');
+        tag.textContent = kind.padEnd(18);
+        tag.style.color = EVENT_COLOR[kind];
+        line.append(tag, trackId.slice(0, 8));
         status.prepend(line);
-        while (status.children.length > 10) status.lastChild.remove();
-      });
+        while (status.children.length > 16) status.lastChild.remove();
+      }
+      editor.addEventListener('daw-track-ready', (e) => logEvent('track-ready', e.detail.trackId));
+      editor.addEventListener('daw-spectrogram-ready', (e) =>
+        logEvent('spectrogram-ready', e.detail.trackId)
+      );
 
       document.getElementById('colormap').addEventListener('change', (e) => {
         editor.spectrogramColorMap = e.target.value;

--- a/examples/dawcore-tone/spectrogram.html
+++ b/examples/dawcore-tone/spectrogram.html
@@ -52,9 +52,12 @@
         font-family: monospace;
         font-size: 0.75rem;
         color: #888;
-        max-height: 80px;
+        max-height: 240px;
         overflow-y: auto;
         margin-top: 12px;
+      }
+      #status div {
+        white-space: pre;
       }
     </style>
   </head>
@@ -140,12 +143,23 @@
       editor.spectrogramColorMap = 'magma';
 
       const status = document.getElementById('status');
-      editor.addEventListener('daw-spectrogram-ready', (e) => {
+      const EVENT_COLOR = {
+        'track-ready': '#63C75F',         // green — audio decoded + peaks rendered
+        'spectrogram-ready': '#d08070',   // red — FFT viewport tier rendered
+      };
+      function logEvent(kind, trackId) {
         const line = document.createElement('div');
-        line.textContent = 'ready: track ' + e.detail.trackId;
+        const tag = document.createElement('span');
+        tag.textContent = kind.padEnd(18);
+        tag.style.color = EVENT_COLOR[kind];
+        line.append(tag, trackId.slice(0, 8));
         status.prepend(line);
-        while (status.children.length > 10) status.lastChild.remove();
-      });
+        while (status.children.length > 16) status.lastChild.remove();
+      }
+      editor.addEventListener('daw-track-ready', (e) => logEvent('track-ready', e.detail.trackId));
+      editor.addEventListener('daw-spectrogram-ready', (e) =>
+        logEvent('spectrogram-ready', e.detail.trackId)
+      );
 
       document.getElementById('colormap').addEventListener('change', (e) => {
         editor.spectrogramColorMap = e.target.value;

--- a/packages/dawcore-spectrogram/CLAUDE.md
+++ b/packages/dawcore-spectrogram/CLAUDE.md
@@ -16,11 +16,13 @@
 
 Class that owns the worker pool, clip+canvas registries, viewport state, and render dispatch. Extends `EventTarget` — dispatches `viewport-ready` (CustomEvent) after the viewport tier completes per track.
 
+**`viewport-ready` semantics:** fires **at most once per `(generation, trackId)` pair**. Generation bumps (setViewport with a real change, setConfig, setColorMap) reset the dispatched-set so the event re-fires on the next render. Late `registerCanvas` calls that trigger a fresh render within the same generation do NOT re-fire. `setViewport` is also short-circuited when called with identical state — no generation bump, no abort, no render. These dedups prevent N-renders-per-track-load patterns where the dispatched event count grows quadratically during initial loading.
+
 **Constructor:** `new SpectrogramOrchestrator({ workerFactory, workerPoolSize?, config, colorMap?, devicePixelRatio? })`. The consumer owns worker URL resolution — pass a factory rather than baking URLs into the orchestrator.
 
 **Lifecycle:** `registerClip` (audio data), `registerCanvas` (OffscreenCanvas + metadata), `setViewport`, `setConfig`, `setColorMap`. Each setter that affects render output bumps a generation counter and calls `pool.abortGeneration(prev)` so stale FFT work drops cleanly. `dispose()` is idempotent.
 
-**Protected fields:** `pool`, `config`, `colorMap`, `devicePixelRatio`, `clips`, `canvases`, `viewport`, `generation`, `colorLUT`, `disposed`. Protected (not private) so `noUnusedLocals` doesn't flag dormant fields between task slices.
+**Protected fields:** `pool`, `config`, `colorMap`, `devicePixelRatio`, `clips`, `canvases`, `viewport`, `generation`, `colorLUT`, `disposed`, `readyDispatched`. Protected (not private) so `noUnusedLocals` doesn't flag dormant fields between task slices.
 
 ## Three-Tier Render
 

--- a/packages/dawcore-spectrogram/__tests__/orchestrator.test.ts
+++ b/packages/dawcore-spectrogram/__tests__/orchestrator.test.ts
@@ -160,6 +160,20 @@ describe('SpectrogramOrchestrator — canvas registration', () => {
     });
     expect(mockPool.abortGeneration).toHaveBeenCalled();
   });
+
+  it('setViewport short-circuits when called with identical state — no abort, no re-render', () => {
+    const state = {
+      visibleStartPx: 0,
+      visibleEndPx: 100,
+      bufferStartPx: 0,
+      bufferEndPx: 100,
+      samplesPerPixel: 1024,
+    };
+    orch.setViewport(state);
+    mockPool.abortGeneration.mockClear();
+    orch.setViewport({ ...state });
+    expect(mockPool.abortGeneration).not.toHaveBeenCalled();
+  });
 });
 
 describe('SpectrogramOrchestrator — tier-aware render', () => {
@@ -254,5 +268,61 @@ describe('SpectrogramOrchestrator — tier-aware render', () => {
     });
     await new Promise((r) => setTimeout(r, 20));
     expect(count).toBe(1);
+  });
+
+  it('does not re-emit viewport-ready for the same track when a later registerCanvas triggers another render', async () => {
+    let count = 0;
+    orch.addEventListener('viewport-ready', () => {
+      count += 1;
+    });
+    orch.setViewport({
+      visibleStartPx: 0,
+      visibleEndPx: 500,
+      bufferStartPx: 0,
+      bufferEndPx: 1500,
+      samplesPerPixel: 1024,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(count).toBe(1);
+    // Late canvas registration triggers another render with the SAME viewport
+    // and generation. The track was already marked ready — don't re-fire.
+    orch.registerCanvas({
+      canvasId: 'c1-ch0-chunk3',
+      canvas: { width: 1000, height: 100 } as unknown as OffscreenCanvas,
+      clipId: 'c1',
+      trackId: 't1',
+      channelIndex: 0,
+      chunkIndex: 3,
+      globalPixelOffset: 3000,
+      widthPx: 1000,
+      heightPx: 100,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(count).toBe(1);
+  });
+
+  it('re-emits viewport-ready after setViewport bumps the generation', async () => {
+    let count = 0;
+    orch.addEventListener('viewport-ready', () => {
+      count += 1;
+    });
+    orch.setViewport({
+      visibleStartPx: 0,
+      visibleEndPx: 500,
+      bufferStartPx: 0,
+      bufferEndPx: 1500,
+      samplesPerPixel: 1024,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(count).toBe(1);
+    orch.setViewport({
+      visibleStartPx: 1000,
+      visibleEndPx: 1500,
+      bufferStartPx: 500,
+      bufferEndPx: 2000,
+      samplesPerPixel: 1024,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(count).toBe(2);
   });
 });

--- a/packages/dawcore-spectrogram/src/orchestrator/SpectrogramOrchestrator.ts
+++ b/packages/dawcore-spectrogram/src/orchestrator/SpectrogramOrchestrator.ts
@@ -66,6 +66,12 @@ export class SpectrogramOrchestrator extends EventTarget {
   protected colorLUT = new ColorLUTCache();
   protected disposed = false;
   protected renderInFlight = false;
+  // Tracks which trackIds have already emitted `viewport-ready` for the
+  // current generation. Cleared on every generation bump (setViewport /
+  // setConfig / setColorMap). Without this, every render — including
+  // those triggered by late `registerCanvas` calls during track-by-track
+  // loading — would re-fire the event for every track in the canvas map.
+  protected readyDispatched = new Set<string>();
 
   constructor(opts: SpectrogramOrchestratorOptions) {
     super();
@@ -121,8 +127,10 @@ export class SpectrogramOrchestrator extends EventTarget {
 
   setViewport(state: ViewportState): void {
     if (this.disposed) return;
+    if (this.viewport && viewportsEqual(this.viewport, state)) return;
     const prevGeneration = this.generation;
     this.generation += 1;
+    this.readyDispatched.clear();
     this.pool.abortGeneration(prevGeneration);
     this.viewport = state;
     this.scheduleRender();
@@ -133,6 +141,7 @@ export class SpectrogramOrchestrator extends EventTarget {
     this.config = config;
     const prevGeneration = this.generation;
     this.generation += 1;
+    this.readyDispatched.clear();
     this.pool.abortGeneration(prevGeneration);
     this.colorLUT.clear();
     this.scheduleRender();
@@ -143,6 +152,7 @@ export class SpectrogramOrchestrator extends EventTarget {
     this.colorMap = colorMap;
     const prevGeneration = this.generation;
     this.generation += 1;
+    this.readyDispatched.clear();
     this.pool.abortGeneration(prevGeneration);
     this.scheduleRender();
   }
@@ -158,6 +168,7 @@ export class SpectrogramOrchestrator extends EventTarget {
     this.canvases.clear();
     this.viewport = null;
     this.colorLUT.clear();
+    this.readyDispatched.clear();
     this.pool.terminate();
   }
 
@@ -188,7 +199,10 @@ export class SpectrogramOrchestrator extends EventTarget {
       // Phase 1a: viewport tier — render synchronously (priority)
       await this.renderTier(tiers.viewport, generation, viewport);
       if (this.generation !== generation || this.disposed) return;
-      this.dispatchEvent(new CustomEvent('viewport-ready', { detail: { trackId } }));
+      if (!this.readyDispatched.has(trackId)) {
+        this.readyDispatched.add(trackId);
+        this.dispatchEvent(new CustomEvent('viewport-ready', { detail: { trackId } }));
+      }
       // Phase 1b: buffer tier
       await this.renderTier(tiers.buffer, generation, viewport);
       if (this.generation !== generation || this.disposed) return;
@@ -292,4 +306,14 @@ export class SpectrogramOrchestrator extends EventTarget {
       }
     });
   }
+}
+
+function viewportsEqual(a: ViewportState, b: ViewportState): boolean {
+  return (
+    a.visibleStartPx === b.visibleStartPx &&
+    a.visibleEndPx === b.visibleEndPx &&
+    a.bufferStartPx === b.bufferStartPx &&
+    a.bufferEndPx === b.bufferEndPx &&
+    a.samplesPerPixel === b.samplesPerPixel
+  );
 }

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -628,13 +628,31 @@ export class DawEditorElement extends LitElement {
     }
   }
 
+  /**
+   * Cache of the last ViewportState forwarded to the spectrogram controller.
+   * Lit's `updated()` fires on every reactive state change (`_isPlaying`,
+   * `_selectedTrackId`, etc.) — most of which don't affect the spectrogram
+   * viewport. Skip the cross-controller call when nothing changed.
+   *
+   * The orchestrator dedupes too, but this avoids the call entirely.
+   */
+  private _lastSpectrogramViewport: {
+    vs: number;
+    ve: number;
+    spp: number;
+  } | null = null;
+
   protected updated(_changed: Map<string, unknown>): void {
     // Forward viewport + zoom into the spectrogram controller on every update
     // so scroll, resize, and zoom all trigger orchestrator.setViewport.
     if (this._spectrogramController) {
       const vs = this._viewport.visibleStart;
       const ve = this._viewport.visibleEnd;
+      const spp = this._renderSpp;
       if (Number.isFinite(vs) && Number.isFinite(ve)) {
+        const prev = this._lastSpectrogramViewport;
+        if (prev && prev.vs === vs && prev.ve === ve && prev.spp === spp) return;
+        this._lastSpectrogramViewport = { vs, ve, spp };
         const span = ve - vs;
         const bufferPad = span * 0.25;
         this._spectrogramController.setViewport({
@@ -642,7 +660,7 @@ export class DawEditorElement extends LitElement {
           visibleEndPx: ve,
           bufferStartPx: Math.max(0, vs - bufferPad),
           bufferEndPx: ve + bufferPad,
-          samplesPerPixel: this._renderSpp,
+          samplesPerPixel: spp,
         });
       }
     }


### PR DESCRIPTION
## Summary

The spectrogram demo was emitting a near-quadratic burst of `daw-spectrogram-ready` events on initial load (ascending pattern: 4 events for the first-loaded track, 3 for the next, 2 for the next), plus an extra N events on every Play/Stop click. Two overlapping causes:

1. **`<daw-editor>.updated()` ran on every reactive state change** (`_isPlaying`, `_engineTracks`, `_selectedTrackId`, …) and unconditionally called `_spectrogramController.setViewport(...)` with unchanged vs/ve/samplesPerPixel. Every call bumped the orchestrator's generation, aborted in-flight FFT work, and triggered a render — which re-emitted `viewport-ready` for every track. So Play/Stop alone produced N events per click.
2. **`SpectrogramOrchestrator.runRender` dispatched `viewport-ready` for every track in the canvas map on every render.** Late `registerCanvas` calls during track-by-track loading each scheduled a fresh render, each of which re-emitted for every already-loaded track.

## Fix (defense in depth)

- `<daw-editor>.updated()` caches the last forwarded `ViewportState` and short-circuits when `(vs, ve, samplesPerPixel)` are unchanged.
- `SpectrogramOrchestrator.setViewport` short-circuits when the new state is deep-equal to the current viewport (no generation bump, no pool abort, no render).
- `SpectrogramOrchestrator` tracks a `readyDispatched: Set<trackId>` and only emits `viewport-ready` once per `(generation, trackId)`. The set is cleared on every generation bump (`setViewport` / `setConfig` / `setColorMap`) and in `dispose()`.

The `(generation, trackId)` dedup is the load-bearing fix for the initial-load explosion. The two short-circuits eliminate the Play/Stop redundancy at two layers, so a future caller that doesn't dedupe still gets the right behavior.

## Verified live on the spectrogram demo (3 spectrogram tracks)

| Action | Before | After |
| --- | --- | --- |
| Initial load | 10 events (ascending 2+3+4+1) | **3** (one per track) |
| Play | +3 | **0** |
| Stop | +3 | **0** |
| Color-map change | +3 | **3** (real config change → correct re-emit) |

## Test plan

- [x] `pnpm --filter @dawcore/spectrogram test` — 174 pass (3 new tests)
- [x] `pnpm --filter @dawcore/components test` — 437 pass
- [x] Manual on `examples/dawcore-native/spectrogram.html`: load count, Play, Stop, color-map change all match the table above
- [ ] CI React 18 + React 19 matrix passes