### PR TITLE
fix(transport): sample-rate domain corrections in ClipPlayer + TempoMap/MeterMap input validation

### DIFF
--- a/packages/transport/src/__tests__/clip-player.test.ts
+++ b/packages/transport/src/__tests__/clip-player.test.ts
@@ -365,3 +365,108 @@ describe('ClipPlayer', () => {
     expect(duration).toBeCloseTo(1.5);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sample-rate unit regression tests: offsetSamples/durationSamples index the
+// BUFFER (its own rate); startSample and the loop boundary live on the
+// TIMELINE (the SampleTimeline rate); Fade.duration is SECONDS. These were
+// conflated when buffer rate == timeline rate — the default decodeAudioData
+// path — and silently wrong otherwise (e.g. a 48 kHz Opus on a 44.1 kHz
+// timeline started trimmed clips ~8.8% too deep).
+// ---------------------------------------------------------------------------
+describe('ClipPlayer sample-rate domains', () => {
+  function make441Setup() {
+    const ctx = createMockAudioContext(44100);
+    const tempoMap = new TempoMap(960, 120);
+    const sampleTimeline = new SampleTimeline(44100);
+    sampleTimeline.setTempoMap(tempoMap);
+    return { ctx, tempoMap, sampleTimeline };
+  }
+
+  function make48kBufferClip(overrides: Partial<AudioClip> = {}): AudioClip {
+    return makeClip({
+      sampleRate: 48000,
+      audioBuffer: {
+        duration: 2,
+        length: 96000,
+        sampleRate: 48000,
+        numberOfChannels: 2,
+        getChannelData: vi.fn(),
+        copyFromChannel: vi.fn(),
+        copyToChannel: vi.fn(),
+      } as unknown as AudioBuffer,
+      ...overrides,
+    });
+  }
+
+  it('consume divides offset/duration by the BUFFER rate, not the timeline rate', () => {
+    const { ctx, tempoMap, sampleTimeline } = make441Setup();
+    // 1s trim offset and 1s duration, expressed in 48 kHz buffer samples,
+    // played on a 44.1 kHz timeline.
+    const clip = make48kBufferClip({
+      startSample: 0,
+      offsetSamples: 48000,
+      durationSamples: 48000,
+    });
+    const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
+    player.setTracks([makeTrack([clip])], new Map([['track-1', createMockTrackNode('track-1')]]));
+
+    const events = player.generate(0 as Tick, 960 as Tick);
+    expect(events.length).toBe(1);
+    player.consume(events[0]);
+
+    const source = (ctx.createBufferSource as any).mock.results[0].value;
+    const [, offset, duration] = source.start.mock.calls[0];
+    // 48000 buffer samples at 48 kHz = exactly 1 second. Dividing by the
+    // timeline rate would give 48000/44100 = 1.0884s — too deep / too long.
+    expect(offset).toBeCloseTo(1.0, 9);
+    expect(duration).toBeCloseTo(1.0, 9);
+  });
+
+  it('onPositionJump converts the timeline offset into buffer samples', () => {
+    const { ctx, tempoMap, sampleTimeline } = make441Setup();
+    // Clip at timeline 0, 2s of 48 kHz audio (96000 buffer samples).
+    const clip = make48kBufferClip({
+      startSample: 0,
+      offsetSamples: 0,
+      durationSamples: 96000,
+    });
+    const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
+    player.setTracks([makeTrack([clip])], new Map([['track-1', createMockTrackNode('track-1')]]));
+
+    // Jump to 1.0s = 1920 ticks at 120 BPM.
+    player.onPositionJump(1920 as Tick);
+
+    const source = (ctx.createBufferSource as any).mock.results[0].value;
+    const [, offset, duration] = source.start.mock.calls[0];
+    // 1s into the clip = 48000 BUFFER samples of offset (not 44100), and
+    // 1s remains of the 2s clip.
+    expect(offset).toBeCloseTo(1.0, 4);
+    expect(duration).toBeCloseTo(1.0, 4);
+  });
+
+  it('treats Fade.duration as seconds, matching the Tone adapter convention', () => {
+    const ctx = createMockAudioContext();
+    const tempoMap = new TempoMap(960, 120);
+    const sampleTimeline = new SampleTimeline(48000);
+    sampleTimeline.setTempoMap(tempoMap);
+    const clip = makeClip({
+      startSample: 0,
+      durationSamples: 48000,
+      fadeIn: { duration: 0.25 },
+      fadeOut: { duration: 0.25 },
+    });
+    const player = new ClipPlayer(ctx, sampleTimeline, tempoMap, (t) => t);
+    player.setTracks([makeTrack([clip])], new Map([['track-1', createMockTrackNode('track-1')]]));
+
+    const events = player.generate(0 as Tick, 960 as Tick);
+    player.consume(events[0]);
+
+    const gainNode = (ctx.createGain as any).mock.results[0].value;
+    // Fade-in ramps from 0 at `when` to gain at `when + 0.25` SECONDS.
+    // The old code read 0.25 as samples: 0.25/48000 ≈ 5.2 microseconds.
+    const rampCalls = gainNode.gain.linearRampToValueAtTime.mock.calls;
+    expect(rampCalls.length).toBeGreaterThan(0);
+    expect(rampCalls[0][1]).toBeCloseTo(0.25, 9);
+  });
+});

--- a/packages/transport/src/__tests__/meter-map.test.ts
+++ b/packages/transport/src/__tests__/meter-map.test.ts
@@ -251,3 +251,19 @@ describe('MeterMap', () => {
     expect(mm.isBarBoundary(7200 as Tick)).toBe(true);
   });
 });
+
+describe('MeterMap constructor validation', () => {
+  it('applies the same meter validation as setMeter', () => {
+    // Previously the constructor bypassed _validateMeter, so an invalid
+    // initial meter silently corrupted every bar computation.
+    expect(() => new MeterMap(960, 0, 4)).toThrow(/numerator/);
+    expect(() => new MeterMap(960, 33, 4)).toThrow(/numerator/);
+    expect(() => new MeterMap(960, 4, 3)).toThrow(/power of 2/);
+    expect(() => new MeterMap(960, 4, 64)).toThrow(/power of 2/);
+  });
+
+  it('accepts valid initial meters', () => {
+    expect(() => new MeterMap(960, 7, 8)).not.toThrow();
+    expect(new MeterMap(960, 7, 8).getMeter()).toEqual({ numerator: 7, denominator: 8 });
+  });
+});

--- a/packages/transport/src/__tests__/tempo-map.test.ts
+++ b/packages/transport/src/__tests__/tempo-map.test.ts
@@ -339,3 +339,29 @@ describe('TempoMap curve interpolation', () => {
     expect(curveSec).toBeLessThan(slowSec);
   });
 });
+
+describe('TempoMap BPM validation', () => {
+  it('rejects zero, negative, and non-finite BPM in setTempo', () => {
+    const map = new TempoMap(960, 120);
+    // bpm <= 0 poisons the secondsAtTick cache (Infinity / non-monotonic
+    // values that break the secondsToTicks binary search) — reject at the
+    // boundary like curve-slope validation already does.
+    expect(() => map.setTempo(0)).toThrow(/finite positive/);
+    expect(() => map.setTempo(-120, 960 as Tick)).toThrow(/finite positive/);
+    expect(() => map.setTempo(NaN)).toThrow(/finite positive/);
+    expect(() => map.setTempo(Infinity)).toThrow(/finite positive/);
+  });
+
+  it('rejects an invalid initial BPM in the constructor', () => {
+    expect(() => new TempoMap(960, 0)).toThrow(/finite positive/);
+    expect(() => new TempoMap(960, -1)).toThrow(/finite positive/);
+  });
+
+  it('a rejected setTempo leaves the map unchanged', () => {
+    const map = new TempoMap(960, 120);
+    map.setTempo(140, 960 as Tick);
+    expect(() => map.setTempo(0, 1920 as Tick)).toThrow();
+    expect(map.getTempo(1920 as Tick)).toBe(140); // still the prior tempo
+    expect(map.ticksToSeconds(960 as Tick)).toBeCloseTo(0.5, 12);
+  });
+});

--- a/packages/transport/src/audio/clip-player.ts
+++ b/packages/transport/src/audio/clip-player.ts
@@ -8,17 +8,18 @@ export interface ClipEvent extends SchedulerEvent {
   trackId: string;
   clipId: string;
   audioBuffer: AudioBuffer;
-  /** Clip position on timeline (integer samples) */
+  /** Clip position on timeline (integer samples, at the TIMELINE sample rate) */
   startSample: Sample;
-  /** Offset into audioBuffer (integer samples) */
+  /** Offset into audioBuffer (integer samples, at the BUFFER's own sample
+   *  rate — they index the buffer, not the timeline) */
   offsetSamples: Sample;
-  /** Duration to play (integer samples) */
+  /** Duration to play (integer samples, at the BUFFER's own sample rate) */
   durationSamples: Sample;
   /** Clip gain multiplier */
   gain: number;
-  /** Fade in duration (integer samples) */
+  /** Fade in duration (integer samples, at the TIMELINE sample rate) */
   fadeInDurationSamples: Sample;
-  /** Fade out duration (integer samples) */
+  /** Fade out duration (integer samples, at the TIMELINE sample rate) */
   fadeOutDurationSamples: Sample;
 }
 
@@ -98,14 +99,35 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
         if (clipTick < (fromTick as number)) continue;
         if (clipTick >= (toTick as number)) continue;
 
-        const fadeInDurationSamples = clip.fadeIn ? (clip.fadeIn.duration ?? 0) : 0;
-        const fadeOutDurationSamples = clip.fadeOut ? (clip.fadeOut.duration ?? 0) : 0;
+        // Two sample-count domains are in play and must not be mixed:
+        // timeline samples (clip.startSample, the loop boundary) and
+        // buffer samples (clip.offsetSamples / durationSamples index the
+        // audio file, which may have a different rate than the timeline).
+        const timelineRate = this._sampleTimeline.sampleRate;
+        const bufferRate = clip.audioBuffer.sampleRate;
+
+        // Fade.duration is SECONDS (the convention shared with the Tone
+        // adapter); pack as timeline samples so consume() recovers the
+        // seconds with one division.
+        const fadeInDurationSamples = clip.fadeIn
+          ? Math.round((clip.fadeIn.duration ?? 0) * timelineRate)
+          : 0;
+        const fadeOutDurationSamples = clip.fadeOut
+          ? Math.round((clip.fadeOut.duration ?? 0) * timelineRate)
+          : 0;
 
         // Clamp duration at loopEnd so the source stops exactly at the
-        // loop boundary. onPositionJump handles the mid-clip restart.
+        // loop boundary. The clamp lives in timeline samples; the event's
+        // duration stays in buffer samples.
         let durationSamples = clip.durationSamples;
-        if (this._loopEnabled && clip.startSample + durationSamples > this._loopEndSamples) {
-          durationSamples = this._loopEndSamples - clip.startSample;
+        if (this._loopEnabled) {
+          const durationTimelineSamples = Math.round(
+            (clip.durationSamples / bufferRate) * timelineRate
+          );
+          const allowedTimelineSamples = this._loopEndSamples - clip.startSample;
+          if (durationTimelineSamples > allowedTimelineSamples) {
+            durationSamples = Math.round((allowedTimelineSamples / timelineRate) * bufferRate);
+          }
         }
 
         events.push({
@@ -139,9 +161,12 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
       return;
     }
 
-    const sampleRate = this._sampleTimeline.sampleRate;
-    const offsetSeconds = event.offsetSamples / sampleRate;
-    const durationSeconds = event.durationSamples / sampleRate;
+    // offsetSamples/durationSamples index the BUFFER, so the buffer's own
+    // rate converts them to seconds; a 48 kHz file on a 44.1 kHz timeline
+    // would otherwise start ~8.8% too deep and play the wrong duration.
+    const bufferRate = event.audioBuffer.sampleRate;
+    const offsetSeconds = event.offsetSamples / bufferRate;
+    const durationSeconds = event.durationSamples / bufferRate;
 
     // Guard against invalid offset
     if (offsetSeconds >= event.audioBuffer.duration) {
@@ -168,10 +193,12 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
     const gainNode = this._audioContext.createGain();
     gainNode.gain.value = event.gain;
 
-    // Apply fades (AudioParam scheduling uses AudioContext time)
+    // Apply fades (AudioParam scheduling uses AudioContext time). Fade
+    // durations are packed as TIMELINE samples (see generate()).
     // Clamp fades so they don't overlap (split duration evenly if they would)
-    let fadeIn = event.fadeInDurationSamples / sampleRate;
-    let fadeOut = event.fadeOutDurationSamples / sampleRate;
+    const timelineRate = this._sampleTimeline.sampleRate;
+    let fadeIn = event.fadeInDurationSamples / timelineRate;
+    let fadeOut = event.fadeOutDurationSamples / timelineRate;
     if (fadeIn + fadeOut > durationSeconds) {
       const ratio = durationSeconds / (fadeIn + fadeOut);
       fadeIn *= ratio;
@@ -228,21 +255,36 @@ export class ClipPlayer implements SchedulerListener<ClipEvent> {
 
         if (clipTick >= (newTick as number)) continue; // hasn't started yet
 
-        // End comparison in samples (duration is audio-file-relative)
-        const clipEndSample = clip.startSample + clip.durationSamples;
+        const timelineRate = this._sampleTimeline.sampleRate;
+        const bufferRate = clip.audioBuffer.sampleRate;
+        const bufToTimeline = (n: number) => Math.round((n / bufferRate) * timelineRate);
+        const timelineToBuf = (n: number) => Math.round((n / timelineRate) * bufferRate);
+
+        // End comparison on the TIMELINE axis: the clip occupies its
+        // buffer-domain duration scaled to timeline samples.
+        const clipEndSample = clip.startSample + bufToTimeline(clip.durationSamples);
         if (clipEndSample <= (newSample as number)) continue; // already finished
 
+        // How far into the clip we are, on the timeline — converted to
+        // buffer samples before indexing the buffer.
         const offsetIntoClipSamples = (newSample as number) - clip.startSample;
-        const offsetSamples = clip.offsetSamples + offsetIntoClipSamples;
-        let durationSamples = clipEndSample - (newSample as number);
+        const offsetSamples = clip.offsetSamples + timelineToBuf(offsetIntoClipSamples);
+        let remainingTimelineSamples = clipEndSample - (newSample as number);
 
-        // Clamp at loop boundary (same as generate)
-        if (this._loopEnabled && (newSample as number) + durationSamples > this._loopEndSamples) {
-          durationSamples = this._loopEndSamples - (newSample as number);
+        // Clamp at loop boundary (same as generate), in timeline samples
+        if (
+          this._loopEnabled &&
+          (newSample as number) + remainingTimelineSamples > this._loopEndSamples
+        ) {
+          remainingTimelineSamples = this._loopEndSamples - (newSample as number);
         }
-        if (durationSamples <= 0) continue;
+        if (remainingTimelineSamples <= 0) continue;
+        const durationSamples = timelineToBuf(remainingTimelineSamples);
 
-        const fadeOutDurationSamples = clip.fadeOut ? (clip.fadeOut.duration ?? 0) : 0;
+        // Fade.duration is seconds; pack as timeline samples (see generate())
+        const fadeOutDurationSamples = clip.fadeOut
+          ? Math.round((clip.fadeOut.duration ?? 0) * timelineRate)
+          : 0;
 
         this.consume({
           trackId,

--- a/packages/transport/src/timeline/meter-map.ts
+++ b/packages/transport/src/timeline/meter-map.ts
@@ -18,6 +18,10 @@ export class MeterMap {
 
   constructor(ppqn: number, numerator: number = 4, denominator: number = 4) {
     this._ppqn = ppqn;
+    // Same gate setMeter() applies — without it, an invalid initial meter
+    // (numerator 0, non-power-of-2 denominator) silently corrupts every
+    // bar computation that follows.
+    this._validateMeter(numerator, denominator);
     this._entries = [{ tick: 0 as Tick, numerator, denominator, barAtTick: 0 }];
   }
 

--- a/packages/transport/src/timeline/tempo-map.ts
+++ b/packages/transport/src/timeline/tempo-map.ts
@@ -32,8 +32,20 @@ export class TempoMap {
   private _entries: MutableTempoEntry[];
 
   constructor(ppqn: number = 960, initialBpm: number = 120) {
+    TempoMap._validateBpm(initialBpm);
     this._ppqn = ppqn;
     this._entries = [{ tick: 0 as Tick, bpm: initialBpm, interpolation: 'step', secondsAtTick: 0 }];
+  }
+
+  /** A non-finite or non-positive BPM silently corrupts the secondsAtTick
+   *  cache (Infinity, or non-monotonic values that break the binary search
+   *  in secondsToTicks) — reject it at the boundary instead. */
+  private static _validateBpm(bpm: number): void {
+    if (!Number.isFinite(bpm) || bpm <= 0) {
+      throw new Error(
+        '[waveform-playlist] TempoMap: bpm must be a finite positive number, got ' + bpm
+      );
+    }
   }
 
   getTempo(atTick: Tick = 0 as Tick): number {
@@ -41,6 +53,7 @@ export class TempoMap {
   }
 
   setTempo(bpm: number, atTick: Tick = 0 as Tick, options?: SetTempoOptions): void {
+    TempoMap._validateBpm(bpm);
     const interpolation = options?.interpolation ?? 'step';
 
     if (typeof interpolation === 'object' && interpolation.type === 'curve') {


### PR DESCRIPTION
## Summary

Fixes from a math audit of `packages/transport` (three parallel re-derivation reviews, cross-checked against the warp-markers tutorial's chapter-08 equivalence tests, which verify this `TempoMap`'s closed forms against independently derived math to 1e-9 on real beat-tracker data).

**The math core audited clean** — step/linear/curve tempo integration and inverses, the `secondsAtTick` cache, `MeterMap` bar arithmetic, clock/scheduler windows, loop wrap, count-in, and metronome accents are all correct. The fixes below are unit-domain and input-validation issues.

### ClipPlayer: sample-rate domain corrections

`AudioClip.offsetSamples`/`durationSamples` are buffer-domain samples (per the type docs), `startSample` and the loop boundary are timeline-domain, and `Fade.duration` is seconds (per the type docs and the Tone adapter). `ClipPlayer` conflated all three — harmless while every buffer matches the timeline rate (the default `decodeAudioData` path resamples to the context rate), wrong otherwise:

- `consume()` divided buffer-domain offset/duration by the **timeline** rate → a 48 kHz file on a 44.1 kHz timeline starts trimmed clips ~8.8% too deep and plays the wrong duration. Now divides by `event.audioBuffer.sampleRate`.
- `onPositionJump()` added timeline spans to buffer offsets and compared clip ends across domains → mid-clip restarts after seek/loop-wrap landed at the wrong buffer position. Now converts explicitly in both directions and clamps loops in timeline samples.
- `generate()`'s loop clamp compared a buffer-domain duration to the timeline-domain loop end. Now clamps in timeline samples and converts the result back.
- **Fades**: `Fade.duration` (seconds) was packed unconverted into a `…Samples` field and then divided by the sample rate — native-path fades lasted microseconds. Now packed as timeline samples so `consume()` recovers the seconds. (The Tone adapter path was already correct.)

`ClipEvent` doc comments now state the domain of every field.

### Input validation (same pattern as the existing curve-slope check)

- **TempoMap**: `bpm` must be finite and positive (constructor + `setTempo`). `bpm ≤ 0` silently poisoned the `secondsAtTick` cache with `Infinity` or non-monotonic values that break the `secondsToTicks` binary search.
- **MeterMap**: the constructor now runs the same `_validateMeter` gate as `setMeter`; `new MeterMap(960, 0, 4)` previously created a corrupt initial entry.

### Not addressed (noted for follow-up)

- `samplesToTicks` relies on `secondsToTicks`'s internal rounding rather than rounding explicitly (refactor hazard, not a current bug)
- no guard that `ppqn·4/denominator` is an integer (only matters for ppqn < 8)
- no `removeTempo` to mirror `removeMeter` (API gap)

## Test plan

- [x] 8 new regression tests: 48k-buffer-on-44.1k-timeline `consume` and `onPositionJump` (old code yields 1.088 s where 1.000 s is correct), fade-as-seconds (old code: ~5 µs ramps), BPM validation incl. map-unchanged-after-rejection, MeterMap constructor validation
- [x] Full transport suite: 231 passed (223 pre-existing untouched)
- [x] `npm run build` (tsup + DTS) clean
- [ ] Audible check with a mixed-rate project (48 kHz media on a 44.1 kHz timeline) — trimmed clips and fades through the native adapter