### PR TITLE
docs: complete llms.txt package list + strengthen npm keywords

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,7 +26,9 @@
     "react",
     "waveform-playlist",
     "audio-editor",
-    "multitrack"
+    "multitrack",
+    "daw",
+    "tonejs"
   ],
   "author": "Naomi Aro",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,9 @@
     "audio",
     "webaudio",
     "waveform-playlist",
-    "types"
+    "types",
+    "daw",
+    "audio-editor"
   ],
   "author": "Naomi Aro",
   "license": "MIT",

--- a/packages/dawcore-midi/package.json
+++ b/packages/dawcore-midi/package.json
@@ -22,6 +22,8 @@
   "keywords": [
     "midi",
     "dawcore",
+    "daw",
+    "audio-editor",
     "web-audio",
     "tonejs"
   ],

--- a/packages/dawcore-spectrogram/package.json
+++ b/packages/dawcore-spectrogram/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "keywords": ["spectrogram", "fft", "dawcore", "web-audio"],
+  "keywords": ["spectrogram", "fft", "dawcore", "daw", "audio-editor", "web-audio"],
   "author": "Naomi Aro",
   "license": "MIT",
   "repository": {

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -20,6 +20,15 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "keywords": [
+    "daw",
+    "web-components",
+    "audio",
+    "webaudio",
+    "multitrack",
+    "audio-editor",
+    "lit"
+  ],
   "author": "Naomi Aro",
   "license": "MIT",
   "files": [

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -25,7 +25,9 @@
     "audio",
     "webaudio",
     "waveform-playlist",
-    "engine"
+    "engine",
+    "daw",
+    "audio-editor"
   ],
   "author": "Naomi Aro",
   "license": "MIT",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "keywords": ["waveform", "audio", "webaudio", "transport", "scheduler"],
+  "keywords": ["waveform", "audio", "webaudio", "transport", "scheduler", "daw", "dawcore"],
   "author": "Naomi Aro",
   "license": "MIT",
   "repository": {

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -28,11 +28,14 @@ waveform-playlist is a React component library for building browser-based audio 
 - `@waveform-playlist/recording` — Microphone access, AudioWorklet recording, VU meter, integrated recording hook, mic-unplug detection
 - `@waveform-playlist/worklets` — Shared AudioWorklet processors: `meter-processor` (sample-accurate peak/RMS metering) and `recording-processor` (multi-channel audio capture). Auto-installed with recording package.
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
+- `@waveform-playlist/loaders` — Lower-level audio loaders (BlobLoader, XHRLoader, LoaderFactory) for custom fetch/decode pipelines outside the React provider.
 - `@waveform-playlist/media-element-playout` — HTMLAudioElement playback with pitch-preserving speed control, optional Web Audio routing for fades and Tone.js effect bridging
 - `@waveform-playlist/midi` — React layer for MIDI: `useMidiTracks` hook converts .mid files to ClipTrack[] with midiNotes for piano roll visualization and SoundFont/PolySynth playback. As of v13+ the parser is re-exported from `@dawcore/midi`; React API surface is unchanged.
+- `@dawcore/components` — Web Components for multi-track audio editing (Lit-based): `<daw-editor>`, `<daw-track>`, `<daw-clip>`, `<daw-waveform>`, `<daw-playhead>`, `<daw-ruler>`, transport buttons. Framework-agnostic — works in any framework or vanilla HTML. No Tone.js dependency; uses native Web Audio via `@dawcore/transport`. Consumer supplies a `PlayoutAdapter` (no default).
 - `@dawcore/midi` — Framework-agnostic MIDI parser (`parseMidiFile`, `parseMidiUrl` — pure functions, no React). Used by `@dawcore/components` via dynamic import inside `editor.loadMidi()`, and re-exported by `@waveform-playlist/midi`.
 - `@waveform-playlist/spectrogram` — Optional spectrogram package (v13+): React `SpectrogramProvider` + UI (menu items, settings modal) integrating via `SpectrogramIntegrationContext`. Computation/worker/orchestrator are imported from `@dawcore/spectrogram`.
 - `@dawcore/spectrogram` — Framework-agnostic FFT computation, Web Worker, and `SpectrogramOrchestrator` class (viewport classification, 3-tier render, generation-based abort, contiguous chunk grouping, color LUT cache). Shared between the React Provider and the dawcore Lit element layer.
+- `@dawcore/transport` — Native Web Audio transport (zero dependencies): scheduler, clock, tempo/meter map, metronome, loop. Replaces Tone.js Transport for the dawcore stack. Implements the `PlayoutAdapter` interface from `@waveform-playlist/engine` via `NativePlayoutAdapter`.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Two parallel improvements for LLM/search discovery, both surfaced by the doc-audit agent dispatch.

### Part 1 — `llms.txt` Packages section was incomplete

Three packages were missing from the bullet list even though `@dawcore/components` is already referenced inline at line 99 (\`from \`@dawcore/components\`\`) and `@dawcore/transport` is the backbone of the dawcore stack. Added with descriptions consistent with the existing entries and placed to preserve the current grouping (React stack → optional add-ons → \`@dawcore/*\` family):

- `@waveform-playlist/loaders` — inserted after \`webaudio-peaks\`
- `@dawcore/components` — inserted as the lead \`@dawcore/*\` entry
- `@dawcore/transport` — inserted at the end of the \`@dawcore/*\` family

### Part 2 — npm keyword gaps

The worst offender: **\`@dawcore/components\` shipped with \`keywords: []\`** (empty array). Beyond that, none of the packages surface for \"daw\" or \"audio editor\" npm searches today.

| Package | Change |
|---|---|
| \`@dawcore/components\` | Empty array → 7 entries (daw, web-components, audio, webaudio, multitrack, audio-editor, lit) |
| \`@dawcore/midi\` | +daw, +audio-editor |
| \`@dawcore/spectrogram\` | +daw, +audio-editor |
| \`@dawcore/transport\` | +daw, +dawcore |
| \`@waveform-playlist/browser\` | +daw, +tonejs |
| \`@waveform-playlist/core\` | +daw, +audio-editor |
| \`@waveform-playlist/engine\` | +daw, +audio-editor |

**Deliberately left alone:** root \`package.json\` keywords (already broad), peripheral utilities (\`loaders\`, \`webaudio-peaks\`, \`worklets\`) — their existing keywords are adequate.

**No version bumps** — keywords ride along with each package's next normal release; no need to force a republish.

## Test plan

- [x] \`pnpm --filter website build\` — clean (Docusaurus served \`llms.txt\` without errors, all 7 \`package.json\` files parsed valid by pnpm workspace resolution)
- [ ] Eyeball rendered \`/llms.txt\` at deployed preview
- [ ] Confirm next per-package release picks up the new keywords