### PR TITLE
feat(transport): math-audit follow-ups — removeTempo, explicit rounding, ppqn guard

### DIFF
--- a/packages/transport/src/__tests__/meter-map.test.ts
+++ b/packages/transport/src/__tests__/meter-map.test.ts
@@ -267,3 +267,19 @@ describe('MeterMap constructor validation', () => {
     expect(new MeterMap(960, 7, 8).getMeter()).toEqual({ numerator: 7, denominator: 8 });
   });
 });
+
+describe('MeterMap ppqn divisibility validation', () => {
+  it('rejects meters whose ticksPerBeat would be fractional', () => {
+    // ppqn 6, denominator 16: ticksPerBeat = 6*4/16 = 1.5 — bar boundaries
+    // would land on fractional ticks and corrupt barToTick/tickToBar.
+    expect(() => new MeterMap(6, 4, 16)).toThrow(/not divisible/);
+    const map = new MeterMap(6, 4, 4); // 6*4/4 = 6, fine
+    expect(() => map.setMeter(3, 16)).toThrow(/not divisible/);
+  });
+
+  it('accepts all denominators up to 32 at the default ppqn', () => {
+    for (const d of [1, 2, 4, 8, 16, 32]) {
+      expect(() => new MeterMap(960, 4, d)).not.toThrow();
+    }
+  });
+});

--- a/packages/transport/src/__tests__/sample-timeline.test.ts
+++ b/packages/transport/src/__tests__/sample-timeline.test.ts
@@ -63,3 +63,20 @@ describe('SampleTimeline tick conversions', () => {
     expect(() => st.ticksToSamples(960 as Tick)).toThrow();
   });
 });
+
+describe('samplesToTicks integer contract', () => {
+  it('returns integer ticks at a non-commensurate sample rate', () => {
+    // 44100 Hz at 120 BPM/960 PPQN: 1 tick = 22.96875 samples — every
+    // conversion involves rounding. The integer contract must hold at this
+    // boundary, not by accident of TempoMap internals.
+    const tempoMap = new TempoMap(960, 120);
+    const timeline = new SampleTimeline(44100);
+    timeline.setTempoMap(tempoMap);
+    for (const ticks of [1, 7, 240, 961, 12345]) {
+      const samples = timeline.ticksToSamples(ticks as Tick);
+      const back = timeline.samplesToTicks(samples);
+      expect(Number.isInteger(back as number)).toBe(true);
+      expect(Math.abs((back as number) - ticks)).toBeLessThanOrEqual(0); // exact round-trip here
+    }
+  });
+});

--- a/packages/transport/src/__tests__/tempo-map.test.ts
+++ b/packages/transport/src/__tests__/tempo-map.test.ts
@@ -365,3 +365,29 @@ describe('TempoMap BPM validation', () => {
     expect(map.ticksToSeconds(960 as Tick)).toBeCloseTo(0.5, 12);
   });
 });
+
+describe('TempoMap.removeTempo', () => {
+  it('removes an entry and recomputes the seconds cache for later entries', () => {
+    const map = new TempoMap(960, 120);
+    map.setTempo(60, 960 as Tick); // beat 2 onward at 60 BPM
+    map.setTempo(240, 1920 as Tick); // beat 3 onward at 240 BPM
+    // With the 60 BPM entry: t(1920) = 0.5 + 1.0 = 1.5s
+    expect(map.ticksToSeconds(1920 as Tick)).toBeCloseTo(1.5, 12);
+
+    map.removeTempo(960 as Tick);
+    // Now 120 BPM holds until tick 1920: t(1920) = 1.0s, and the 240 BPM
+    // entry's cached secondsAtTick must have been recomputed.
+    expect(map.ticksToSeconds(1920 as Tick)).toBeCloseTo(1.0, 12);
+    expect(map.ticksToSeconds(2880 as Tick)).toBeCloseTo(1.25, 12); // +1 beat at 240
+    expect(map.getTempo(960 as Tick)).toBe(120);
+  });
+
+  it('treats tick 0 as permanent and unknown ticks as no-ops', () => {
+    const map = new TempoMap(960, 120);
+    map.setTempo(60, 960 as Tick);
+    map.removeTempo(0 as Tick); // permanent
+    map.removeTempo(480 as Tick); // no entry there
+    expect(map.getTempo(0 as Tick)).toBe(120);
+    expect(map.getTempo(960 as Tick)).toBe(60);
+  });
+});

--- a/packages/transport/src/timeline/meter-map.ts
+++ b/packages/transport/src/timeline/meter-map.ts
@@ -218,5 +218,18 @@ export class MeterMap {
         '[waveform-playlist] MeterMap: denominator must be a power of 2 (1-32), got ' + denominator
       );
     }
+    // ticksPerBeat = ppqn * 4 / denominator must be an integer, or bar
+    // boundaries land on fractional ticks and barToTick/tickToBar corrupt
+    // silently. Only reachable with ppqn < 8 given denominator <= 32, but
+    // cheap to reject here.
+    if (!Number.isInteger((this._ppqn * 4) / denominator)) {
+      throw new Error(
+        '[waveform-playlist] MeterMap: ppqn (' +
+          this._ppqn +
+          ') * 4 is not divisible by denominator (' +
+          denominator +
+          ') — bar boundaries would fall on fractional ticks'
+      );
+    }
   }
 }

--- a/packages/transport/src/timeline/sample-timeline.ts
+++ b/packages/transport/src/timeline/sample-timeline.ts
@@ -40,6 +40,10 @@ export class SampleTimeline {
         '[waveform-playlist] SampleTimeline: tempoMap not set — call setTempoMap() first'
       );
     }
-    return this._tempoMap.secondsToTicks(samples / this._sampleRate);
+    // Round explicitly rather than relying on secondsToTicks' internal
+    // rounding — the integer Tick contract belongs to THIS boundary, and
+    // a TempoMap refactor returning float ticks must not silently break
+    // the Sample → Tick path. Mirrors the rounding in ticksToSamples.
+    return Math.round(this._tempoMap.secondsToTicks(samples / this._sampleRate)) as Tick;
   }
 }

--- a/packages/transport/src/timeline/tempo-map.ts
+++ b/packages/transport/src/timeline/tempo-map.ts
@@ -147,6 +147,19 @@ export class TempoMap {
     this._entries = [{ tick: 0 as Tick, bpm: first.bpm, interpolation: 'step', secondsAtTick: 0 }];
   }
 
+  /** Remove the tempo entry at exactly `atTick`, if one exists. The tick-0
+   *  entry is permanent (a map must always have a tempo) — removing it is a
+   *  no-op, matching removeMeter's treatment of the initial meter. The
+   *  seconds cache is recomputed from the removal point, the same partial
+   *  update setTempo uses. */
+  removeTempo(atTick: Tick): void {
+    if (atTick === 0) return;
+    const i = this._entries.findIndex((e) => e.tick === atTick);
+    if (i === -1) return;
+    this._entries = [...this._entries.slice(0, i), ...this._entries.slice(i + 1)];
+    this._recomputeCache(i);
+  }
+
   /** Get the interpolated BPM at a tick position */
   private _getTempoAt(atTick: Tick): number {
     const entryIndex = this._entryIndexAt(atTick);

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -509,6 +509,18 @@ export class Transport {
     this._emit('tempochange', { bpm: this._tempoMap.getTempo(), atTick: 0 as Tick });
   }
 
+  /** Remove the tempo entry at exactly `atTick` (tick 0 is permanent — a
+   *  no-op, like removeMeter's initial entry). Mirrors setTempo's loop-cache
+   *  invalidation and event; the emitted bpm is the tempo now in force at
+   *  the removed position. */
+  removeTempo(atTick: Tick): void {
+    this._tempoMap.removeTempo(atTick);
+    if (this._loopEnabled) {
+      this._loopStartSeconds = this._tempoMap.ticksToSeconds(this._loopStartTick);
+    }
+    this._emit('tempochange', { bpm: this._tempoMap.getTempo(atTick), atTick });
+  }
+
   barToTick(bar: number): Tick {
     return this._meterMap.barToTick(bar);
   }


### PR DESCRIPTION
Implements all three checklist items from #408 (deferred from the #405 audit). 5 new tests; 236 green; build clean. Details in the commit message.

Fixes #408