### PR TITLE
feat(wam): @dawcore/wam scaffold + idempotent host initialization (#420)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,7 @@ Package-specific conventions, architecture, and patterns live in each package's 
 - `packages/spectrogram/CLAUDE.md` — Integration context, SpectrogramChannel index
 - `packages/dawcore/CLAUDE.md` — Lit Web Components, native AudioContext (no Tone.js), element types, CSS theming
 - `packages/transport/CLAUDE.md` — Native Web Audio transport, scheduler, clock, MeterMap, PlayoutAdapter bridge
+- `packages/dawcore-wam/CLAUDE.md` — WAM 2.0 plugin hosting, host init, SDK pinning, wam-studio reference
 - `website/CLAUDE.md` — Docusaurus site, CSS pitfalls, custom pages
 
 ---

--- a/packages/dawcore-wam/CLAUDE.md
+++ b/packages/dawcore-wam/CLAUDE.md
@@ -1,0 +1,22 @@
+# @dawcore/wam Package
+
+**Purpose:** Framework-agnostic WAM 2.0 (Web Audio Modules) plugin hosting. Consumed by `@dawcore/components` as an optional peer dep via dynamic import (the `@dawcore/midi` pattern) — non-WAM users pay zero bundle cost.
+
+**Epic:** Sub-issues of #413 land here incrementally (host init → loader → chain integration → GUI → persistence → transport bridge → offline export → discovery).
+
+**Build/test:** tsup (CJS+ESM+DTS), `pnpm typecheck && tsup`-style. Tests: `cd packages/dawcore-wam && npx vitest run`. Scaffold mirrors `packages/dawcore-midi`.
+
+## Conventions
+
+- **SDK deps are exact-pinned** (`@webaudiomodules/api`, `@webaudiomodules/sdk` — alpha/zerover). A breaking SDK bump must touch only this package.
+- **No DOM/Lit/React** — anything UI-flavored ships as plain-DOM factories so the future React layer reuses it.
+- Test-only helpers (e.g. `_resetWamHostCacheForTests`) are exported from their module but **not** from `src/index.ts` — tests deep-import from `../src/<module>`.
+- Mock the SDK boundary in tests with `vi.hoisted` + `vi.mock('@webaudiomodules/sdk', ...)` — a plain `const fn = vi.fn()` referenced in a mock factory hits the TDZ because the factory executes during import resolution.
+
+## Host Initialization (`src/host.ts`)
+
+`ensureWamHost(audioContext)` — idempotent per context (WeakMap of in-flight promises; concurrent callers share one init), failure-evicting (retry re-inits). State guards: `closed` rejects; realtime contexts must be `running` (worklet load needs a post-gesture resume); **`OfflineAudioContext` is accepted while `'suspended'`** (detected via `'startRendering' in ctx`) — offline rendering inits the host *before* `startRendering()`, and a naive running-check would make offline WAM export (#426) impossible.
+
+## Reference Implementation
+
+wam-studio (local checkout at `~/Code/wam-studio`) — `public/src/Models/Plugin.ts` shows the full plugin lifecycle: `createInstance(hostGroupId, ctx)`, GUI/audio lifecycle split (`createGui`/`destroyGui` independent of `audioNode.destroy()`), and `cloneInto(offlineCtx, groupId)` for offline rendering via getState/setState transfer.

--- a/packages/dawcore-wam/README.md
+++ b/packages/dawcore-wam/README.md
@@ -1,0 +1,32 @@
+# @dawcore/wam
+
+Web Audio Modules (WAM 2.0) plugin hosting for the dawcore family. [WAM](https://github.com/webaudiomodules) is an open plugin standard for the Web Audio API — the browser equivalent of VST/AU. Plugins are ES modules loaded at runtime that expose an `AudioNode` for graph insertion plus their own GUIs.
+
+This package is framework-agnostic (no Lit, no React). `@dawcore/components` consumes it as an **optional peer dependency** — `<daw-track>.addWamPlugin()` dynamic-imports it on first use, so non-WAM users pay zero bundle cost.
+
+## Installation
+
+```bash
+npm install @dawcore/wam
+```
+
+## Usage
+
+### Host initialization
+
+The WAM host is a one-time per-AudioContext setup that creates a plugin group for event routing between plugins on the same context.
+
+```typescript
+import { ensureWamHost } from '@dawcore/wam';
+
+// Idempotent: concurrent and repeated calls for the same context share
+// one initialization and resolve to the same host group.
+const { hostGroupId } = await ensureWamHost(audioContext);
+```
+
+- Realtime contexts must be **running** (resume after a user gesture first) — host init loads an AudioWorklet module.
+- `OfflineAudioContext` is accepted while `'suspended'`: offline rendering initializes the host *before* `startRendering()`.
+
+## Status
+
+Part of the [WAM 2.0 plugin support epic](https://github.com/naomiaro/waveform-playlist/issues/413). Plugin loading, chain integration, GUI embedding, persistence, and transport sync land in subsequent releases.

--- a/packages/dawcore-wam/__tests__/host.test.ts
+++ b/packages/dawcore-wam/__tests__/host.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { initializeWamHost } = vi.hoisted(() => ({
+  initializeWamHost: vi.fn(),
+}));
+
+vi.mock('@webaudiomodules/sdk', () => ({
+  initializeWamHost,
+}));
+
+import { ensureWamHost, _resetWamHostCacheForTests } from '../src/host';
+
+let groupCounter: number;
+
+function mockRealtimeContext(state: AudioContextState = 'running'): BaseAudioContext {
+  return {
+    state,
+    sampleRate: 48000,
+    resume: vi.fn(),
+  } as unknown as BaseAudioContext;
+}
+
+function mockOfflineContext(): BaseAudioContext {
+  return {
+    state: 'suspended',
+    sampleRate: 48000,
+    startRendering: vi.fn(),
+  } as unknown as BaseAudioContext;
+}
+
+beforeEach(() => {
+  groupCounter = 0;
+  initializeWamHost.mockReset();
+  initializeWamHost.mockImplementation(async () => {
+    groupCounter += 1;
+    return ['group-' + groupCounter, 'key-' + groupCounter];
+  });
+  _resetWamHostCacheForTests();
+});
+
+describe('ensureWamHost', () => {
+  it('initializes the host and returns hostGroupId and hostGroupKey', async () => {
+    const ctx = mockRealtimeContext();
+    const result = await ensureWamHost(ctx);
+
+    expect(initializeWamHost).toHaveBeenCalledTimes(1);
+    expect(initializeWamHost).toHaveBeenCalledWith(ctx);
+    expect(result).toEqual({ hostGroupId: 'group-1', hostGroupKey: 'key-1' });
+  });
+
+  it('is idempotent per context — second call returns the same group without re-init', async () => {
+    const ctx = mockRealtimeContext();
+    const first = await ensureWamHost(ctx);
+    const second = await ensureWamHost(ctx);
+
+    expect(initializeWamHost).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('concurrent callers share one in-flight initialization', async () => {
+    const ctx = mockRealtimeContext();
+    const [a, b] = await Promise.all([ensureWamHost(ctx), ensureWamHost(ctx)]);
+
+    expect(initializeWamHost).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(b);
+  });
+
+  it('distinct contexts get distinct host groups', async () => {
+    const a = await ensureWamHost(mockRealtimeContext());
+    const b = await ensureWamHost(mockRealtimeContext());
+
+    expect(initializeWamHost).toHaveBeenCalledTimes(2);
+    expect(a.hostGroupId).not.toBe(b.hostGroupId);
+  });
+
+  it('rejects on a suspended realtime context with a resume hint', async () => {
+    const ctx = mockRealtimeContext('suspended');
+
+    await expect(ensureWamHost(ctx)).rejects.toThrow(
+      /\[waveform-playlist\].*resume/i
+    );
+    expect(initializeWamHost).not.toHaveBeenCalled();
+  });
+
+  it('rejects on a closed context', async () => {
+    const ctx = mockRealtimeContext('closed');
+
+    await expect(ensureWamHost(ctx)).rejects.toThrow(/\[waveform-playlist\]/);
+    expect(initializeWamHost).not.toHaveBeenCalled();
+  });
+
+  it('allows a suspended OfflineAudioContext (offline rendering inits before startRendering)', async () => {
+    const ctx = mockOfflineContext();
+    const result = await ensureWamHost(ctx);
+
+    expect(initializeWamHost).toHaveBeenCalledTimes(1);
+    expect(result.hostGroupId).toBe('group-1');
+  });
+
+  it('evicts a failed initialization so a retry re-initializes', async () => {
+    const ctx = mockRealtimeContext();
+    initializeWamHost.mockRejectedValueOnce(new Error('worklet load failed'));
+
+    await expect(ensureWamHost(ctx)).rejects.toThrow('worklet load failed');
+
+    const result = await ensureWamHost(ctx);
+    expect(initializeWamHost).toHaveBeenCalledTimes(2);
+    expect(result.hostGroupId).toBe('group-1');
+  });
+});

--- a/packages/dawcore-wam/package.json
+++ b/packages/dawcore-wam/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@dawcore/wam",
+  "version": "0.0.1",
+  "description": "Web Audio Modules (WAM 2.0) plugin hosting for the dawcore family",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "wam",
+    "web-audio-modules",
+    "plugins",
+    "dawcore",
+    "daw",
+    "audio-editor",
+    "web-audio"
+  ],
+  "author": "Naomi Aro",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/naomiaro/waveform-playlist.git",
+    "directory": "packages/dawcore-wam"
+  },
+  "homepage": "https://naomiaro.github.io/waveform-playlist",
+  "bugs": {
+    "url": "https://github.com/naomiaro/waveform-playlist/issues"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@webaudiomodules/api": "2.0.0-alpha.6",
+    "@webaudiomodules/sdk": "0.0.12"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/dawcore-wam/src/host.ts
+++ b/packages/dawcore-wam/src/host.ts
@@ -1,0 +1,63 @@
+import { initializeWamHost } from '@webaudiomodules/sdk';
+
+export interface WamHostInfo {
+  hostGroupId: string;
+  hostGroupKey: string;
+}
+
+/**
+ * Per-context host registry. Keyed by the context itself so realtime and
+ * offline contexts each get their own plugin group. WeakMap so a discarded
+ * context (e.g. a finished OfflineAudioContext) doesn't pin the entry.
+ */
+let hostCache = new WeakMap<BaseAudioContext, Promise<WamHostInfo>>();
+
+function isOfflineContext(audioContext: BaseAudioContext): boolean {
+  return 'startRendering' in audioContext;
+}
+
+/**
+ * Initialize the WAM host environment on a context, once. Subsequent calls
+ * for the same context (including concurrent ones) share the original
+ * initialization and resolve to the same host group.
+ *
+ * Realtime contexts must be running — WAM host init loads an AudioWorklet
+ * module, which requires a resumed context (first user gesture). Offline
+ * contexts are allowed while 'suspended': they only start running inside
+ * startRendering(), and host init must happen before that.
+ */
+export function ensureWamHost(audioContext: BaseAudioContext): Promise<WamHostInfo> {
+  const cached = hostCache.get(audioContext);
+  if (cached) {
+    return cached;
+  }
+
+  if (audioContext.state === 'closed') {
+    return Promise.reject(new Error('[waveform-playlist] ensureWamHost: AudioContext is closed'));
+  }
+  if (!isOfflineContext(audioContext) && audioContext.state !== 'running') {
+    return Promise.reject(
+      new Error(
+        '[waveform-playlist] ensureWamHost: AudioContext is "' +
+          audioContext.state +
+          '" — resume it (requires a user gesture) before loading WAM plugins'
+      )
+    );
+  }
+
+  const pending = initializeWamHost(audioContext)
+    .then(([hostGroupId, hostGroupKey]: [string, string]) => ({ hostGroupId, hostGroupKey }))
+    .catch((err: unknown) => {
+      // Evict so a later call can retry instead of replaying this failure.
+      hostCache.delete(audioContext);
+      throw err;
+    });
+
+  hostCache.set(audioContext, pending);
+  return pending;
+}
+
+/** Test-only: drop all cached host initializations. */
+export function _resetWamHostCacheForTests(): void {
+  hostCache = new WeakMap();
+}

--- a/packages/dawcore-wam/src/index.ts
+++ b/packages/dawcore-wam/src/index.ts
@@ -1,2 +1,2 @@
-export { ensureWamHost, _resetWamHostCacheForTests } from './host';
+export { ensureWamHost } from './host';
 export type { WamHostInfo } from './host';

--- a/packages/dawcore-wam/src/index.ts
+++ b/packages/dawcore-wam/src/index.ts
@@ -1,0 +1,2 @@
+export { ensureWamHost, _resetWamHostCacheForTests } from './host';
+export type { WamHostInfo } from './host';

--- a/packages/dawcore-wam/tsconfig.json
+++ b/packages/dawcore-wam/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/dawcore-wam/tsup.config.ts
+++ b/packages/dawcore-wam/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/browser:
     dependencies:
@@ -161,7 +161,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/core:
     devDependencies:
@@ -173,7 +173,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/dawcore:
     dependencies:
@@ -235,7 +235,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/dawcore-spectrogram:
     dependencies:
@@ -259,6 +259,25 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@20.19.42)(happy-dom@20.10.2)
 
+  packages/dawcore-wam:
+    dependencies:
+      '@webaudiomodules/api':
+        specifier: 2.0.0-alpha.6
+        version: 2.0.0-alpha.6
+      '@webaudiomodules/sdk':
+        specifier: 0.0.12
+        version: 0.0.12
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.41)(postcss@8.5.15)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.42)
+
   packages/engine:
     devDependencies:
       '@waveform-playlist/core':
@@ -272,7 +291,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/loaders:
     dependencies:
@@ -291,7 +310,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/media-element-playout:
     dependencies:
@@ -366,7 +385,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/recording:
     dependencies:
@@ -476,7 +495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/ui-components:
     dependencies:
@@ -574,7 +593,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   packages/worklets:
     devDependencies:
@@ -589,7 +608,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.42)(jsdom@28.1.0)
+        version: 3.2.6(@types/node@20.19.42)
 
   website:
     dependencies:
@@ -9279,6 +9298,23 @@ packages:
       tinyrainbow: 2.0.0
     dev: true
 
+  /@vitest/mocker@3.2.6(vite@6.4.3):
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.4.3(@types/node@20.19.42)
+    dev: true
+
   /@vitest/mocker@3.2.6(vite@7.3.5):
     resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
@@ -9442,6 +9478,14 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  /@webaudiomodules/api@2.0.0-alpha.6:
+    resolution: {integrity: sha512-GFyp7fVgNd26aFlmk7svGWtwrS1PqrwWajR+JDnbF3aSka9TteZbIcKA6lQ1D7gMc+n8h+te69h+zG5DWwYKIw==}
+    dev: false
+
+  /@webaudiomodules/sdk@0.0.12:
+    resolution: {integrity: sha512-8eV+7wX8Wjrkjs3sIysq508ehS4mBEkLdwk8xinY3IXGi/zvWIfoipbWfvQ+AsaKnN3hBMGZI0AgLf1GlApBIA==}
+    dev: false
 
   /@webcontainer/env@1.1.1:
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -17291,7 +17335,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@3.2.6(@types/node@20.19.42)(happy-dom@20.10.2):
+  /vitest@3.2.6(@types/node@20.19.42):
     resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -17331,7 +17375,6 @@ packages:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
-      happy-dom: 20.10.2
       magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.4
@@ -17342,6 +17385,74 @@ packages:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.5(@types/node@20.19.42)
+      vite-node: 3.2.4(@types/node@20.19.42)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /vitest@3.2.6(@types/node@20.19.42)(happy-dom@20.10.2):
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@types/node': 20.19.42
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@6.4.3)
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      happy-dom: 20.10.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@20.19.42)
       vite-node: 3.2.4(@types/node@20.19.42)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
@@ -17390,7 +17501,7 @@ packages:
       '@types/chai': 5.2.3
       '@types/node': 20.19.42
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5)
+      '@vitest/mocker': 3.2.6(vite@6.4.3)
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -17409,7 +17520,7 @@ packages:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@20.19.42)
+      vite: 6.4.3(@types/node@20.19.42)
       vite-node: 3.2.4(@types/node@20.19.42)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
@@ -17458,7 +17569,7 @@ packages:
       '@types/chai': 5.2.3
       '@types/node': 20.19.42
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5)
+      '@vitest/mocker': 3.2.6(vite@6.4.3)
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -17477,7 +17588,7 @@ packages:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@20.19.42)
+      vite: 6.4.3(@types/node@20.19.42)
       vite-node: 3.2.4(@types/node@20.19.42)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:


### PR DESCRIPTION
Closes #420. Part of the WAM 2.0 plugin support epic #413.

## Summary

Scaffolds the new framework-agnostic **`@dawcore/wam`** package (0.0.1) and ships its first slice: idempotent WAM host initialization.

- **Package** at `packages/dawcore-wam`, following the `@dawcore/midi` scaffold conventions (tsup CJS+ESM+DTS, `pnpm typecheck && tsup`-compatible scripts, vitest, `sideEffects: false`). SDK deps **exact-pinned** (alpha/zerover): `@webaudiomodules/api@2.0.0-alpha.6`, `@webaudiomodules/sdk@0.0.12` — a breaking SDK bump touches exactly this package.
- **`ensureWamHost(audioContext): Promise<{hostGroupId, hostGroupKey}>`**:
  - Idempotent per context via `WeakMap<BaseAudioContext, Promise<WamHostInfo>>` — repeated *and concurrent* callers share one in-flight initialization (no host-init races).
  - Failed initializations are evicted from the cache so a retry re-initializes instead of replaying the failure.
  - State guards: `closed` contexts reject; **realtime** contexts must be `running` (host init loads an AudioWorklet module — requires post-user-gesture resume) with a `[waveform-playlist]`-prefixed resume hint.
  - **`OfflineAudioContext` accepted while `'suspended'`** — detected via `'startRendering' in ctx`. Offline contexts only run inside `startRendering()`, and the offline-export issue (#426) must init the host *before* rendering. A naive `state !== 'running'` guard would have made offline WAM rendering impossible; pinned by test.
- Lockfile committed (CI uses `--frozen-lockfile`).

## Test plan

- [x] TDD: 8 unit tests written first and watched fail (module-missing RED), then implemented: init + result shape, idempotency, concurrent promise sharing, distinct contexts → distinct groups, suspended-realtime rejection, closed rejection, suspended-offline acceptance, failure eviction + retry
- [x] `cd packages/dawcore-wam && npx vitest run` — 8/8
- [x] `pnpm --filter @dawcore/wam typecheck` + `build` (DTS emits cleanly against real SDK types)
- [x] `pnpm -w lint` — 0 errors (prettier applied)
