### PR TITLE
feat(transport): master effects insertion point (connectMasterOutput) (#416)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,8 @@ Package-specific patterns live in each package's CLAUDE.md (see "Per-Package Doc
 
 **Plans directory:** `plans/` contains future feature specs (waveform service, listening test tool).
 
+**Effects/WAM roadmap:** Tracked as GitHub epics with native sub-issues — #412 (unified effects chain), #413 (WAM 2.0, `@dawcore/wam`), #414 (Faust), #415 (WCLAP spike). The architecture/design record lives in the epic issue bodies, not in docs/specs. TODO.md's WAM section is superseded by these issues.
+
 **Debug tests:** `debug/tonejs/` contains standalone HTML reproductions of upstream Tone.js bugs. Each file loads Tone.js from CDN with a one-click reproduce button — change the `<script src>` version to test new releases. See `debug/tonejs/README.md`.
 
 **Debug apps:** `debug/standalone-midi/` is a standalone Vite+React app using workspace components (not Docusaurus) for isolating rendering bugs. Run with `cd debug/standalone-midi && pnpm exec vite`.
@@ -348,4 +350,4 @@ Package-specific conventions, architecture, and patterns live in each package's 
 
 ---
 
-**Last Updated:** 2026-03-31
+**Last Updated:** 2026-06-10

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -135,6 +135,8 @@ When any track is soloed, all non-soloed tracks are muted via `TrackNode.setMute
 
 `connectTrackOutput(trackId, node)` accepts any AudioNode chain (Tone.js effects, WAM plugins, native nodes). The transport has zero knowledge of Tone.js.
 
+`connectMasterOutput(node)` / `disconnectMasterOutput()` are the master-bus equivalents — the chain is inserted between the master gain and `audioContext.destination` via `MasterNode.connectEffects`. Master insertion uses a **targeted** `disconnect(destination)` (not blanket `disconnect()`) so parallel taps on `masterOutputNode` (analyzers, recorders) survive chain connect/disconnect. The caller routes the chain's output to `audioContext.destination`.
+
 ## NativePlayoutAdapter
 
 Thin bridge to `PlaylistEngine`. Implements all `PlayoutAdapter` methods (required + optional: `addTrack`, `removeTrack`, `updateTrack`). `init()` resumes suspended AudioContext and waits for Safari warmup (see Patterns). `transport` getter exposes the Transport for direct access to tempo, metronome, and effects hooks.

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -10,7 +10,7 @@ Native Web Audio transport for multi-track audio scheduling, looping, tempo, and
 - **Built-in metronome** — Beat-grid click scheduling with accent on beat 1. Default synthesized click sounds out of the box.
 - **Count-in (pre-roll)** — Configurable bars of click sounds before playback begins. Beat-by-beat events for UI countdown.
 - **Per-track signal chain** — Native GainNode (volume) → StereoPannerNode → GainNode (mute) → effects hook → master output.
-- **Effects plugin hook** — `connectTrackOutput(trackId, node)` inserts any `AudioNode` chain (Tone.js effects, WAM plugins, native nodes).
+- **Effects plugin hook** — `connectTrackOutput(trackId, node)` and `connectMasterOutput(node)` insert any `AudioNode` chain (Tone.js effects, WAM plugins, native nodes) per-track or on the master bus.
 - **Type-safe coordinates** — Branded `Tick` and `Sample` types prevent accidentally passing seconds where ticks or samples are expected. Zero runtime cost.
 - **PlayoutAdapter bridge** — `NativePlayoutAdapter` implements the `PlayoutAdapter` interface from `@waveform-playlist/engine`.
 
@@ -156,6 +156,17 @@ transport.connectTrackOutput('vocals', reverb);
 
 // Remove effects — restores direct routing to master
 transport.disconnectTrackOutput('vocals');
+
+// Master bus effects — inserted between master gain and destination
+const compressor = audioContext.createDynamicsCompressor();
+compressor.connect(audioContext.destination);
+
+transport.connectMasterOutput(compressor);
+
+// Remove master effects — restores direct routing to destination.
+// Parallel taps on transport.masterOutputNode (analyzers, recorders)
+// are unaffected by connect/disconnect.
+transport.disconnectMasterOutput();
 ```
 
 ## API
@@ -224,8 +235,10 @@ new Transport(audioContext: AudioContext, options?: TransportOptions)
 - `isCountingIn()` — whether count-in is active
 
 **Effects:**
-- `connectTrackOutput(trackId, node)` — Insert effects chain
-- `disconnectTrackOutput(trackId)` — Remove effects chain
+- `connectTrackOutput(trackId, node)` — Insert per-track effects chain
+- `disconnectTrackOutput(trackId)` — Remove per-track effects chain
+- `connectMasterOutput(node)` — Insert master bus effects chain
+- `disconnectMasterOutput()` — Remove master bus effects chain
 
 **Events:**
 - `on(event, callback)` / `off(event, callback)`

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawcore/transport",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Native Web Audio transport for waveform-playlist — scheduling, looping, tempo, metronome",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transport/src/__tests__/master-node.test.ts
+++ b/packages/transport/src/__tests__/master-node.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MasterNode } from '../audio/master-node';
+
+function createMockGainNode() {
+  return {
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+function mockAudioContext() {
+  return {
+    createGain: vi.fn(() => createMockGainNode()),
+  } as unknown as AudioContext;
+}
+
+function getGainNode(ctx: AudioContext) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (ctx.createGain as any).mock.results[0].value;
+}
+
+function createMockNode() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { connect: vi.fn(), disconnect: vi.fn() } as any;
+}
+
+describe('MasterNode', () => {
+  let ctx: AudioContext;
+
+  beforeEach(() => {
+    ctx = mockAudioContext();
+  });
+
+  it('connectOutput routes gain to destination', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+
+    const gain = getGainNode(ctx);
+    expect(gain.connect).toHaveBeenCalledWith(destination);
+  });
+
+  it('connectEffects reroutes output through the effects input', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+
+    const effectsInput = createMockNode();
+    master.connectEffects(effectsInput);
+
+    const gain = getGainNode(ctx);
+    // Targeted disconnect — only the destination edge, so parallel taps
+    // (analyzers, recorders) on the master output survive.
+    expect(gain.disconnect).toHaveBeenCalledWith(destination);
+    expect(gain.disconnect).not.toHaveBeenCalledWith();
+    expect(gain.connect).toHaveBeenCalledWith(effectsInput);
+  });
+
+  it('connectEffects twice replaces the first chain cleanly', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+
+    const firstChain = createMockNode();
+    const secondChain = createMockNode();
+    master.connectEffects(firstChain);
+    master.connectEffects(secondChain);
+
+    const gain = getGainNode(ctx);
+    // The first chain's edge must be severed before the second connects.
+    expect(gain.disconnect).toHaveBeenCalledWith(firstChain);
+    expect(gain.connect).toHaveBeenCalledWith(secondChain);
+    // No duplicate connection to the first chain remains: connect order is
+    // destination, firstChain, secondChain.
+    expect(gain.connect.mock.calls.map((c: unknown[]) => c[0])).toEqual([
+      destination,
+      firstChain,
+      secondChain,
+    ]);
+  });
+
+  it('disconnectEffects restores direct routing to destination', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+
+    const effectsInput = createMockNode();
+    master.connectEffects(effectsInput);
+    master.disconnectEffects();
+
+    const gain = getGainNode(ctx);
+    expect(gain.disconnect).toHaveBeenCalledWith(effectsInput);
+    const lastConnect = gain.connect.mock.calls.at(-1)[0];
+    expect(lastConnect).toBe(destination);
+  });
+
+  it('disconnectEffects without a connected chain is a no-op', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+
+    master.disconnectEffects();
+
+    const gain = getGainNode(ctx);
+    // Only the initial connectOutput call — no disconnect churn.
+    expect(gain.disconnect).not.toHaveBeenCalled();
+    expect(gain.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose while effects connected disconnects everything', () => {
+    const master = new MasterNode(ctx);
+    const destination = createMockNode();
+    master.connectOutput(destination);
+    master.connectEffects(createMockNode());
+
+    master.dispose();
+
+    const gain = getGainNode(ctx);
+    // Blanket disconnect on dispose tears down all edges.
+    expect(gain.disconnect).toHaveBeenCalledWith();
+  });
+});

--- a/packages/transport/src/__tests__/transport.test.ts
+++ b/packages/transport/src/__tests__/transport.test.ts
@@ -554,4 +554,69 @@ describe('Transport', () => {
     // Should not throw — extra args are ignored
     expect(noArgListener).toHaveBeenCalledTimes(1);
   });
+
+  describe('master effects hook (#416)', () => {
+    function getMasterGain(ctx: AudioContext) {
+      // MasterNode creates the first GainNode during Transport construction.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (ctx.createGain as any).mock.results[0].value;
+    }
+
+    function createMockChainInput() {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { connect: vi.fn(), disconnect: vi.fn() } as any;
+    }
+
+    it('connectMasterOutput inserts the chain between master gain and destination', () => {
+      const ctx = mockAudioContext();
+      const transport = new Transport(ctx);
+      const chainInput = createMockChainInput();
+
+      transport.connectMasterOutput(chainInput);
+
+      const masterGain = getMasterGain(ctx);
+      expect(masterGain.disconnect).toHaveBeenCalledWith(ctx.destination);
+      expect(masterGain.connect).toHaveBeenCalledWith(chainInput);
+    });
+
+    it('disconnectMasterOutput restores direct routing to destination', () => {
+      const ctx = mockAudioContext();
+      const transport = new Transport(ctx);
+      const chainInput = createMockChainInput();
+
+      transport.connectMasterOutput(chainInput);
+      transport.disconnectMasterOutput();
+
+      const masterGain = getMasterGain(ctx);
+      expect(masterGain.disconnect).toHaveBeenCalledWith(chainInput);
+      const lastConnect = masterGain.connect.mock.calls.at(-1)[0];
+      expect(lastConnect).toBe(ctx.destination);
+    });
+
+    it('connectMasterOutput twice replaces the chain without double-connections', () => {
+      const ctx = mockAudioContext();
+      const transport = new Transport(ctx);
+      const firstChain = createMockChainInput();
+      const secondChain = createMockChainInput();
+
+      transport.connectMasterOutput(firstChain);
+      transport.connectMasterOutput(secondChain);
+
+      const masterGain = getMasterGain(ctx);
+      expect(masterGain.disconnect).toHaveBeenCalledWith(firstChain);
+      expect(masterGain.connect.mock.calls.map((c: unknown[]) => c[0])).toEqual([
+        ctx.destination,
+        firstChain,
+        secondChain,
+      ]);
+    });
+
+    it('dispose while master chain connected does not throw', () => {
+      const ctx = mockAudioContext();
+      const transport = new Transport(ctx);
+      transport.connectMasterOutput(createMockChainInput());
+
+      expect(() => transport.dispose()).not.toThrow();
+    });
+  });
 });

--- a/packages/transport/src/audio/master-node.ts
+++ b/packages/transport/src/audio/master-node.ts
@@ -1,5 +1,7 @@
 export class MasterNode {
   private _gainNode: GainNode;
+  private _destination: AudioNode | null = null;
+  private _effectsInput: AudioNode | null = null;
 
   constructor(audioContext: AudioContext) {
     this._gainNode = audioContext.createGain();
@@ -13,6 +15,41 @@ export class MasterNode {
     return this._gainNode;
   }
 
+  /** Connect the master output to its final destination (audioContext.destination) */
+  connectOutput(destination: AudioNode): void {
+    this._destination = destination;
+    this._gainNode.connect(destination);
+  }
+
+  /**
+   * Insert an effects chain between the master gain and the destination.
+   * Only the destination edge is severed (targeted disconnect), so parallel
+   * taps on the master output (analyzers, recorders) keep working.
+   * The caller is responsible for routing the chain's output onward.
+   */
+  connectEffects(effectsInput: AudioNode): void {
+    if (this._effectsInput) {
+      // Replace: sever the previous chain's edge; destination edge is already gone
+      this._gainNode.disconnect(this._effectsInput);
+    } else if (this._destination) {
+      this._gainNode.disconnect(this._destination);
+    }
+    this._gainNode.connect(effectsInput);
+    this._effectsInput = effectsInput;
+  }
+
+  /** Remove the effects chain and restore direct routing to the destination */
+  disconnectEffects(): void {
+    if (!this._effectsInput) {
+      return;
+    }
+    this._gainNode.disconnect(this._effectsInput);
+    if (this._destination) {
+      this._gainNode.connect(this._destination);
+    }
+    this._effectsInput = null;
+  }
+
   setVolume(value: number): void {
     this._gainNode.gain.value = value;
   }
@@ -23,5 +60,7 @@ export class MasterNode {
     } catch (err) {
       console.warn('[waveform-playlist] MasterNode.dispose: error disconnecting: ' + String(err));
     }
+    this._destination = null;
+    this._effectsInput = null;
   }
 }

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -637,6 +637,22 @@ export class Transport {
     return this._masterNode.output;
   }
 
+  /**
+   * Insert an effects chain on the master bus, between the master gain and
+   * audioContext.destination. Accepts any AudioNode chain (Tone.js effects,
+   * WAM plugins, native nodes). The caller is responsible for connecting the
+   * chain's output to audioContext.destination. Calling again replaces the
+   * previous chain. Parallel taps on `masterOutputNode` are unaffected.
+   */
+  connectMasterOutput(node: AudioNode): void {
+    this._masterNode.connectEffects(node);
+  }
+
+  /** Remove the master effects chain and restore direct routing to audioContext.destination. */
+  disconnectMasterOutput(): void {
+    this._masterNode.disconnectEffects();
+  }
+
   // --- Events ---
 
   on<K extends TransportEventType>(event: K, cb: TransportEvents[K]): void {
@@ -706,7 +722,7 @@ export class Transport {
 
   private _initAudioGraph(audioContext: AudioContext): void {
     this._masterNode = new MasterNode(audioContext);
-    this._masterNode.output.connect(audioContext.destination);
+    this._masterNode.connectOutput(audioContext.destination);
 
     const toAudioTime = (transportTime: number) => this._clock.toAudioTime(transportTime);
 


### PR DESCRIPTION
Closes #416. Part of the unified effects chain epic #412.

## Summary

Adds the master-bus effects insertion point to `@dawcore/transport`, mirroring the existing per-track `connectTrackOutput` hook:

- `transport.connectMasterOutput(node)` — inserts any `AudioNode` chain between the master gain and `audioContext.destination`. Calling again replaces the previous chain cleanly (old edge severed before the new one connects).
- `transport.disconnectMasterOutput()` — restores direct routing to the destination.
- `MasterNode` gains `connectOutput`/`connectEffects`/`disconnectEffects` following the `TrackNode` pattern; `Transport._initAudioGraph` now wires the destination through `connectOutput` instead of a raw `connect`.

**Deliberate divergence from `TrackNode`:** master insertion uses a *targeted* `disconnect(destination)` rather than a blanket `disconnect()`. The `masterOutputNode` getter documents parallel taps (analyzers, recorders) as a supported pattern — a blanket disconnect would silently kill those taps when a chain is inserted. Pinned by test.

**Contract** (same as the per-track hook): the caller routes the chain's output onward to `audioContext.destination`. Documented in TSDoc + README.

`@dawcore/transport` 0.0.12 → 0.0.13.

## Test plan

- [x] TDD: 10 new unit tests written first and watched fail (6 `MasterNode`, 4 transport-level: insert, restore, replace-without-double-connect, dispose-while-connected, no-op disconnect, parallel-tap preservation)
- [x] Full transport suite: 255/255 pass (`cd packages/transport && npx vitest run`)
- [x] `pnpm --filter @dawcore/transport typecheck`
- [x] `pnpm lint` from root — 0 errors (warnings are pre-existing baseline)
- [x] No stray vitest processes after test runs
