### PR TITLE
style(website): theme search bar + modal for Berlin Underground aesthetic

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -553,6 +553,56 @@ div[class*='announcementBar'] code {
   padding: 0.1em 0.4em;
 }
 
+/* ============================================
+   SEARCH MODAL — Berlin Underground theming
+   Overrides exposed by @easyops-cn/docusaurus-search-local
+   ============================================ */
+
+[data-theme='dark'] {
+  /* Modal panel — same pure-black as the navbar input so the field
+     visually extends into the dropdown when opened */
+  --search-local-modal-background: #000;
+  --search-local-modal-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 8px 32px 0 rgba(0, 0, 0, 0.6);
+
+  /* Result rows — subtle elevation over modal bg */
+  --search-local-hit-background: rgba(255, 255, 255, 0.03);
+  --search-local-hit-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --search-local-hit-color: var(--ifm-font-color-base);
+
+  /* Active/keyboard-selected row */
+  --search-local-highlight-color: var(--ifm-color-primary);
+  --search-local-hit-active-color: #0a0a0f;
+
+  /* Tree breadcrumbs, icons, file paths */
+  --search-local-muted-color: var(--ifm-font-color-secondary);
+
+  /* Navbar search input — match page body text (amber on near-black);
+     bg defaults to grey --ifm-color-emphasis-200, override to pure black
+     so the field reads as a depressed slot cut into the navbar */
+  --ifm-navbar-search-input-color: var(--ifm-font-color-base);
+  --ifm-navbar-search-input-placeholder-color: var(--ifm-font-color-secondary);
+  --ifm-navbar-search-input-background-color: #000;
+}
+
+/* Boxy/brutalist corners + body font — form inputs don't inherit
+   font-family by default, so set it explicitly to match page text */
+.navbar__search-input {
+  border-radius: 0;
+  font-family: var(--ifm-font-family-base);
+}
+
+/* Plugin uses CSS-modules with hashed class names; partial-match
+   attribute selectors are stable across builds. !important is needed
+   because the plugin's selectors (.searchBar .dropdownMenu) match our
+   specificity and load order isn't guaranteed. */
+[class*='dropdownMenu_'],
+[class*='suggestion_'],
+[class*='searchHint_'] {
+  border-radius: 0 !important;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .hero__title {


### PR DESCRIPTION
## Summary

Follow-up to #396 (offline search install). Overrides the plugin's exposed CSS variables plus a few Infima navbar tokens so the search experience integrates with the existing dark amber/red/green palette and brutalist corner treatment.

## Dark mode changes

| Surface | Before | After |
|---|---|---|
| Navbar search input bg | Grey (\`--ifm-color-emphasis-200\`) | Pure \`#000\` — reads as a slot cut into the navbar |
| Modal panel bg | Lighter surface (\`--ifm-background-surface-color\`) | Pure \`#000\` — matches the input, so the dropdown visually extends from it |
| Modal shadow | Default soft drop | Hairline 1px white outline + 8px/32px deep shadow |
| Result rows | Plain | \`rgba(255,255,255,0.03)\` lift + 1px inset border |
| Active/cursor row | Default highlight | Ampelmännchen green (\`#63C75F\`) bg with \`#0a0a0f\` text |
| Breadcrumbs/icons/paths | Default muted | Secondary amber (\`--ifm-font-color-secondary\`) |
| Input text + placeholder | Default | Body amber (\`--ifm-font-color-base\` / \`-secondary\`) |
| Input font | OS system UI | Space Grotesk (\`--ifm-font-family-base\`) |

## Brutalist corner consistency

Flattened \`border-radius\` to \`0\` on the input, modal panel, every result row, and the \`⌘K\` keycap hints — matches \`.button\`, \`.card\`, \`pre\`, and \`code\` elsewhere in \`custom.css\`.

## Implementation notes

- **CSS variables for everything reachable** — the plugin exposes \`--search-local-modal-background\`, \`--search-local-hit-*\`, \`--search-local-highlight-color\`, \`--search-local-muted-color\` etc. as \`var(name, fallback)\` patterns, so overriding at \`[data-theme='dark']\` is the lowest-friction path.
- **\`[class*='dropdownMenu_']\` attribute selectors** for things the plugin doesn't expose (like \`border-radius\`) — the plugin ships CSS modules with hashed class names, so we can't target \`.dropdownMenu\` literally. Same pattern as the existing \`div[class*='announcementBar']\` rules.
- **\`!important\` on radius overrides** — required because the plugin's selectors (\`.searchBar .dropdownMenu\`) match our specificity and load order isn't guaranteed.
- **Two hardcoded \`#000\` values** for input + modal bg — fine for now since the intent is \"these are the same thing\"; if that look sticks we can promote to a local \`--wfpl-search-bg\` var.

## Test plan

- [x] \`pnpm --filter website build\` — clean
- [x] Visual eyeball at \`pnpm --filter website serve\` — input slot reads black, dropdown extends flush, text in amber, green highlight on keyboard cursor, sharp corners throughout
- [ ] Confirm light mode unaffected (overrides are all gated behind \`[data-theme='dark']\`)
- [ ] Confirm no regression on the navbar's existing \`backdrop-filter\` interplay