### PR TITLE
feat(dawcore): EffectsChainController + native effect registry (#417)

### DIFF
--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -126,6 +126,15 @@
 - **Discriminator name should not collide with sibling field names** — `ClipDescriptor` originally used `source: 'dom' | 'drop'` next to `src: string`; reading `clipDesc.source === 'dom'` and `clipDesc.src` on adjacent lines was a real readability hazard. Use `kind` for discriminators in this codebase.
 - **3+ narrowing sites = type predicate** — when a discriminated-union check (`c.kind === 'dom' && c.clipId === ...`) appears at multiple call sites, extract `isDomClip(c): c is DomClipDescriptor` co-located with the type definition. Five sites was the threshold that paid for the helper in PR #383.
 
+## Effects Chain (core, #417)
+
+- **`src/effects/`** — `EffectsChainController` (ordered chain between owned input/output gains) + effect registry (`registerEffect`/`getEffectDefinitions`/`createEffectInstance`, five `native-*` built-ins). Element APIs (`<daw-track>.addEffect` etc.) are #418; WAM entries join via #422.
+- **Entries are kind-agnostic** — chain operations never branch on `kind` (`'native' | 'wam' | ...`). New plugin standards wrap their node into `EffectChainItem` and get move/remove/bypass/events for free.
+- **Topology rebuilds, params never** — `setParams` calls the instance's `applyParams` in place. Rebuilds sever ONLY the chain's own outgoing edges (`input.disconnect()` + each entry's `output.disconnect()`) — never the consumer's edges into `input` / out of `output`.
+- **Bypass is two-mode** — definitions with `wetParam` bypass by zeroing wet (stored/restored, no rebuild); others are removed from the series with the instance kept alive at its position. `setParams` on a bypassed wet effect stores the new wet without making it audible.
+- **Registry definitions take `BaseAudioContext`** — same definitions must serve offline rendering (#426). Don't add `AudioContext`-only API usage to built-ins.
+- **Registry tests** — call `_resetEffectRegistryForTests()` in `beforeEach` (module-level Map; built-ins re-registered). Test-only helpers are exported from their module but NOT from `src/index.ts`.
+
 ## CSS Theming
 
 Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DOM:

--- a/packages/dawcore/src/__tests__/effect-registry.test.ts
+++ b/packages/dawcore/src/__tests__/effect-registry.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  registerEffect,
+  getEffectDefinitions,
+  createEffectInstance,
+  _resetEffectRegistryForTests,
+} from '../effects/effect-registry';
+
+function mockParam(value = 0) {
+  return { value };
+}
+
+function mockNode(extra: Record<string, unknown> = {}) {
+  return { connect: vi.fn(), disconnect: vi.fn(), ...extra };
+}
+
+function mockAudioContext() {
+  return {
+    createGain: vi.fn(() => mockNode({ gain: mockParam(1) })),
+    createDelay: vi.fn(() => mockNode({ delayTime: mockParam(0) })),
+    createBiquadFilter: vi.fn(() =>
+      mockNode({ type: 'lowpass', frequency: mockParam(350), Q: mockParam(1) })
+    ),
+    createDynamicsCompressor: vi.fn(() =>
+      mockNode({
+        threshold: mockParam(-24),
+        knee: mockParam(30),
+        ratio: mockParam(12),
+        attack: mockParam(0.003),
+        release: mockParam(0.25),
+      })
+    ),
+    createStereoPanner: vi.fn(() => mockNode({ pan: mockParam(0) })),
+  } as unknown as BaseAudioContext;
+}
+
+beforeEach(() => {
+  _resetEffectRegistryForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('effect registry', () => {
+  it('ships the native built-ins', () => {
+    const defs = getEffectDefinitions();
+    for (const type of [
+      'native-gain',
+      'native-filter',
+      'native-compressor',
+      'native-delay',
+      'native-stereo-panner',
+    ]) {
+      expect(defs.has(type), type + ' should be registered').toBe(true);
+    }
+  });
+
+  it('registerEffect adds a custom definition', () => {
+    registerEffect('custom-boost', {
+      label: 'Boost',
+      category: 'dynamics',
+      defaults: { amount: 2 },
+      params: { amount: { min: 0, max: 4, step: 0.1 } },
+      create: (ctx) => {
+        const node = ctx.createGain();
+        return {
+          input: node,
+          output: node,
+          applyParams: (p) => {
+            if (p.amount !== undefined) node.gain.value = p.amount;
+          },
+        };
+      },
+    });
+
+    expect(getEffectDefinitions().has('custom-boost')).toBe(true);
+  });
+
+  it('re-registering a type warns and overwrites', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const def = getEffectDefinitions().get('native-gain')!;
+    registerEffect('native-gain', { ...def, label: 'Replaced Gain' });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[waveform-playlist]'));
+    expect(getEffectDefinitions().get('native-gain')!.label).toBe('Replaced Gain');
+  });
+
+  it('createEffectInstance throws on unknown type, listing available types', () => {
+    expect(() => createEffectInstance('does-not-exist', mockAudioContext())).toThrow(
+      /does-not-exist[\s\S]*native-gain/
+    );
+  });
+
+  it('createEffectInstance merges defaults with overrides and applies them', () => {
+    const ctx = mockAudioContext();
+    const created = createEffectInstance('native-gain', ctx, { gain: 0.25 });
+
+    expect(created.params.gain).toBe(0.25);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gainNode = (ctx.createGain as any).mock.results[0].value;
+    expect(gainNode.gain.value).toBe(0.25);
+  });
+
+  it('native-delay declares a wet param and applyParams drives it', () => {
+    const ctx = mockAudioContext();
+    const created = createEffectInstance('native-delay', ctx);
+
+    expect(created.wetParam).toBe('wet');
+    created.instance.applyParams({ wet: 0 });
+    // The wet gain node must now be silent. Find a gain node whose value is 0.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gainNodes = (ctx.createGain as any).mock.results.map((r: { value: any }) => r.value);
+    expect(gainNodes.some((n: { gain: { value: number } }) => n.gain.value === 0)).toBe(true);
+  });
+
+  it('getEffectDefinitions returns a copy — mutating it does not affect the registry', () => {
+    const defs = getEffectDefinitions();
+    defs.delete('native-gain');
+    expect(getEffectDefinitions().has('native-gain')).toBe(true);
+  });
+});

--- a/packages/dawcore/src/__tests__/effects-chain-controller.test.ts
+++ b/packages/dawcore/src/__tests__/effects-chain-controller.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EffectsChainController } from '../effects/effects-chain-controller';
+import type { EffectChainItem } from '../effects/types';
+
+function mockNode(label: string) {
+  return {
+    label,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    gain: { value: 1 },
+  };
+}
+
+let nodeCounter = 0;
+
+function mockAudioContext() {
+  return {
+    createGain: vi.fn(() => mockNode('gain-' + ++nodeCounter)),
+  } as unknown as BaseAudioContext;
+}
+
+function makeItem(overrides: Partial<EffectChainItem> = {}): EffectChainItem {
+  const input = mockNode('fx-in-' + ++nodeCounter);
+  const output = mockNode('fx-out-' + ++nodeCounter);
+  return {
+    kind: 'native',
+    type: 'test-effect',
+    instance: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      input: input as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      output: output as any,
+      applyParams: vi.fn(),
+      dispose: vi.fn(),
+    },
+    params: { amount: 1 },
+    ...overrides,
+  };
+}
+
+/** The series of connect() targets currently outgoing from a mock node — last call wins per rebuild. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lastConnectTarget(node: any): unknown {
+  const calls = node.connect.mock.calls;
+  return calls.length ? calls[calls.length - 1][0] : undefined;
+}
+
+beforeEach(() => {
+  nodeCounter = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EffectsChainController', () => {
+  it('empty chain passes input straight through to output', () => {
+    const ctx = mockAudioContext();
+    const chain = new EffectsChainController(ctx);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(chain.input as any)).toBe(chain.output);
+  });
+
+  it('add wires input -> effect -> output', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const item = makeItem();
+    const id = chain.add(item);
+
+    expect(typeof id).toBe('string');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(chain.input as any)).toBe(item.instance.input);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(item.instance.output as any)).toBe(chain.output);
+  });
+
+  it('second add appends in series and entries reflect order', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const first = makeItem({ type: 'first' });
+    const second = makeItem({ type: 'second' });
+    chain.add(first);
+    chain.add(second);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(first.instance.output as any)).toBe(second.instance.input);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(second.instance.output as any)).toBe(chain.output);
+    expect(chain.entries.map((e) => e.type)).toEqual(['first', 'second']);
+  });
+
+  it('add at index 0 inserts before existing entries', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    chain.add(makeItem({ type: 'first' }));
+    chain.add(makeItem({ type: 'inserted' }), 0);
+
+    expect(chain.entries.map((e) => e.type)).toEqual(['inserted', 'first']);
+  });
+
+  it('move reorders the chain and rewires', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const a = makeItem({ type: 'a' });
+    const b = makeItem({ type: 'b' });
+    chain.add(a);
+    const idB = chain.add(b);
+
+    chain.move(idB, 0);
+
+    expect(chain.entries.map((e) => e.type)).toEqual(['b', 'a']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(b.instance.output as any)).toBe(a.instance.input);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(a.instance.output as any)).toBe(chain.output);
+  });
+
+  it('setParams applies the delta without rebuilding the chain', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const item = makeItem();
+    const id = chain.add(item);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const connectCallsBefore = (chain.input as any).connect.mock.calls.length;
+
+    chain.setParams(id, { amount: 0.5 });
+
+    expect(item.instance.applyParams).toHaveBeenCalledWith({ amount: 0.5 });
+    expect(chain.entries[0].params.amount).toBe(0.5);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((chain.input as any).connect.mock.calls.length).toBe(connectCallsBefore);
+  });
+
+  it('bypass on a wet effect zeroes wet and restores it, without rebuild', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const item = makeItem({ params: { wet: 0.7 }, wetParam: 'wet' });
+    const id = chain.add(item);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const connectCallsBefore = (chain.input as any).connect.mock.calls.length;
+
+    chain.setBypassed(id, true);
+    expect(item.instance.applyParams).toHaveBeenCalledWith({ wet: 0 });
+    expect(chain.entries[0].bypassed).toBe(true);
+
+    chain.setBypassed(id, false);
+    expect(item.instance.applyParams).toHaveBeenCalledWith({ wet: 0.7 });
+    expect(chain.entries[0].bypassed).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((chain.input as any).connect.mock.calls.length).toBe(connectCallsBefore);
+  });
+
+  it('bypass on a non-wet effect removes it from the series but keeps the instance', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const a = makeItem({ type: 'a' });
+    const b = makeItem({ type: 'b' });
+    const idA = chain.add(a);
+    chain.add(b);
+
+    chain.setBypassed(idA, true);
+
+    // a is out of the audio path: input goes straight to b
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(chain.input as any)).toBe(b.instance.input);
+    expect(a.instance.dispose).not.toHaveBeenCalled();
+    // still listed, flagged bypassed, position preserved
+    expect(chain.entries.map((e) => e.type)).toEqual(['a', 'b']);
+    expect(chain.entries[0].bypassed).toBe(true);
+
+    chain.setBypassed(idA, false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(chain.input as any)).toBe(a.instance.input);
+  });
+
+  it('remove rewires around the entry and disposes the instance', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const a = makeItem({ type: 'a' });
+    const b = makeItem({ type: 'b' });
+    const idA = chain.add(a);
+    chain.add(b);
+
+    chain.remove(idA);
+
+    expect(chain.entries.map((e) => e.type)).toEqual(['b']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(lastConnectTarget(chain.input as any)).toBe(b.instance.input);
+    expect(a.instance.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('entries returns defensive copies', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    chain.add(makeItem());
+
+    const snapshot = chain.entries;
+    snapshot[0].params.amount = 999;
+    snapshot.pop();
+
+    expect(chain.entries).toHaveLength(1);
+    expect(chain.entries[0].params.amount).toBe(1);
+  });
+
+  it('operations on an unknown id warn and no-op', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chain = new EffectsChainController(mockAudioContext());
+    chain.add(makeItem());
+
+    chain.remove('nope');
+    chain.move('nope', 0);
+    chain.setParams('nope', { x: 1 });
+    chain.setBypassed('nope', true);
+
+    expect(warn).toHaveBeenCalledTimes(4);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[waveform-playlist]'));
+    expect(chain.entries).toHaveLength(1);
+  });
+
+  it('dispose disconnects the chain and disposes all instances', () => {
+    const chain = new EffectsChainController(mockAudioContext());
+    const a = makeItem();
+    const b = makeItem();
+    chain.add(a);
+    chain.add(b);
+
+    chain.dispose();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((chain.input as any).disconnect).toHaveBeenCalled();
+    expect(a.instance.dispose).toHaveBeenCalledTimes(1);
+    expect(b.instance.dispose).toHaveBeenCalledTimes(1);
+    expect(chain.entries).toHaveLength(0);
+  });
+});

--- a/packages/dawcore/src/effects/effect-registry.ts
+++ b/packages/dawcore/src/effects/effect-registry.ts
@@ -1,0 +1,164 @@
+import type { CreatedEffect, EffectDefinition } from './types';
+
+const MAX_DELAY_SECONDS = 10;
+
+let registry = new Map<string, EffectDefinition>();
+
+export function registerEffect(type: string, definition: EffectDefinition): void {
+  if (registry.has(type)) {
+    console.warn(
+      '[waveform-playlist] registerEffect: overwriting existing effect type "' + type + '"'
+    );
+  }
+  registry.set(type, definition);
+}
+
+/** A copy — mutating the returned map does not affect the registry. */
+export function getEffectDefinitions(): Map<string, EffectDefinition> {
+  return new Map(registry);
+}
+
+export function createEffectInstance(
+  type: string,
+  audioContext: BaseAudioContext,
+  params: Record<string, number> = {}
+): CreatedEffect {
+  const definition = registry.get(type);
+  if (!definition) {
+    throw new Error(
+      '[waveform-playlist] createEffectInstance: unknown effect type "' +
+        type +
+        '". Available types: ' +
+        [...registry.keys()].join(', ')
+    );
+  }
+  const merged = { ...definition.defaults, ...params };
+  const instance = definition.create(audioContext, merged);
+  instance.applyParams(merged);
+  return { instance, params: merged, wetParam: definition.wetParam };
+}
+
+/** Test-only: restore the registry to just the built-ins. */
+export function _resetEffectRegistryForTests(): void {
+  registry = new Map();
+  registerBuiltIns();
+}
+
+function singleNode(
+  node: AudioNode,
+  applyParams: (params: Record<string, number>) => void
+): { input: AudioNode; output: AudioNode; applyParams: (params: Record<string, number>) => void } {
+  return { input: node, output: node, applyParams };
+}
+
+function registerBuiltIns(): void {
+  registry.set('native-gain', {
+    label: 'Gain',
+    category: 'dynamics',
+    defaults: { gain: 1 },
+    params: { gain: { min: 0, max: 2, step: 0.01 } },
+    create: (ctx) => {
+      const node = ctx.createGain();
+      return singleNode(node, (p) => {
+        if (p.gain !== undefined) node.gain.value = p.gain;
+      });
+    },
+  });
+
+  registry.set('native-filter', {
+    label: 'Lowpass Filter',
+    category: 'filter',
+    defaults: { frequency: 1000, q: 1 },
+    params: {
+      frequency: { min: 20, max: 20000, step: 1, unit: 'Hz' },
+      q: { min: 0.1, max: 20, step: 0.1 },
+    },
+    create: (ctx) => {
+      const node = ctx.createBiquadFilter();
+      node.type = 'lowpass';
+      return singleNode(node, (p) => {
+        if (p.frequency !== undefined) node.frequency.value = p.frequency;
+        if (p.q !== undefined) node.Q.value = p.q;
+      });
+    },
+  });
+
+  registry.set('native-compressor', {
+    label: 'Compressor',
+    category: 'dynamics',
+    defaults: { threshold: -24, knee: 30, ratio: 12, attack: 0.003, release: 0.25 },
+    params: {
+      threshold: { min: -60, max: 0, step: 1, unit: 'dB' },
+      knee: { min: 0, max: 40, step: 1, unit: 'dB' },
+      ratio: { min: 1, max: 20, step: 0.5 },
+      attack: { min: 0, max: 1, step: 0.001, unit: 's' },
+      release: { min: 0, max: 1, step: 0.01, unit: 's' },
+    },
+    create: (ctx) => {
+      const node = ctx.createDynamicsCompressor();
+      return singleNode(node, (p) => {
+        if (p.threshold !== undefined) node.threshold.value = p.threshold;
+        if (p.knee !== undefined) node.knee.value = p.knee;
+        if (p.ratio !== undefined) node.ratio.value = p.ratio;
+        if (p.attack !== undefined) node.attack.value = p.attack;
+        if (p.release !== undefined) node.release.value = p.release;
+      });
+    },
+  });
+
+  registry.set('native-stereo-panner', {
+    label: 'Stereo Panner',
+    category: 'spatial',
+    defaults: { pan: 0 },
+    params: { pan: { min: -1, max: 1, step: 0.01 } },
+    create: (ctx) => {
+      const node = ctx.createStereoPanner();
+      return singleNode(node, (p) => {
+        if (p.pan !== undefined) node.pan.value = p.pan;
+      });
+    },
+  });
+
+  registry.set('native-delay', {
+    label: 'Delay',
+    category: 'delay',
+    defaults: { delayTime: 0.25, feedback: 0.4, wet: 0.35 },
+    params: {
+      delayTime: { min: 0, max: MAX_DELAY_SECONDS, step: 0.01, unit: 's' },
+      feedback: { min: 0, max: 0.95, step: 0.01 },
+      wet: { min: 0, max: 1, step: 0.01 },
+    },
+    wetParam: 'wet',
+    create: (ctx) => {
+      const input = ctx.createGain();
+      const output = ctx.createGain();
+      const delay = ctx.createDelay(MAX_DELAY_SECONDS);
+      const feedback = ctx.createGain();
+      const wet = ctx.createGain();
+      const dry = ctx.createGain();
+
+      input.connect(dry);
+      dry.connect(output);
+      input.connect(delay);
+      delay.connect(feedback);
+      feedback.connect(delay);
+      delay.connect(wet);
+      wet.connect(output);
+
+      return {
+        input,
+        output,
+        applyParams: (p) => {
+          if (p.delayTime !== undefined) delay.delayTime.value = p.delayTime;
+          if (p.feedback !== undefined) feedback.gain.value = p.feedback;
+          if (p.wet !== undefined) {
+            wet.gain.value = p.wet;
+            dry.gain.value = 1 - p.wet;
+          }
+        },
+      };
+    },
+  });
+}
+
+registerBuiltIns();

--- a/packages/dawcore/src/effects/effects-chain-controller.ts
+++ b/packages/dawcore/src/effects/effects-chain-controller.ts
@@ -1,0 +1,156 @@
+import type { EffectChainItem, EffectState } from './types';
+
+interface ChainEntry extends EffectChainItem {
+  id: string;
+  bypassed: boolean;
+}
+
+let idCounter = 0;
+
+/**
+ * An ordered insert-effects chain. Owns `input`/`output` gain nodes; entries
+ * are wired in series between them (empty chain = straight passthrough).
+ *
+ * Topology changes (add/remove/move/disconnect-bypass) rebuild the internal
+ * wiring; parameter changes never do. Only the controller's own outgoing
+ * edges are severed during a rebuild — the consumer's edges into `input` and
+ * out of `output` are untouched.
+ */
+export class EffectsChainController {
+  private _input: GainNode;
+  private _output: GainNode;
+  private _entries: ChainEntry[] = [];
+  private _disposed = false;
+
+  constructor(audioContext: BaseAudioContext) {
+    this._input = audioContext.createGain();
+    this._output = audioContext.createGain();
+    this._input.connect(this._output);
+  }
+
+  /** Connect the upstream source (track mute node, master gain) into this. */
+  get input(): AudioNode {
+    return this._input;
+  }
+
+  /** Route this onward (to the master bus / destination). */
+  get output(): AudioNode {
+    return this._output;
+  }
+
+  get entries(): EffectState[] {
+    return this._entries.map((entry) => ({
+      id: entry.id,
+      kind: entry.kind,
+      type: entry.type,
+      params: { ...entry.params },
+      bypassed: entry.bypassed,
+    }));
+  }
+
+  add(item: EffectChainItem, index?: number): string {
+    const id = 'effect-' + ++idCounter;
+    const entry: ChainEntry = { ...item, params: { ...item.params }, id, bypassed: false };
+    const at =
+      index === undefined
+        ? this._entries.length
+        : Math.max(0, Math.min(index, this._entries.length));
+    this._entries = [...this._entries.slice(0, at), entry, ...this._entries.slice(at)];
+    this._rebuild();
+    return id;
+  }
+
+  remove(effectId: string): void {
+    const entry = this._find('remove', effectId);
+    if (!entry) return;
+    this._entries = this._entries.filter((e) => e.id !== effectId);
+    entry.instance.output.disconnect();
+    entry.instance.dispose?.();
+    this._rebuild();
+  }
+
+  move(effectId: string, newIndex: number): void {
+    const entry = this._find('move', effectId);
+    if (!entry) return;
+    const without = this._entries.filter((e) => e.id !== effectId);
+    const at = Math.max(0, Math.min(newIndex, without.length));
+    this._entries = [...without.slice(0, at), entry, ...without.slice(at)];
+    this._rebuild();
+  }
+
+  setParams(effectId: string, params: Record<string, number>): void {
+    const entry = this._find('setParams', effectId);
+    if (!entry) return;
+    entry.params = { ...entry.params, ...params };
+    if (entry.bypassed && entry.wetParam && entry.wetParam in params) {
+      // Store the new wet level but keep the audible wet at 0 while bypassed.
+      const { [entry.wetParam]: _stored, ...rest } = params;
+      if (Object.keys(rest).length > 0) {
+        entry.instance.applyParams(rest);
+      }
+      return;
+    }
+    entry.instance.applyParams(params);
+  }
+
+  setBypassed(effectId: string, bypassed: boolean): void {
+    const entry = this._find('setBypassed', effectId);
+    if (!entry || entry.bypassed === bypassed) return;
+    entry.bypassed = bypassed;
+
+    if (entry.wetParam) {
+      // Wet-style bypass: zero the wet level, restore the stored value later.
+      const wet = bypassed ? 0 : (entry.params[entry.wetParam] ?? 0);
+      entry.instance.applyParams({ [entry.wetParam]: wet });
+      return;
+    }
+    // No wet param: take the entry out of the series, keep the instance alive.
+    this._rebuild();
+  }
+
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    this._severOwnEdges();
+    for (const entry of this._entries) {
+      entry.instance.dispose?.();
+    }
+    this._entries = [];
+    try {
+      this._output.disconnect();
+    } catch {
+      // Output may already be detached by the consumer.
+    }
+  }
+
+  private _find(op: string, effectId: string): ChainEntry | undefined {
+    const entry = this._entries.find((e) => e.id === effectId);
+    if (!entry) {
+      console.warn(
+        '[waveform-playlist] EffectsChainController.' + op + ': unknown effectId "' + effectId + '"'
+      );
+    }
+    return entry;
+  }
+
+  /** Sever only this chain's outgoing edges — never the consumer's. */
+  private _severOwnEdges(): void {
+    this._input.disconnect();
+    for (const entry of this._entries) {
+      entry.instance.output.disconnect();
+    }
+  }
+
+  private _rebuild(): void {
+    this._severOwnEdges();
+    let previous: AudioNode = this._input;
+    for (const entry of this._entries) {
+      if (entry.bypassed && !entry.wetParam) {
+        continue;
+      }
+      previous.connect(entry.instance.input);
+      previous = entry.instance.output;
+    }
+    previous.connect(this._output);
+  }
+}

--- a/packages/dawcore/src/effects/types.ts
+++ b/packages/dawcore/src/effects/types.ts
@@ -1,0 +1,63 @@
+/** Range/display metadata for one effect parameter. */
+export interface EffectParamDef {
+  min: number;
+  max: number;
+  step?: number;
+  /** 's', 'ms', 'Hz', 'dB', '%' … */
+  unit?: string;
+}
+
+/**
+ * A live, wired effect. `input`/`output` are the chain attachment points
+ * (the same node for single-node effects). `applyParams` updates AudioParams
+ * in place — the chain never rebuilds for parameter changes.
+ */
+export interface EffectInstance {
+  input: AudioNode;
+  output: AudioNode;
+  applyParams: (params: Record<string, number>) => void;
+  dispose?: () => void;
+}
+
+/** A registered effect type. `create` must work on any BaseAudioContext so
+ *  the same definitions serve offline rendering. */
+export interface EffectDefinition {
+  label: string;
+  category: string;
+  defaults: Record<string, number>;
+  params: Record<string, EffectParamDef>;
+  /** Name of the wet/dry param, when the effect has one. Bypass zeroes it
+   *  (storing the original); effects without one are bypassed by
+   *  disconnection. */
+  wetParam?: string;
+  create: (audioContext: BaseAudioContext, params: Record<string, number>) => EffectInstance;
+}
+
+/**
+ * What the chain controller stores per slot. Kind-agnostic: 'native' entries
+ * come from the registry, 'wam' entries (future) wrap a WAM plugin's
+ * audioNode — chain operations never branch on kind.
+ */
+export interface EffectChainItem {
+  kind: string;
+  type: string;
+  instance: EffectInstance;
+  params: Record<string, number>;
+  wetParam?: string;
+}
+
+/** Public, serializable view of one chain entry. */
+export interface EffectState {
+  id: string;
+  kind: string;
+  type: string;
+  params: Record<string, number>;
+  bypassed: boolean;
+}
+
+/** Result of creating an effect via the registry. */
+export interface CreatedEffect {
+  instance: EffectInstance;
+  params: Record<string, number>;
+  wetParam?: string;
+}

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -88,3 +88,16 @@ export type {
   DawClipSplitDetail,
   LoadFilesResult,
 } from './events';
+
+// Effects (chain core — element APIs land in #418)
+export {
+  registerEffect,
+  getEffectDefinitions,
+  createEffectInstance,
+} from './effects/effect-registry';
+export type {
+  EffectDefinition,
+  EffectParamDef,
+  EffectInstance,
+  EffectState,
+} from './effects/types';


### PR DESCRIPTION
Closes #417. Part of the unified effects chain epic #412. Builds on the transport hooks from #432.

## Summary

The framework-agnostic core of the unified effects chain — no Lit, no element APIs (those land in #418), fully unit-testable without a DOM.

**`EffectsChainController`** (`packages/dawcore/src/effects/effects-chain-controller.ts`)
- Ordered chain entries wired in series between owned `input`/`output` GainNodes; empty chain is a straight passthrough. The owner connects `transport.connectTrackOutput(trackId, chain.input)` / `connectMasterOutput(chain.input)` and routes `chain.output` onward.
- **Kind-agnostic by construction**: entries carry `kind` (`'native'` today, `'wam'` in #422) and chain operations never branch on it — a WAM plugin's audioNode wraps into the same `EffectChainItem` shape.
- Topology changes (add/remove/move/disconnect-bypass) rebuild wiring; `setParams` never rebuilds (pinned by test asserting connect-call counts). Rebuilds sever **only the chain's own outgoing edges** — consumer edges into `input` and out of `output` are untouched.
- Bypass semantics per the migration spec: wet-style effects zero the wet param (original stored, restored on un-bypass, no rebuild); effects without one are removed from the series with the instance kept alive at its position. `setParams` on a bypassed wet effect stores the new wet level without making it audible.
- Unknown-id operations warn (`[waveform-playlist]` prefix) and no-op. `entries` returns defensive copies. `dispose()` is idempotent.

**Effect registry** (`packages/dawcore/src/effects/effect-registry.ts`)
- `registerEffect` / `getEffectDefinitions` (returns a copy) / `createEffectInstance` (throws on unknown type, listing available types).
- Five `native-*` built-ins, all plain Web Audio nodes: `native-gain`, `native-filter` (lowpass biquad), `native-compressor`, `native-delay` (delay + feedback loop + wet/dry crossfade, `wetParam: 'wet'`), `native-stereo-panner`. Created against `BaseAudioContext` so the same definitions serve offline rendering (#426 prerequisite).
- Re-registering an existing type warns and overwrites.

Public exports added to the package index: `registerEffect`, `getEffectDefinitions`, `createEffectInstance` + types (matches the spec's consumer import path). The controller itself stays internal until #418 wires it to elements.

## Test plan

- [x] TDD: 19 new tests written first and watched fail (12 controller, 7 registry) — ordering, insert-at-index, move rewiring, params-without-rebuild, both bypass modes, remove+dispose, defensive copies, unknown-id warns, dispose cleanup; registry built-ins, custom registration, overwrite warning, unknown-type throw, defaults merging, wet-param wiring, definitions-copy isolation
- [x] Full dawcore suite: 514/514 (`cd packages/dawcore && npx vitest run`)
- [x] `cd packages/dawcore && pnpm typecheck`
- [x] `pnpm -w lint` — 0 errors
