### PR TITLE
test: add coverage for @waveform-playlist/spectrogram React layer

### DIFF
--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -17,7 +17,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "keywords": [
     "waveform",
@@ -42,9 +42,14 @@
     "README.md"
   ],
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.31",
     "@types/styled-components": "^5.1.36",
     "@waveform-playlist/browser": "workspace:*",
+    "jsdom": "^28.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "styled-components": "^6.4.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.6"

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef, useCallback, useMemo, type ReactNod
 import {
   MAX_CANVAS_WIDTH,
   type SpectrogramConfig,
-  type SpectrogramComputeConfig,
   type ColorMapValue,
   type RenderMode,
   type TrackSpectrogramOverrides,
@@ -14,6 +13,19 @@ import {
   SpectrogramAbortError,
   type SpectrogramWorkerApi,
 } from '@dawcore/spectrogram';
+import {
+  extractChunkNumber,
+  parseCanvasId,
+  groupContiguousIndices,
+  classifyChunkTiers,
+  computeChunkSampleRange,
+  resolveRenderMode,
+  toComputeConfig,
+  buildConfigKey,
+  buildFFTKey,
+  mapsDiffer,
+  type ChunkTiers,
+} from './spectrogram-helpers';
 import { SpectrogramMenuItems } from './components';
 import { SpectrogramSettingsModal } from './components';
 import {
@@ -22,16 +34,6 @@ import {
   type SpectrogramCanvasRegistration,
 } from '@waveform-playlist/browser';
 import { usePlaylistData, usePlaylistControls } from '@waveform-playlist/browser';
-
-/** Extract the chunk number from a canvas ID like "clipId-ch0-chunk5" → 5 */
-function extractChunkNumber(canvasId: string): number {
-  const match = canvasId.match(/chunk(\d+)$/);
-  if (!match) {
-    console.warn(`[spectrogram] Unexpected canvas ID format: ${canvasId}`);
-    return 0;
-  }
-  return parseInt(match[1], 10);
-}
 
 export interface SpectrogramProviderProps {
   config?: SpectrogramConfig;
@@ -136,50 +138,23 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     const currentKeys = new Map<string, string>();
     const currentFFTKeys = new Map<string, string>();
     tracks.forEach((track) => {
-      const mode =
-        trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+      const override = trackSpectrogramOverrides.get(track.id);
+      const mode = resolveRenderMode(override, track.renderMode);
       if (mode === 'waveform') return;
-      const cfg =
-        trackSpectrogramOverrides.get(track.id)?.config ??
-        track.spectrogramConfig ??
-        spectrogramConfig;
-      const cm =
-        trackSpectrogramOverrides.get(track.id)?.colorMap ??
-        track.spectrogramColorMap ??
-        spectrogramColorMap;
-      currentKeys.set(track.id, JSON.stringify({ mode, cfg, cm, mono }));
-      const computeConfig: SpectrogramComputeConfig = {
-        fftSize: cfg?.fftSize,
-        hopSize: cfg?.hopSize,
-        windowFunction: cfg?.windowFunction,
-        alpha: cfg?.alpha,
-        zeroPaddingFactor: cfg?.zeroPaddingFactor,
-      };
-      currentFFTKeys.set(track.id, JSON.stringify({ mode, mono, ...computeConfig }));
+      const cfg = override?.config ?? track.spectrogramConfig ?? spectrogramConfig;
+      const cm = override?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap;
+      currentKeys.set(track.id, buildConfigKey({ mode, cfg, cm, mono }));
+      currentFFTKeys.set(
+        track.id,
+        buildFFTKey({ mode, mono, computeConfig: toComputeConfig(cfg) })
+      );
     });
 
     const prevKeys = prevSpectrogramConfigRef.current;
     const prevFFTKeys = prevSpectrogramFFTKeyRef.current;
 
-    let configChanged = currentKeys.size !== prevKeys.size;
-    if (!configChanged) {
-      for (const [idx, key] of currentKeys) {
-        if (prevKeys.get(idx) !== key) {
-          configChanged = true;
-          break;
-        }
-      }
-    }
-
-    let fftKeyChanged = currentFFTKeys.size !== prevFFTKeys.size;
-    if (!fftKeyChanged) {
-      for (const [idx, key] of currentFFTKeys) {
-        if (prevFFTKeys.get(idx) !== key) {
-          fftKeyChanged = true;
-          break;
-        }
-      }
-    }
+    const configChanged = mapsDiffer(prevKeys, currentKeys);
+    const fftKeyChanged = mapsDiffer(prevFFTKeys, currentFFTKeys);
 
     const canvasVersionChanged = spectrogramCanvasVersion !== prevCanvasVersionRef.current;
     prevCanvasVersionRef.current = spectrogramCanvasVersion;
@@ -248,8 +223,8 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     }> = [];
 
     tracks.forEach((track, i) => {
-      const mode =
-        trackSpectrogramOverrides.get(track.id)?.renderMode ?? track.renderMode ?? 'waveform';
+      const override = trackSpectrogramOverrides.get(track.id);
+      const mode = resolveRenderMode(override, track.renderMode);
       if (mode === 'waveform') return;
 
       const trackConfigChanged =
@@ -261,16 +236,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
         track.clips.some((clip) => spectrogramCanvasRegistryRef.current.has(clip.id));
       if (!trackConfigChanged && !hasRegisteredCanvases) return;
 
-      const cfg =
-        trackSpectrogramOverrides.get(track.id)?.config ??
-        track.spectrogramConfig ??
-        spectrogramConfig ??
-        {};
+      const cfg = override?.config ?? track.spectrogramConfig ?? spectrogramConfig ?? {};
       const cm =
-        trackSpectrogramOverrides.get(track.id)?.colorMap ??
-        track.spectrogramColorMap ??
-        spectrogramColorMap ??
-        'viridis';
+        override?.colorMap ?? track.spectrogramColorMap ?? spectrogramColorMap ?? 'viridis';
 
       for (const clip of track.clips) {
         if (!clip.audioBuffer) continue;
@@ -327,42 +295,15 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     const getVisibleChunkRange = (
       channelInfo: { canvasIds: string[]; canvasWidths: number[] },
       clipPixelOffset = 0
-    ): { viewportIndices: number[]; bufferIndices: number[]; remainingIndices: number[] } => {
+    ): ChunkTiers => {
       const container = scrollContainerRef.current;
-      if (!container) {
-        return {
-          viewportIndices: channelInfo.canvasWidths.map((_, i) => i),
-          bufferIndices: [],
-          remainingIndices: [],
-        };
-      }
-
-      const scrollLeft = container.scrollLeft;
-      const viewportWidth = container.clientWidth;
-      // Match the 1.5× overscan buffer used by useVisibleChunkIndices
-      // (ScrollViewport.tsx) so spectrogram FFT covers all mounted canvases.
-      const buffer = viewportWidth * 1.5;
-      const bufferStart = Math.max(0, scrollLeft - buffer);
-      const bufferEnd = scrollLeft + viewportWidth + buffer;
-
-      const viewportIndices: number[] = [];
-      const bufferIndices: number[] = [];
-      const remainingIndices: number[] = [];
-
-      for (let i = 0; i < channelInfo.canvasWidths.length; i++) {
-        const chunkNumber = extractChunkNumber(channelInfo.canvasIds[i]);
-        const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + clipPixelOffset;
-        const chunkRight = chunkLeft + channelInfo.canvasWidths[i];
-        if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
-          viewportIndices.push(i);
-        } else if (chunkRight > bufferStart && chunkLeft < bufferEnd) {
-          bufferIndices.push(i);
-        } else {
-          remainingIndices.push(i);
-        }
-      }
-
-      return { viewportIndices, bufferIndices, remainingIndices };
+      return classifyChunkTiers(
+        channelInfo,
+        clipPixelOffset,
+        container
+          ? { scrollLeft: container.scrollLeft, viewportWidth: container.clientWidth }
+          : null
+      );
     };
 
     const renderChunkSubset = async (
@@ -430,29 +371,15 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       },
       gen: number
     ): Promise<string> => {
-      // Determine the sample range these chunks cover
-      const chunkNumbers = indices.map((i) => extractChunkNumber(channelInfo.canvasIds[i]));
-      const minChunk = Math.min(...chunkNumbers);
-      const maxChunk = Math.max(...chunkNumbers);
-      const maxChunkIdx = indices[chunkNumbers.indexOf(maxChunk)];
-      const lastChunkWidth = channelInfo.canvasWidths[maxChunkIdx];
-
-      const startPx = minChunk * MAX_CANVAS_WIDTH;
-      const endPx = maxChunk * MAX_CANVAS_WIDTH + lastChunkWidth;
-
-      const windowSize = item.config.fftSize ?? 2048;
-      const rangeStartSample = item.offsetSamples + Math.floor(startPx * samplesPerPixel);
-      const rangeEndSample = Math.min(
-        item.offsetSamples + item.durationSamples,
-        item.offsetSamples + Math.ceil(endPx * samplesPerPixel)
-      );
-
-      // Pad by windowSize to avoid edge artifacts
-      const paddedStart = Math.max(item.offsetSamples, rangeStartSample - windowSize);
-      const paddedEnd = Math.min(
-        item.offsetSamples + item.durationSamples,
-        rangeEndSample + windowSize
-      );
+      // Determine the (window-padded) sample range these chunks cover.
+      const { paddedStart, paddedEnd } = computeChunkSampleRange({
+        channelInfo,
+        indices,
+        fftSize: item.config.fftSize ?? 2048,
+        offsetSamples: item.offsetSamples,
+        durationSamples: item.durationSamples,
+        samplesPerPixel,
+      });
 
       const { cacheKey } = await api.computeFFT(
         {
@@ -469,31 +396,6 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       );
 
       return cacheKey;
-    };
-
-    // Split indices into contiguous groups based on chunk numbers.
-    // E.g., remaining=[0,1,4,5] → [[0,1],[4,5]] — prevents computing
-    // an FFT range spanning the gap between 1 and 4.
-    const groupContiguousIndices = (
-      channelInfo: { canvasIds: string[] },
-      indices: number[]
-    ): number[][] => {
-      if (indices.length === 0) return [];
-      const groups: number[][] = [];
-      let currentGroup = [indices[0]];
-      let prevChunk = extractChunkNumber(channelInfo.canvasIds[indices[0]]);
-      for (let i = 1; i < indices.length; i++) {
-        const chunk = extractChunkNumber(channelInfo.canvasIds[indices[i]]);
-        if (chunk === prevChunk + 1) {
-          currentGroup.push(indices[i]);
-        } else {
-          groups.push(currentGroup);
-          currentGroup = [indices[i]];
-        }
-        prevChunk = chunk;
-      }
-      groups.push(currentGroup);
-      return groups;
     };
 
     const computeAsync = async () => {
@@ -894,10 +796,9 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
     }
 
     // Canvas IDs follow the format `${clipId}-ch${channelIndex}-chunk${n}`.
-    const match = canvasId.match(/^(.+)-ch(\d+)-chunk\d+$/);
-    if (!match) return;
-    const clipId = match[1];
-    const channelIndex = parseInt(match[2], 10);
+    const parsed = parseCanvasId(canvasId);
+    if (!parsed) return;
+    const { clipId, channelIndex } = parsed;
 
     const registry = spectrogramCanvasRegistryRef.current;
     const perClip = registry.get(clipId);

--- a/packages/spectrogram/src/__tests__/SpectrogramMenuItems.test.tsx
+++ b/packages/spectrogram/src/__tests__/SpectrogramMenuItems.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SpectrogramMenuItems } from '../components/SpectrogramMenuItems';
+
+afterEach(() => cleanup());
+
+function setup(overrides: Partial<Parameters<typeof SpectrogramMenuItems>[0]> = {}) {
+  const props = {
+    renderMode: 'waveform' as const,
+    onRenderModeChange: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  const items = SpectrogramMenuItems(props);
+  // Render each item's content so we can interact with it.
+  render(
+    <div>
+      {items.map((item) => (
+        <React.Fragment key={item.id}>{item.content}</React.Fragment>
+      ))}
+    </div>
+  );
+  return { props, items };
+}
+
+describe('SpectrogramMenuItems', () => {
+  it('returns a display item and a settings item', () => {
+    const { items } = setup();
+    expect(items.map((i) => i.id)).toEqual(['spectrogram-display', 'spectrogram-settings']);
+  });
+
+  it('checks the radio matching the current render mode', () => {
+    setup({ renderMode: 'spectrogram' });
+    const spectrogram = screen.getByLabelText('Spectrogram') as HTMLInputElement;
+    const waveform = screen.getByLabelText('Waveform') as HTMLInputElement;
+    expect(spectrogram.checked).toBe(true);
+    expect(waveform.checked).toBe(false);
+  });
+
+  it('emits the selected mode and closes the menu on change', () => {
+    const { props } = setup({ renderMode: 'waveform' });
+    fireEvent.click(screen.getByLabelText('Both'));
+    expect(props.onRenderModeChange).toHaveBeenCalledWith('both');
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it('opens settings (after closing the menu) from the settings button', () => {
+    const { props } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /spectrogram settings/i }));
+    expect(props.onClose).toHaveBeenCalledOnce();
+    expect(props.onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it('does not require an onClose handler', () => {
+    const onRenderModeChange = vi.fn();
+    const items = SpectrogramMenuItems({
+      renderMode: 'waveform',
+      onRenderModeChange,
+      onOpenSettings: vi.fn(),
+    });
+    render(
+      <div>
+        {items.map((i) => (
+          <React.Fragment key={i.id}>{i.content}</React.Fragment>
+        ))}
+      </div>
+    );
+    expect(() => fireEvent.click(screen.getByLabelText('Spectrogram'))).not.toThrow();
+    expect(onRenderModeChange).toHaveBeenCalledWith('spectrogram');
+  });
+});

--- a/packages/spectrogram/src/__tests__/SpectrogramSettingsModal.test.tsx
+++ b/packages/spectrogram/src/__tests__/SpectrogramSettingsModal.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { SpectrogramConfig, ColorMapValue } from '@waveform-playlist/core';
+import { SpectrogramSettingsModal } from '../components/SpectrogramSettingsModal';
+
+// jsdom historically lacked <dialog> showModal/close. Polyfill only when absent
+// so the open/close effect doesn't throw. The form content renders regardless
+// of actual modal open-state, so assertions hold either way.
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+      this.open = true;
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+      this.open = false;
+      this.dispatchEvent(new Event('close'));
+    };
+  }
+});
+
+afterEach(() => cleanup());
+
+const baseConfig: SpectrogramConfig = {
+  fftSize: 4096,
+  windowFunction: 'hamming',
+  frequencyScale: 'linear',
+  minFrequency: 100,
+  maxFrequency: 18000,
+  gainDb: 30,
+  rangeDb: 70,
+  zeroPaddingFactor: 4,
+  hopSize: 1024,
+  labels: true,
+};
+
+function renderModal(
+  overrides: {
+    open?: boolean;
+    config?: SpectrogramConfig;
+    colorMap?: ColorMapValue;
+    onApply?: ReturnType<typeof vi.fn>;
+    onClose?: ReturnType<typeof vi.fn>;
+  } = {}
+) {
+  const onApply = overrides.onApply ?? vi.fn();
+  const onClose = overrides.onClose ?? vi.fn();
+  const utils = render(
+    <SpectrogramSettingsModal
+      open={overrides.open ?? true}
+      onClose={onClose}
+      config={overrides.config ?? baseConfig}
+      colorMap={overrides.colorMap ?? 'magma'}
+      onApply={onApply}
+    />
+  );
+  // DOM order: [fftSize, hopSize, zeroPadding, windowFn, freqScale, colorMap]
+  const selects = () => screen.getAllByRole('combobox') as HTMLSelectElement[];
+  // DOM order: [minFreq, maxFreq, rangeDb, gainDb]
+  const numbers = () => screen.getAllByRole('spinbutton') as HTMLInputElement[];
+  return { onApply, onClose, selects, numbers, ...utils };
+}
+
+describe('SpectrogramSettingsModal', () => {
+  it('initialises form fields from the config and color map', () => {
+    const { selects, numbers } = renderModal();
+    const [fft, hop, zeroPad, windowFn, freqScale, colorMap] = selects();
+    expect(fft.value).toBe('4096');
+    expect(hop.value).toBe('1024');
+    expect(zeroPad.value).toBe('4');
+    expect(windowFn.value).toBe('hamming');
+    expect(freqScale.value).toBe('linear');
+    expect(colorMap.value).toBe('magma');
+
+    const [minFreq, maxFreq, rangeDb, gainDb] = numbers();
+    expect(minFreq.value).toBe('100');
+    expect(maxFreq.value).toBe('18000');
+    expect(rangeDb.value).toBe('70');
+    expect(gainDb.value).toBe('30');
+
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('updates hop size when the FFT size changes', () => {
+    const { selects } = renderModal();
+    fireEvent.change(selects()[0], { target: { value: '8192' } });
+    // hop size resets to fftSize / 4 = 2048
+    expect(selects()[1].value).toBe('2048');
+  });
+
+  it('Apply emits the edited config plus color map, then closes', () => {
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    const { selects } = renderModal({ onApply, onClose });
+
+    fireEvent.change(selects()[3], { target: { value: 'blackman' } }); // window function
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const [emittedConfig, emittedColorMap] = onApply.mock.calls[0];
+    expect(emittedConfig).toMatchObject({
+      fftSize: 4096,
+      windowFunction: 'blackman',
+      frequencyScale: 'linear',
+      minFrequency: 100,
+      maxFrequency: 18000,
+      gainDb: 30,
+      rangeDb: 70,
+      zeroPaddingFactor: 4,
+      hopSize: 1024,
+      labels: true,
+    });
+    expect(emittedColorMap).toBe('magma');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cancel closes without applying', () => {
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onApply, onClose });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it('re-syncs local form state when the config prop changes', () => {
+    const { selects, rerender } = renderModal();
+    expect(selects()[0].value).toBe('4096');
+
+    rerender(
+      <SpectrogramSettingsModal
+        open
+        onClose={vi.fn()}
+        config={{ ...baseConfig, fftSize: 512, windowFunction: 'hann' }}
+        colorMap="viridis"
+        onApply={vi.fn()}
+      />
+    );
+
+    expect(selects()[0].value).toBe('512');
+    expect(selects()[3].value).toBe('hann');
+    expect((selects()[5] as HTMLSelectElement).value).toBe('viridis');
+  });
+});

--- a/packages/spectrogram/src/__tests__/spectrogram-helpers.test.ts
+++ b/packages/spectrogram/src/__tests__/spectrogram-helpers.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  extractChunkNumber,
+  parseCanvasId,
+  groupContiguousIndices,
+  classifyChunkTiers,
+  computeChunkSampleRange,
+  resolveRenderMode,
+  toComputeConfig,
+  buildConfigKey,
+  buildFFTKey,
+  mapsDiffer,
+  type ChannelChunkInfo,
+} from '../spectrogram-helpers';
+import type { SpectrogramConfig } from '@waveform-playlist/core';
+
+// Build a ChannelChunkInfo from an array of chunk numbers, with a uniform
+// (or per-chunk) canvas width. Canvas IDs follow `clip-ch0-chunk{n}`.
+function channelInfo(chunkNumbers: number[], widths: number | number[] = 1000): ChannelChunkInfo {
+  return {
+    canvasIds: chunkNumbers.map((n) => `clip-ch0-chunk${n}`),
+    canvasWidths: chunkNumbers.map((_, i) => (Array.isArray(widths) ? widths[i] : widths)),
+  };
+}
+
+describe('extractChunkNumber', () => {
+  it('extracts the trailing chunk number', () => {
+    expect(extractChunkNumber('clip-ch0-chunk5')).toBe(5);
+    expect(extractChunkNumber('a-b-c-ch1-chunk42')).toBe(42);
+    expect(extractChunkNumber('chunk0')).toBe(0);
+  });
+
+  it('returns 0 and warns on an unexpected format', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(extractChunkNumber('not-a-valid-id')).toBe(0);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});
+
+describe('parseCanvasId', () => {
+  it('parses clip id and channel index', () => {
+    expect(parseCanvasId('myclip-ch0-chunk5')).toEqual({ clipId: 'myclip', channelIndex: 0 });
+    expect(parseCanvasId('clip-ch2-chunk10')).toEqual({ clipId: 'clip', channelIndex: 2 });
+  });
+
+  it('keeps hyphens in the clip id (greedy match)', () => {
+    expect(parseCanvasId('a-b-c-ch1-chunk0')).toEqual({ clipId: 'a-b-c', channelIndex: 1 });
+  });
+
+  it('returns null when the id does not match', () => {
+    expect(parseCanvasId('bad')).toBeNull();
+    expect(parseCanvasId('clip-ch0')).toBeNull();
+    expect(parseCanvasId('clip-chunk0')).toBeNull();
+  });
+});
+
+describe('groupContiguousIndices', () => {
+  it('returns an empty array for no indices', () => {
+    expect(groupContiguousIndices(channelInfo([0, 1, 2]), [])).toEqual([]);
+  });
+
+  it('keeps contiguous chunks in one group', () => {
+    expect(groupContiguousIndices(channelInfo([0, 1, 2]), [0, 1, 2])).toEqual([[0, 1, 2]]);
+  });
+
+  it('splits at gaps in chunk numbers', () => {
+    // indices [0,1,2,3] map to chunk numbers [0,1,4,5] → two groups
+    expect(groupContiguousIndices(channelInfo([0, 1, 4, 5]), [0, 1, 2, 3])).toEqual([
+      [0, 1],
+      [2, 3],
+    ]);
+  });
+
+  it('groups by chunk number, not index position', () => {
+    // registry holds non-consecutive chunks [10,14,15]
+    expect(groupContiguousIndices(channelInfo([10, 14, 15]), [0, 1, 2])).toEqual([[0], [1, 2]]);
+  });
+});
+
+describe('classifyChunkTiers', () => {
+  it('treats every chunk as in-viewport when there is no container', () => {
+    const info = channelInfo([0, 1, 2]);
+    expect(classifyChunkTiers(info, 0, null)).toEqual({
+      viewportIndices: [0, 1, 2],
+      bufferIndices: [],
+      remainingIndices: [],
+    });
+  });
+
+  it('classifies into viewport / buffer / remaining tiers', () => {
+    // chunks 0..3, width 1000 each, MAX_CANVAS_WIDTH=1000.
+    // viewport: scrollLeft 0, width 1000. buffer overscan = 1.5 * 1000 = 1500.
+    const info = channelInfo([0, 1, 2, 3]);
+    const tiers = classifyChunkTiers(info, 0, { scrollLeft: 0, viewportWidth: 1000 });
+    expect(tiers.viewportIndices).toEqual([0]); // [0,1000) intersects viewport
+    expect(tiers.bufferIndices).toEqual([1, 2]); // left < bufferEnd (2500)
+    expect(tiers.remainingIndices).toEqual([3]); // left 3000 > bufferEnd
+  });
+
+  it('shifts classification by the clip pixel offset', () => {
+    // Same chunks, but the clip starts 1000px into the timeline.
+    const info = channelInfo([0, 1, 2, 3]);
+    const tiers = classifyChunkTiers(info, 1000, { scrollLeft: 1000, viewportWidth: 1000 });
+    // chunk0 now spans [1000,2000) → intersects viewport at scrollLeft 1000
+    expect(tiers.viewportIndices).toEqual([0]);
+  });
+});
+
+describe('computeChunkSampleRange', () => {
+  it('covers the chunk range without padding past the clip when far from edges', () => {
+    const info = channelInfo([0, 1], 1000);
+    const range = computeChunkSampleRange({
+      channelInfo: info,
+      indices: [0, 1],
+      fftSize: 2048,
+      offsetSamples: 0,
+      durationSamples: 1_000_000,
+      samplesPerPixel: 256,
+    });
+    // startPx=0 → rangeStart 0 → padded max(0, -2048) = 0
+    // endPx=2000 → rangeEnd ceil(2000*256)=512000 → padded +2048 = 514048
+    expect(range).toEqual({ paddedStart: 0, paddedEnd: 514048 });
+  });
+
+  it('clamps padded range to the clip bounds', () => {
+    const info = channelInfo([5], 500);
+    const range = computeChunkSampleRange({
+      channelInfo: info,
+      indices: [0],
+      fftSize: 1024,
+      offsetSamples: 10_000,
+      durationSamples: 50_000, // clip ends at sample 60_000
+      samplesPerPixel: 10,
+    });
+    // startPx=5000 → rangeStart 10000 + 50000 = 60000 (== clip end)
+    // rangeEnd clamps to 60000; paddedStart = 60000-1024 = 58976; paddedEnd clamps to 60000
+    expect(range).toEqual({ paddedStart: 58_976, paddedEnd: 60_000 });
+  });
+});
+
+describe('resolveRenderMode', () => {
+  it('prefers the override render mode', () => {
+    expect(resolveRenderMode({ renderMode: 'spectrogram' }, 'waveform')).toBe('spectrogram');
+  });
+
+  it('falls back to the track render mode when there is no override', () => {
+    expect(resolveRenderMode(undefined, 'both')).toBe('both');
+    expect(resolveRenderMode(undefined, 'spectrogram')).toBe('spectrogram');
+  });
+
+  it('defaults to waveform when nothing is set', () => {
+    expect(resolveRenderMode(undefined, undefined)).toBe('waveform');
+  });
+});
+
+describe('toComputeConfig', () => {
+  it('returns all-undefined fields for undefined config', () => {
+    expect(toComputeConfig(undefined)).toEqual({
+      fftSize: undefined,
+      hopSize: undefined,
+      windowFunction: undefined,
+      alpha: undefined,
+      zeroPaddingFactor: undefined,
+    });
+  });
+
+  it('picks only the FFT-affecting fields', () => {
+    const result = toComputeConfig({
+      fftSize: 4096,
+      hopSize: 1024,
+      windowFunction: 'hamming',
+      alpha: 0.5,
+      zeroPaddingFactor: 4,
+      // appearance-only fields must NOT leak into the compute config:
+      frequencyScale: 'mel',
+      minFrequency: 0,
+      maxFrequency: 20000,
+      gainDb: 20,
+      rangeDb: 80,
+    });
+    expect(result).toEqual({
+      fftSize: 4096,
+      hopSize: 1024,
+      windowFunction: 'hamming',
+      alpha: 0.5,
+      zeroPaddingFactor: 4,
+    });
+    expect(result).not.toHaveProperty('frequencyScale');
+    expect(result).not.toHaveProperty('gainDb');
+  });
+});
+
+describe('buildConfigKey / buildFFTKey', () => {
+  it('produces a stable key for identical inputs', () => {
+    const a = buildConfigKey({
+      mode: 'spectrogram',
+      cfg: { fftSize: 2048 },
+      cm: 'viridis',
+      mono: false,
+    });
+    const b = buildConfigKey({
+      mode: 'spectrogram',
+      cfg: { fftSize: 2048 },
+      cm: 'viridis',
+      mono: false,
+    });
+    expect(a).toBe(b);
+  });
+
+  it('config key changes with color map, but FFT key does not', () => {
+    const base = {
+      mode: 'spectrogram' as const,
+      cfg: { fftSize: 2048 } as SpectrogramConfig,
+      mono: false,
+    };
+    const cfgKeyA = buildConfigKey({ ...base, cm: 'viridis' });
+    const cfgKeyB = buildConfigKey({ ...base, cm: 'magma' });
+    expect(cfgKeyA).not.toBe(cfgKeyB);
+
+    const computeConfig = toComputeConfig(base.cfg);
+    const fftKeyA = buildFFTKey({ mode: base.mode, mono: base.mono, computeConfig });
+    const fftKeyB = buildFFTKey({ mode: base.mode, mono: base.mono, computeConfig });
+    expect(fftKeyA).toBe(fftKeyB);
+    // colour map is not part of the FFT key at all
+    expect(fftKeyA).not.toContain('viridis');
+    expect(fftKeyA).not.toContain('magma');
+  });
+
+  it('FFT key changes when an FFT-affecting field changes', () => {
+    const keyA = buildFFTKey({
+      mode: 'spectrogram',
+      mono: false,
+      computeConfig: toComputeConfig({ fftSize: 2048 }),
+    });
+    const keyB = buildFFTKey({
+      mode: 'spectrogram',
+      mono: false,
+      computeConfig: toComputeConfig({ fftSize: 4096 }),
+    });
+    expect(keyA).not.toBe(keyB);
+  });
+});
+
+describe('mapsDiffer', () => {
+  const map = (entries: [string, string][]) => new Map(entries);
+
+  it('returns false for equal maps', () => {
+    expect(mapsDiffer(map([['a', '1']]), map([['a', '1']]))).toBe(false);
+  });
+
+  it('returns true when sizes differ', () => {
+    expect(
+      mapsDiffer(
+        map([['a', '1']]),
+        map([
+          ['a', '1'],
+          ['b', '2'],
+        ])
+      )
+    ).toBe(true);
+  });
+
+  it('returns true when a value differs', () => {
+    expect(mapsDiffer(map([['a', '1']]), map([['a', '2']]))).toBe(true);
+  });
+
+  it('returns true when keys differ at equal size', () => {
+    expect(mapsDiffer(map([['a', '1']]), map([['b', '1']]))).toBe(true);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/packages/spectrogram/src/spectrogram-helpers.ts
+++ b/packages/spectrogram/src/spectrogram-helpers.ts
@@ -1,0 +1,238 @@
+import {
+  MAX_CANVAS_WIDTH,
+  type SpectrogramConfig,
+  type SpectrogramComputeConfig,
+  type ColorMapValue,
+  type RenderMode,
+  type TrackSpectrogramOverrides,
+} from '@waveform-playlist/core';
+
+/**
+ * Pure, side-effect-free helpers extracted from `SpectrogramProvider`.
+ *
+ * These cover the geometry/key logic that the provider's worker-orchestration
+ * effect depends on (chunk classification, FFT sample ranges, contiguous
+ * grouping, config-change detection). Keeping them DOM-free makes them unit
+ * testable in a Node environment — the provider supplies the imperative shell
+ * (refs, worker calls, React state) around this functional core.
+ */
+
+/** A channel's registered canvas chunks: parallel arrays of IDs and pixel widths. */
+export interface ChannelChunkInfo {
+  canvasIds: string[];
+  canvasWidths: number[];
+}
+
+/** Chunk indices grouped by their relationship to the current scroll viewport. */
+export interface ChunkTiers {
+  /** Chunks intersecting the exact viewport — fast first paint. */
+  viewportIndices: number[];
+  /** Chunks within the 1.5× overscan buffer but outside the viewport. */
+  bufferIndices: number[];
+  /** Chunks outside the buffer — rendered in background batches. */
+  remainingIndices: number[];
+}
+
+/** Scroll-container metrics needed to classify chunks. `null` ⇒ no container yet. */
+export interface ViewportMetrics {
+  scrollLeft: number;
+  viewportWidth: number;
+}
+
+/** Extract the chunk number from a canvas ID like `"clipId-ch0-chunk5"` → `5`. */
+export function extractChunkNumber(canvasId: string): number {
+  const match = canvasId.match(/chunk(\d+)$/);
+  if (!match) {
+    console.warn(`[spectrogram] Unexpected canvas ID format: ${canvasId}`);
+    return 0;
+  }
+  return parseInt(match[1], 10);
+}
+
+/**
+ * Parse a canvas ID of the form `${clipId}-ch${channelIndex}-chunk${n}` into its
+ * clip ID and channel index. Returns `null` when the ID doesn't match.
+ */
+export function parseCanvasId(canvasId: string): { clipId: string; channelIndex: number } | null {
+  const match = canvasId.match(/^(.+)-ch(\d+)-chunk\d+$/);
+  if (!match) return null;
+  return { clipId: match[1], channelIndex: parseInt(match[2], 10) };
+}
+
+/**
+ * Split indices into contiguous groups based on their chunk numbers, e.g.
+ * indices mapping to chunks `[0,1,4,5]` → `[[0,1],[4,5]]`. Prevents computing an
+ * FFT range that spans the gap between non-adjacent chunks.
+ */
+export function groupContiguousIndices(
+  channelInfo: { canvasIds: string[] },
+  indices: number[]
+): number[][] {
+  if (indices.length === 0) return [];
+  const groups: number[][] = [];
+  let currentGroup = [indices[0]];
+  let prevChunk = extractChunkNumber(channelInfo.canvasIds[indices[0]]);
+  for (let i = 1; i < indices.length; i++) {
+    const chunk = extractChunkNumber(channelInfo.canvasIds[indices[i]]);
+    if (chunk === prevChunk + 1) {
+      currentGroup.push(indices[i]);
+    } else {
+      groups.push(currentGroup);
+      currentGroup = [indices[i]];
+    }
+    prevChunk = chunk;
+  }
+  groups.push(currentGroup);
+  return groups;
+}
+
+/**
+ * Classify a channel's chunks into viewport / buffer / remaining tiers.
+ *
+ * The buffer uses a 1.5× viewport-width overscan to match
+ * `useVisibleChunkIndices` in ScrollViewport, so FFT covers every mounted
+ * canvas. When `viewport` is `null` (no scroll container yet), every chunk is
+ * treated as in-viewport.
+ */
+export function classifyChunkTiers(
+  channelInfo: ChannelChunkInfo,
+  clipPixelOffset = 0,
+  viewport: ViewportMetrics | null
+): ChunkTiers {
+  if (!viewport) {
+    return {
+      viewportIndices: channelInfo.canvasWidths.map((_, i) => i),
+      bufferIndices: [],
+      remainingIndices: [],
+    };
+  }
+
+  const { scrollLeft, viewportWidth } = viewport;
+  const buffer = viewportWidth * 1.5;
+  const bufferStart = Math.max(0, scrollLeft - buffer);
+  const bufferEnd = scrollLeft + viewportWidth + buffer;
+
+  const viewportIndices: number[] = [];
+  const bufferIndices: number[] = [];
+  const remainingIndices: number[] = [];
+
+  for (let i = 0; i < channelInfo.canvasWidths.length; i++) {
+    const chunkNumber = extractChunkNumber(channelInfo.canvasIds[i]);
+    const chunkLeft = chunkNumber * MAX_CANVAS_WIDTH + clipPixelOffset;
+    const chunkRight = chunkLeft + channelInfo.canvasWidths[i];
+    if (chunkRight > scrollLeft && chunkLeft < scrollLeft + viewportWidth) {
+      viewportIndices.push(i);
+    } else if (chunkRight > bufferStart && chunkLeft < bufferEnd) {
+      bufferIndices.push(i);
+    } else {
+      remainingIndices.push(i);
+    }
+  }
+
+  return { viewportIndices, bufferIndices, remainingIndices };
+}
+
+export interface ChunkSampleRangeParams {
+  channelInfo: { canvasIds: string[]; canvasWidths: number[] };
+  indices: number[];
+  /** FFT window size (samples) used to pad the range against edge artifacts. */
+  fftSize: number;
+  offsetSamples: number;
+  durationSamples: number;
+  samplesPerPixel: number;
+}
+
+/**
+ * Compute the (window-padded, clip-clamped) sample range covered by a set of
+ * chunk indices. Computing per-batch ranges on demand avoids allocating one
+ * giant FFT array for a full clip (which OOMs on 1hr+ files).
+ */
+export function computeChunkSampleRange({
+  channelInfo,
+  indices,
+  fftSize,
+  offsetSamples,
+  durationSamples,
+  samplesPerPixel,
+}: ChunkSampleRangeParams): { paddedStart: number; paddedEnd: number } {
+  const chunkNumbers = indices.map((i) => extractChunkNumber(channelInfo.canvasIds[i]));
+  const minChunk = Math.min(...chunkNumbers);
+  const maxChunk = Math.max(...chunkNumbers);
+  const maxChunkIdx = indices[chunkNumbers.indexOf(maxChunk)];
+  const lastChunkWidth = channelInfo.canvasWidths[maxChunkIdx];
+
+  const startPx = minChunk * MAX_CANVAS_WIDTH;
+  const endPx = maxChunk * MAX_CANVAS_WIDTH + lastChunkWidth;
+
+  const rangeStartSample = offsetSamples + Math.floor(startPx * samplesPerPixel);
+  const rangeEndSample = Math.min(
+    offsetSamples + durationSamples,
+    offsetSamples + Math.ceil(endPx * samplesPerPixel)
+  );
+
+  // Pad by one window on each side to avoid edge artifacts, clamped to the clip.
+  const paddedStart = Math.max(offsetSamples, rangeStartSample - fftSize);
+  const paddedEnd = Math.min(offsetSamples + durationSamples, rangeEndSample + fftSize);
+
+  return { paddedStart, paddedEnd };
+}
+
+/** Resolve a track's effective render mode: override → track → `'waveform'`. */
+export function resolveRenderMode(
+  override: TrackSpectrogramOverrides | undefined,
+  trackRenderMode: RenderMode | undefined
+): RenderMode {
+  return override?.renderMode ?? trackRenderMode ?? 'waveform';
+}
+
+/** Project a `SpectrogramConfig` down to the fields that affect FFT computation. */
+export function toComputeConfig(cfg: SpectrogramConfig | undefined): SpectrogramComputeConfig {
+  return {
+    fftSize: cfg?.fftSize,
+    hopSize: cfg?.hopSize,
+    windowFunction: cfg?.windowFunction,
+    alpha: cfg?.alpha,
+    zeroPaddingFactor: cfg?.zeroPaddingFactor,
+  };
+}
+
+/**
+ * Stable string key for a track's full spectrogram appearance (mode + config +
+ * color map + mono). A change means the rendered output must be recomputed.
+ */
+export function buildConfigKey(params: {
+  mode: RenderMode;
+  cfg: SpectrogramConfig | undefined;
+  cm: ColorMapValue | undefined;
+  mono: boolean;
+}): string {
+  const { mode, cfg, cm, mono } = params;
+  return JSON.stringify({ mode, cfg, cm, mono });
+}
+
+/**
+ * Stable string key for the inputs that affect the FFT only (mode + mono +
+ * compute config). A change here means the cached FFT data is stale; a config
+ * change that leaves this key untouched (e.g. color map) only needs re-display.
+ */
+export function buildFFTKey(params: {
+  mode: RenderMode;
+  mono: boolean;
+  computeConfig: SpectrogramComputeConfig;
+}): string {
+  const { mode, mono, computeConfig } = params;
+  return JSON.stringify({ mode, mono, ...computeConfig });
+}
+
+/**
+ * Whether two key maps differ — different size, or any key present in `current`
+ * whose value doesn't match `prev`. Used to detect config/FFT changes between
+ * effect runs.
+ */
+export function mapsDiffer(prev: Map<string, string>, current: Map<string, string>): boolean {
+  if (current.size !== prev.size) return true;
+  for (const [key, value] of current) {
+    if (prev.get(key) !== value) return true;
+  }
+  return false;
+}

--- a/packages/spectrogram/vitest.config.ts
+++ b/packages/spectrogram/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,13 +425,10 @@ importers:
       '@waveform-playlist/core':
         specifier: workspace:*
         version: link:../core
-      react:
-        specifier: ^18.0.0
-        version: 18.3.1
-      styled-components:
-        specifier: ^6.0.0
-        version: 6.4.2(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)
       '@types/react':
         specifier: ^18.3.31
         version: 18.3.31
@@ -441,6 +438,18 @@ importers:
       '@waveform-playlist/browser':
         specifier: workspace:*
         version: link:../browser
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      styled-components:
+        specifier: ^6.4.2
+        version: 6.4.2(react-dom@18.3.1)(react@18.3.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.41)(postcss@8.5.15)(typescript@5.9.3)
@@ -5666,17 +5675,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1):
-    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
-    peerDependencies:
-      '@types/react': '>=16'
-      react: '>=16'
-    dependencies:
-      '@types/mdx': 2.0.14
-      '@types/react': 18.3.31
-      react: 18.3.1
-    dev: true
-
   /@mdx-js/react@3.1.1(@types/react@18.3.31)(react@19.2.7):
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
@@ -8108,13 +8106,13 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@18.3.31)(react@18.3.1)
+      '@mdx-js/react': 3.1.1(@types/react@18.3.31)(react@19.2.7)
       '@storybook/csf-plugin': 10.4.3(esbuild@0.27.7)(storybook@10.4.3)(vite@8.0.16)(webpack@5.104.1)
-      '@storybook/icons': 2.0.2(react-dom@18.3.1)(react@18.3.1)
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@18.3.1)(react@18.3.1)(storybook@10.4.3)
+      '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.3)
       '@types/react': 18.3.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.6.2)(react-dom@18.3.1)(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -8230,6 +8228,16 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: true
 
+  /@storybook/icons@2.0.2(react-dom@19.2.7)(react@19.2.7):
+    resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    dev: true
+
   /@storybook/preset-react-webpack@10.4.3(@swc/core@1.15.41)(esbuild@0.27.7)(postcss@8.5.15)(react-dom@18.3.1)(react@18.3.1)(storybook@10.4.3)(typescript@5.9.3):
     resolution: {integrity: sha512-814EDY4yMTVECLoIFeCdbpoRuaFxtvN/U5TcB6czb6SDabaagEHsXWWVIDhx1xZlBGK6KUrxD9CMACPcB2fcKA==}
     peerDependencies:
@@ -8308,6 +8316,27 @@ packages:
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.6.2)(react-dom@18.3.1)(react@18.3.1)
+    dev: true
+
+  /@storybook/react-dom-shim@10.4.3(@types/react-dom@18.3.7)(@types/react@18.3.31)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.3):
+    resolution: {integrity: sha512-aPZ+Afd+zdoSygISOVCJIYdiqWJM6uRZFw0zhsONwNcn3kU1TNce6iAoBCY8cpEhDAu61M1QjeIHM3LPy/ieog==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.6.2)(react-dom@18.3.1)(react@18.3.1)
     dev: true
 


### PR DESCRIPTION
## Summary

`@dawcore/spectrogram` (the framework-agnostic core: FFT, window functions, color maps, worker pool, orchestrator) was already covered by 10 test files. The **`@waveform-playlist/spectrogram` React wrapper** had **zero tests** and a node-only vitest config. This PR fills that gap.

To make the provider's logic testable, the pure geometry/key math is extracted from the 967-line `SpectrogramProvider` into a DOM-free helper module (functional core / imperative shell). The provider keeps its worker-orchestration effect but delegates the math — **−99 net lines**, behavior preserved.

## Changes

**Refactor**
- New `src/spectrogram-helpers.ts` — 10 pure functions: `extractChunkNumber`, `parseCanvasId`, `groupContiguousIndices`, `classifyChunkTiers`, `computeChunkSampleRange`, `resolveRenderMode`, `toComputeConfig`, `buildConfigKey`, `buildFFTKey`, `mapsDiffer`.
- `SpectrogramProvider` delegates to them. The viewport DOM read (`scrollLeft`/`clientWidth`) stays in the component; the classification/range math is now pure.

**Tests — 36 passing**
- `spectrogram-helpers.test.ts` (26) — bad canvas IDs, non-contiguous chunks, null viewport, clip-offset shifting, sample-range padding/clamping, and the config-key vs FFT-key distinction (color-map change → re-display only, not recompute).
- `SpectrogramMenuItems.test.tsx` (5) — radio selection, `onClose`/`onOpenSettings` wiring.
- `SpectrogramSettingsModal.test.tsx` (5) — form init from config, FFT→hop-size linkage, Apply/Cancel, prop re-sync.

**Infra** (mirrors `ui-components`)
- vitest `environment: 'jsdom'`; added `@testing-library/react`, `jsdom`, `react-dom`, `styled-components` devDeps; `pnpm-lock.yaml` updated; dropped `--passWithNoTests`.

## Notes
- `SpectrogramSettingsModal` calls `<dialog>.showModal()`/`close()` in an effect. The modal test installs a conditional polyfill (only when jsdom lacks it) so it won't flake across jsdom versions.
- No changes to `@dawcore/spectrogram`.

## Test plan
- [x] `pnpm --filter @waveform-playlist/spectrogram typecheck`
- [x] `pnpm --filter @waveform-playlist/spectrogram build`
- [x] `npx vitest run` (36/36)
- [x] `pnpm lint` (0 errors)
