### PR TITLE
docs(api): fix drift in usePlaybackAnimation, ClipPeaks, useAudioTracks

### DIFF
--- a/website/docs/api/hooks.md
+++ b/website/docs/api/hooks.md
@@ -110,51 +110,66 @@ function usePlaylistData(): {
 
 ### usePlaybackAnimation
 
-Access playback state and timing refs for smooth animations.
+Access playback state, timing refs, and the per-frame animation registry. A single `requestAnimationFrame` loop inside the provider drives all visual updates; components register callbacks instead of spinning their own loops.
 
 ```typescript
+interface FrameData {
+  /** Raw engine time (use for state/logic — NOT for visual positioning). */
+  readonly time: number;
+  /** time − outputLatency − engine.lookAhead. Use for any DOM positioning that
+   *  should match the audible output. */
+  readonly visualTime: number;
+  readonly sampleRate: number;
+  readonly samplesPerPixel: number;
+}
+
 function usePlaybackAnimation(): {
   isPlaying: boolean;
   currentTime: number;
 
-  // Refs for 60fps animation loops
+  // Refs for 60fps animation loops (read inside frame callbacks or rAF)
   currentTimeRef: RefObject<number>;
+  /** Visually-aligned playback time (raw − outputLatency − lookAhead). Read this
+   *  for any static playhead positioning that should match the audible output. */
+  visualTimeRef: RefObject<number>;
   playbackStartTimeRef: RefObject<number>;
   audioStartPositionRef: RefObject<number>;
 
-  /** Returns current playback time from engine (auto-wraps at loop boundaries). */
+  /** Raw playback time from engine (auto-wraps at loop boundaries). */
   getPlaybackTime: () => number;
+  /** Current adapter scheduler lookahead (Tone ~0.1s, native 0). Use for any
+   *  audible-latency calculation that must match the playhead. */
+  getLookAhead: () => number;
+
+  /** Register a per-frame callback driven by the shared animation loop. */
+  registerFrameCallback: (id: string, cb: (data: FrameData) => void) => void;
+  unregisterFrameCallback: (id: string) => void;
 };
 ```
 
 #### Example
 
+Use `registerFrameCallback` rather than your own `requestAnimationFrame` loop — it shares the provider's single rAF, runs only while playing, and hands you a fresh `FrameData` so closure values can't go stale during zoom changes.
+
 ```tsx
 function AnimatedPlayhead() {
-  const { isPlaying, currentTimeRef, playbackStartTimeRef, audioStartPositionRef } = usePlaybackAnimation();
-  const { samplesPerPixel, sampleRate } = usePlaylistData();
+  const { registerFrameCallback, unregisterFrameCallback } = usePlaybackAnimation();
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    let frameId: number;
-
-    const animate = () => {
-      if (ref.current && isPlaying) {
-        const elapsed = getContext().currentTime - (playbackStartTimeRef.current ?? 0);
-        const time = (audioStartPositionRef.current ?? 0) + elapsed;
-        const pixels = (time * sampleRate) / samplesPerPixel;
-        ref.current.style.transform = `translateX(${pixels}px)`;
-      }
-      frameId = requestAnimationFrame(animate);
-    };
-
-    if (isPlaying) frameId = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(frameId);
-  }, [isPlaying]);
+    registerFrameCallback('playhead', ({ visualTime, sampleRate, samplesPerPixel }) => {
+      if (!ref.current) return;
+      const pixels = (visualTime * sampleRate) / samplesPerPixel;
+      ref.current.style.transform = `translateX(${pixels}px)`;
+    });
+    return () => unregisterFrameCallback('playhead');
+  }, [registerFrameCallback, unregisterFrameCallback]);
 
   return <div ref={ref} className="playhead" />;
 }
 ```
+
+For static positioning when playback is stopped (initial render, after pause/seek), read `visualTimeRef.current` instead — the loop keeps it current outside of playback too.
 
 ---
 
@@ -165,11 +180,12 @@ Load and decode audio files into track objects.
 ### Signature
 
 ```typescript
-function useAudioTracks(configs: AudioConfig[]): {
+function useAudioTracks(configs: AudioTrackConfig[]): {
   tracks: ClipTrack[];
   loading: boolean;
   error: string | null;
-  progress: number;
+  loadedCount: number;
+  totalCount: number;
 };
 ```
 
@@ -177,7 +193,7 @@ function useAudioTracks(configs: AudioConfig[]): {
 
 | Name | Type | Description |
 |------|------|-------------|
-| `configs` | `AudioConfig[]` | Array of audio configurations |
+| `configs` | `AudioTrackConfig[]` | Array of audio configurations |
 
 ### AudioTrackConfig
 
@@ -207,17 +223,18 @@ interface AudioTrackConfig {
 | `tracks` | `ClipTrack[]` | Loaded track objects |
 | `loading` | `boolean` | Loading state |
 | `error` | `string \| null` | Error message |
-| `progress` | `number` | Loading progress 0-1 |
+| `loadedCount` | `number` | Number of configs that have finished loading |
+| `totalCount` | `number` | Total number of configs |
 
 ### Example
 
 ```tsx
-const { tracks, loading, error, progress } = useAudioTracks([
+const { tracks, loading, error, loadedCount, totalCount } = useAudioTracks([
   { src: '/audio/track1.mp3', name: 'Track 1' },
   { src: '/audio/track2.mp3', name: 'Track 2', startTime: 5 },
 ]);
 
-if (loading) return <div>Loading... {Math.round(progress * 100)}%</div>;
+if (loading) return <div>Loading {loadedCount} / {totalCount}…</div>;
 if (error) return <div>Error: {error}</div>;
 ```
 

--- a/website/docs/api/llm-reference.md
+++ b/website/docs/api/llm-reference.md
@@ -165,14 +165,28 @@ interface MediaElementDataContextValue {
 ### usePlaybackAnimation()
 
 ```typescript
+interface FrameData {
+  readonly time: number;          // Raw engine time (state/logic — NOT visual positioning)
+  readonly visualTime: number;    // time − outputLatency − engine.lookAhead (use for DOM positioning)
+  readonly sampleRate: number;
+  readonly samplesPerPixel: number;
+}
+
 interface PlaybackAnimationContextValue {
   isPlaying: boolean;
   currentTime: number;
   currentTimeRef: RefObject<number>;
+  /** Visually-aligned playback time (raw − outputLatency − engine.lookAhead). */
+  visualTimeRef: RefObject<number>;
   playbackStartTimeRef: RefObject<number>;
   audioStartPositionRef: RefObject<number>;
-  /** Returns current playback time from engine (auto-wraps at loop boundaries). */
+  /** Raw playback time from engine (auto-wraps at loop boundaries). */
   getPlaybackTime: () => number;
+  /** Current adapter scheduler lookahead (Tone ~0.1s, native 0). */
+  getLookAhead: () => number;
+  /** Register/unregister per-frame callbacks driven by the shared rAF loop. */
+  registerFrameCallback: (id: string, cb: (data: FrameData) => void) => void;
+  unregisterFrameCallback: (id: string) => void;
 }
 ```
 
@@ -309,6 +323,12 @@ interface ClipPeaks {
   durationSamples: number;
   fadeIn?: Fade;
   fadeOut?: Fade;
+  /** MIDI note data — present for clips rendered as piano roll. */
+  midiNotes?: MidiNoteData[];
+  /** Source audio sample rate (waveformData rate when mismatched from context). */
+  sampleRate?: number;
+  /** Offset into the source audio in samples. */
+  offsetSamples?: number;
 }
 
 type TrackClipPeaks = ClipPeaks[];
@@ -326,7 +346,8 @@ function useAudioTracks(
   tracks: ClipTrack[];
   loading: boolean;
   error: string | null;
-  progress: number;
+  loadedCount: number;
+  totalCount: number;
 };
 
 interface AudioTrackConfig {


### PR DESCRIPTION
## Summary

Cross-checked the two API reference pages against current source in `packages/browser/src` and fixed four drift items that would mislead anyone (human or LLM) reading the docs.

**No source changes — docs only.**

### What changed

| Doc | Drift | Fix |
|---|---|---|
| `hooks.md` + `llm-reference.md` | `usePlaybackAnimation` was missing `visualTimeRef`, `getLookAhead`, `registerFrameCallback`, `unregisterFrameCallback` (all in source since the v5 animation-frame registry landed) | Added them, plus the `FrameData` interface used by frame callbacks |
| `hooks.md` | Example demoed a manual `requestAnimationFrame` loop — the exact pattern `browser/CLAUDE.md` says *not* to use | Rewrote example using `registerFrameCallback('playhead', …)` with `visualTime` for DOM positioning |
| `llm-reference.md` | `ClipPeaks` was missing `midiNotes?`, `sampleRate?`, `offsetSamples?` (load-bearing for the MIDI rendering pipeline per `browser/CLAUDE.md`) | Added all three with inline comments |
| `hooks.md` + `llm-reference.md` | `useAudioTracks` documented as returning `progress: number` — that field has never existed | Fixed to `loadedCount: number` + `totalCount: number`, updated the example to match |

The `useAudioTracks` one was the worst: the example at `hooks.md:215, 220` destructured `progress` and rendered `Math.round(progress * 100) + '%'` — anyone copy-pasting it got `NaN%`.

### Source references (verified)

- `packages/browser/src/WaveformPlaylistContext.tsx:50-61` — `ClipPeaks`
- `packages/browser/src/WaveformPlaylistContext.tsx:84-92` — `FrameData`
- `packages/browser/src/WaveformPlaylistContext.tsx:94-120` — `PlaybackAnimationContextValue`
- `packages/browser/src/hooks/useAudioTracks.ts:379` — return shape

## Test plan

- [x] `pnpm --filter website build` — clean (Docusaurus broken-link checker passed)
- [ ] Visual eyeball of rendered code blocks at `/docs/api/hooks` and `/docs/api/llm-reference` on the deployed preview
- [ ] Spot-check that the new `registerFrameCallback` example compiles when copy-pasted into a sandbox