### PR TITLE
feat(wam): plugin loader, descriptor validation, factory cache (#421)

### DIFF
--- a/packages/dawcore-wam/CLAUDE.md
+++ b/packages/dawcore-wam/CLAUDE.md
@@ -17,6 +17,13 @@
 
 `ensureWamHost(audioContext)` — idempotent per context (WeakMap of in-flight promises; concurrent callers share one init), failure-evicting (retry re-inits). State guards: `closed` rejects; realtime contexts must be `running` (worklet load needs a post-gesture resume); **`OfflineAudioContext` is accepted while `'suspended'`** (detected via `'startRendering' in ctx`) — offline rendering inits the host *before* `startRendering()`, and a naive running-check would make offline WAM export (#426) impossible.
 
+## Plugin Loader (`src/loader.ts`)
+
+- `loadWamFactory(url, importFn?)` — dynamic `import(url)` → default export. Cached per URL (in-flight promise shared, failures evicted for retry). `importFn` is injectable for tests — never `vi.mock` dynamic URL imports.
+- `createWamInstance(url, ctx, hostGroupId, { initialState?, importFn? })` — load → `factory.createInstance(hostGroupId, ctx)` → **validate descriptor AFTER instantiation** (many plugins only expose it on the instance) → optional `setState(initialState)`. Validation or state failure destroys the instance before throwing.
+- **Effect-only validation**: `apiVersion` must be `2.x`; `hasAudioInput` AND `hasAudioOutput` required — instrument-only plugins are rejected with an explanatory error (MIDI/instrument hosting is out of epic scope).
+- Wrapper `WamPluginInstance` is headless (no GUI handling — that's the GUI issue) with idempotent `destroy()`. Types are structural (`WamFactory`, `WamPluginAudioNode`) rather than the SDK's alpha typings — keeps the public surface stable across SDK bumps.
+
 ## Reference Implementation
 
 wam-studio (local checkout at `~/Code/wam-studio`) — `public/src/Models/Plugin.ts` shows the full plugin lifecycle: `createInstance(hostGroupId, ctx)`, GUI/audio lifecycle split (`createGui`/`destroyGui` independent of `audioNode.destroy()`), and `cloneInto(offlineCtx, groupId)` for offline rendering via getState/setState transfer.

--- a/packages/dawcore-wam/__tests__/loader.test.ts
+++ b/packages/dawcore-wam/__tests__/loader.test.ts
@@ -75,6 +75,34 @@ describe('loadWamFactory', () => {
     expect(second).toBe(first);
   });
 
+  it('concurrent loads share one in-flight import', async () => {
+    const { WamClass } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const [a, b] = await Promise.all([
+      loadWamFactory(URL_A, importFn),
+      loadWamFactory(URL_A, importFn),
+    ]);
+
+    expect(importFn).toHaveBeenCalledTimes(1);
+    expect(b).toBe(a);
+  });
+
+  it('a failing destroy during cleanup does not mask the validation error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { WamClass, audioNode } = makeWamClass({ hasAudioInput: false });
+    audioNode.destroy.mockImplementation(() => {
+      throw new Error('teardown exploded');
+    });
+    const importFn = makeImportFn({ default: WamClass });
+
+    await expect(createWamInstance(URL_A, ctx, 'group-1', { importFn })).rejects.toThrow(
+      /audio input/i
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('teardown exploded'));
+    warn.mockRestore();
+  });
+
   it('evicts a failed load so a retry re-imports', async () => {
     const { WamClass } = makeWamClass();
     const importFn = vi

--- a/packages/dawcore-wam/__tests__/loader.test.ts
+++ b/packages/dawcore-wam/__tests__/loader.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  loadWamFactory,
+  createWamInstance,
+  _resetWamFactoryCacheForTests,
+} from '../src/loader';
+
+function makeDescriptor(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Test Reverb',
+    vendor: 'Test Vendor',
+    version: '1.0.0',
+    apiVersion: '2.0.0',
+    hasAudioInput: true,
+    hasAudioOutput: true,
+    ...overrides,
+  };
+}
+
+function makeAudioNode() {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    destroy: vi.fn(),
+    getState: vi.fn(async () => ({ preset: 'hall' })),
+    setState: vi.fn(async () => undefined),
+    getParameterInfo: vi.fn(async () => ({})),
+  };
+}
+
+function makeWamClass(descriptorOverrides: Record<string, unknown> = {}) {
+  const audioNode = makeAudioNode();
+  const instance = {
+    descriptor: makeDescriptor(descriptorOverrides),
+    audioNode,
+  };
+  const WamClass = {
+    createInstance: vi.fn(async () => instance),
+  };
+  return { WamClass, instance, audioNode };
+}
+
+function makeImportFn(moduleValue: unknown) {
+  return vi.fn(async () => moduleValue);
+}
+
+const URL_A = 'https://plugins.example.com/reverb/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ctx = { sampleRate: 48000 } as any;
+
+beforeEach(() => {
+  _resetWamFactoryCacheForTests();
+});
+
+describe('loadWamFactory', () => {
+  it('imports the module and resolves its default export', async () => {
+    const { WamClass } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const factory = await loadWamFactory(URL_A, importFn);
+
+    expect(importFn).toHaveBeenCalledWith(URL_A);
+    expect(factory).toBe(WamClass);
+  });
+
+  it('caches the factory — second load does not re-import', async () => {
+    const { WamClass } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const first = await loadWamFactory(URL_A, importFn);
+    const second = await loadWamFactory(URL_A, importFn);
+
+    expect(importFn).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it('evicts a failed load so a retry re-imports', async () => {
+    const { WamClass } = makeWamClass();
+    const importFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ default: WamClass });
+
+    await expect(loadWamFactory(URL_A, importFn)).rejects.toThrow('network down');
+    const factory = await loadWamFactory(URL_A, importFn);
+
+    expect(importFn).toHaveBeenCalledTimes(2);
+    expect(factory).toBe(WamClass);
+  });
+
+  it('rejects a module without a usable default export, naming the url', async () => {
+    const importFn = makeImportFn({ default: undefined });
+
+    await expect(loadWamFactory(URL_A, importFn)).rejects.toThrow(
+      new RegExp('\\[waveform-playlist\\][\\s\\S]*' + 'plugins\\.example\\.com')
+    );
+  });
+});
+
+describe('createWamInstance', () => {
+  it('instantiates via createInstance(hostGroupId, audioContext) and exposes the descriptor', async () => {
+    const { WamClass, audioNode } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const plugin = await createWamInstance(URL_A, ctx, 'group-1', { importFn });
+
+    expect(WamClass.createInstance).toHaveBeenCalledWith('group-1', ctx);
+    expect(plugin.url).toBe(URL_A);
+    expect(plugin.descriptor.name).toBe('Test Reverb');
+    expect(plugin.audioNode).toBe(audioNode);
+  });
+
+  it('rejects a descriptor without a compatible apiVersion and destroys the instance', async () => {
+    const { WamClass, audioNode } = makeWamClass({ apiVersion: '1.0.0' });
+    const importFn = makeImportFn({ default: WamClass });
+
+    await expect(createWamInstance(URL_A, ctx, 'group-1', { importFn })).rejects.toThrow(
+      /apiVersion/
+    );
+    expect(audioNode.destroy).toHaveBeenCalled();
+  });
+
+  it('rejects an instrument-only plugin (no audio input) with an explanatory error', async () => {
+    const { WamClass, audioNode } = makeWamClass({ hasAudioInput: false });
+    const importFn = makeImportFn({ default: WamClass });
+
+    await expect(createWamInstance(URL_A, ctx, 'group-1', { importFn })).rejects.toThrow(
+      /audio input/i
+    );
+    expect(audioNode.destroy).toHaveBeenCalled();
+  });
+
+  it('applies initialState via the audio node', async () => {
+    const { WamClass, audioNode } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+    const state = { preset: 'plate' };
+
+    await createWamInstance(URL_A, ctx, 'group-1', { importFn, initialState: state });
+
+    expect(audioNode.setState).toHaveBeenCalledWith(state);
+  });
+
+  it('destroy() tears down the audio node and is safe to call twice', async () => {
+    const { WamClass, audioNode } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const plugin = await createWamInstance(URL_A, ctx, 'group-1', { importFn });
+    plugin.destroy();
+    plugin.destroy();
+
+    expect(audioNode.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('getState/setState/getParameterInfo delegate to the audio node', async () => {
+    const { WamClass, audioNode } = makeWamClass();
+    const importFn = makeImportFn({ default: WamClass });
+
+    const plugin = await createWamInstance(URL_A, ctx, 'group-1', { importFn });
+    await expect(plugin.getState()).resolves.toEqual({ preset: 'hall' });
+    await plugin.setState({ preset: 'room' });
+    await plugin.getParameterInfo();
+
+    expect(audioNode.setState).toHaveBeenCalledWith({ preset: 'room' });
+    expect(audioNode.getParameterInfo).toHaveBeenCalled();
+  });
+});

--- a/packages/dawcore-wam/src/index.ts
+++ b/packages/dawcore-wam/src/index.ts
@@ -1,2 +1,11 @@
 export { ensureWamHost } from './host';
 export type { WamHostInfo } from './host';
+export { loadWamFactory, createWamInstance } from './loader';
+export type {
+  WamFactory,
+  WamModuleImport,
+  WamPluginAudioNode,
+  WamPluginDescriptor,
+  WamPluginInstance,
+  CreateWamInstanceOptions,
+} from './loader';

--- a/packages/dawcore-wam/src/loader.ts
+++ b/packages/dawcore-wam/src/loader.ts
@@ -114,7 +114,18 @@ export async function createWamInstance(
       await wam.audioNode.setState(options.initialState);
     }
   } catch (err) {
-    wam.audioNode.destroy();
+    try {
+      wam.audioNode.destroy();
+    } catch (destroyErr) {
+      // Never let teardown failure mask the original validation/state error.
+      console.warn(
+        PREFIX +
+          'createWamInstance: cleanup after failure also failed for "' +
+          url +
+          '": ' +
+          String(destroyErr)
+      );
+    }
     throw err;
   }
 

--- a/packages/dawcore-wam/src/loader.ts
+++ b/packages/dawcore-wam/src/loader.ts
@@ -1,0 +1,171 @@
+const PREFIX = '[waveform-playlist] ';
+
+/** Injectable for tests — production uses native dynamic import. */
+export type WamModuleImport = (url: string) => Promise<unknown>;
+
+/** Structural view of a WAM plugin's descriptor (subset we validate/expose). */
+export interface WamPluginDescriptor {
+  name: string;
+  vendor?: string;
+  version?: string;
+  apiVersion: string;
+  hasAudioInput: boolean;
+  hasAudioOutput: boolean;
+  thumbnail?: string;
+  description?: string;
+}
+
+/** Structural view of a WamNode — the plugin's AudioNode plus the WAM API surface. */
+export interface WamPluginAudioNode extends AudioNode {
+  destroy(): void;
+  getState(): Promise<unknown>;
+  setState(state: unknown): Promise<void>;
+  getParameterInfo(...parameterIds: string[]): Promise<unknown>;
+}
+
+interface WamModuleLike {
+  descriptor: WamPluginDescriptor;
+  audioNode: WamPluginAudioNode;
+}
+
+/** The module's default export: a WebAudioModule class (or object) with a createInstance factory. */
+export interface WamFactory {
+  createInstance(hostGroupId: string, audioContext: BaseAudioContext): Promise<WamModuleLike>;
+}
+
+/** A loaded, validated, live plugin wrapped for chain insertion. Headless — GUI handling is separate. */
+export interface WamPluginInstance {
+  url: string;
+  descriptor: WamPluginDescriptor;
+  audioNode: WamPluginAudioNode;
+  getState(): Promise<unknown>;
+  setState(state: unknown): Promise<void>;
+  getParameterInfo(...parameterIds: string[]): Promise<unknown>;
+  /** Tears down the plugin's AudioWorklet. Safe to call more than once. */
+  destroy(): void;
+}
+
+export interface CreateWamInstanceOptions {
+  initialState?: unknown;
+  importFn?: WamModuleImport;
+}
+
+const defaultImport: WamModuleImport = (url) => import(/* @vite-ignore */ url);
+
+let factoryCache = new Map<string, Promise<WamFactory>>();
+
+/**
+ * Load a WAM plugin module and resolve its factory (default export).
+ * Cached per URL with a shared in-flight promise; failed loads are evicted
+ * so a retry re-fetches instead of replaying the failure.
+ */
+export function loadWamFactory(
+  url: string,
+  importFn: WamModuleImport = defaultImport
+): Promise<WamFactory> {
+  const cached = factoryCache.get(url);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = importFn(url)
+    .then((mod) => {
+      const candidate = (mod as { default?: unknown } | null | undefined)?.default;
+      const isUsable =
+        candidate !== null &&
+        (typeof candidate === 'function' || typeof candidate === 'object') &&
+        typeof (candidate as { createInstance?: unknown })?.createInstance === 'function';
+      if (!isUsable) {
+        throw new Error(
+          PREFIX +
+            'loadWamFactory: module at "' +
+            url +
+            '" has no usable default export. A WAM plugin module must default-export a WebAudioModule class with a static createInstance().'
+        );
+      }
+      return candidate as WamFactory;
+    })
+    .catch((err: unknown) => {
+      factoryCache.delete(url);
+      throw err;
+    });
+
+  factoryCache.set(url, pending);
+  return pending;
+}
+
+/**
+ * Load (cached), instantiate, and validate a WAM plugin as an insert effect.
+ * The descriptor is validated AFTER instantiation — many plugins only expose
+ * it on the instance. Invalid plugins are destroyed before the error is thrown.
+ */
+export async function createWamInstance(
+  url: string,
+  audioContext: BaseAudioContext,
+  hostGroupId: string,
+  options: CreateWamInstanceOptions = {}
+): Promise<WamPluginInstance> {
+  const factory = await loadWamFactory(url, options.importFn);
+  const wam = await factory.createInstance(hostGroupId, audioContext);
+
+  try {
+    validateEffectDescriptor(wam.descriptor, url);
+    if (options.initialState !== undefined) {
+      await wam.audioNode.setState(options.initialState);
+    }
+  } catch (err) {
+    wam.audioNode.destroy();
+    throw err;
+  }
+
+  let destroyed = false;
+  return {
+    url,
+    descriptor: wam.descriptor,
+    audioNode: wam.audioNode,
+    getState: () => wam.audioNode.getState(),
+    setState: (state: unknown) => wam.audioNode.setState(state),
+    getParameterInfo: (...parameterIds: string[]) =>
+      wam.audioNode.getParameterInfo(...parameterIds),
+    destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      wam.audioNode.destroy();
+    },
+  };
+}
+
+function validateEffectDescriptor(descriptor: WamPluginDescriptor | undefined, url: string): void {
+  const apiVersion = descriptor?.apiVersion;
+  if (descriptor === undefined || typeof apiVersion !== 'string' || !apiVersion.startsWith('2.')) {
+    throw new Error(
+      PREFIX +
+        'createWamInstance: plugin at "' +
+        url +
+        '" has a missing or incompatible descriptor apiVersion ("' +
+        String(apiVersion) +
+        '"). This host supports WAM 2.x.'
+    );
+  }
+  if (!descriptor.hasAudioInput) {
+    throw new Error(
+      PREFIX +
+        'createWamInstance: plugin at "' +
+        url +
+        '" has no audio input (hasAudioInput=false). Instrument-only plugins cannot be inserted into an effects chain.'
+    );
+  }
+  if (!descriptor.hasAudioOutput) {
+    throw new Error(
+      PREFIX +
+        'createWamInstance: plugin at "' +
+        url +
+        '" has no audio output (hasAudioOutput=false) and cannot be inserted into an effects chain.'
+    );
+  }
+}
+
+/** Test-only: drop all cached factory loads. */
+export function _resetWamFactoryCacheForTests(): void {
+  factoryCache = new Map();
+}


### PR DESCRIPTION
Closes #421. Part of the WAM 2.0 plugin support epic #413. Builds on the scaffold/host init from #433.

## Summary

Second slice of `@dawcore/wam`: plugin loading, validation, instantiation, teardown — everything needed by the chain-integration issue (#422) except the chain itself.

- **`loadWamFactory(url, importFn?)`** — dynamic `import(url)` resolving the default-exported `WebAudioModule` class. Cached per URL (`Map<url, Promise>`): concurrent loads share one fetch, **failed loads are evicted** so a retry re-fetches instead of replaying the failure. Modules without a usable default export (no `createInstance`) get a clear `[waveform-playlist]` error naming the URL. The import function is injectable for tests.
- **`createWamInstance(url, ctx, hostGroupId, {initialState?, importFn?})`** — load (cached) → `factory.createInstance(hostGroupId, audioContext)` → **descriptor validation after instantiation** (many WAM plugins only expose the descriptor on the instance) → optional `setState(initialState)` for restore flows. Any validation/state failure destroys the instance before throwing — no leaked AudioWorklets.
- **Effect-only validation**: `apiVersion` must be 2.x; `hasAudioInput` AND `hasAudioOutput` required. Instrument-only plugins are rejected with an error explaining that MIDI/instrument hosting is out of scope for the effects chain.
- **`WamPluginInstance`** — headless wrapper (`url`, `descriptor`, `audioNode`, `getState`/`setState`/`getParameterInfo` delegation, **idempotent `destroy()`**). GUI handling is deliberately absent (#423). Types are structural rather than re-exporting the SDK's alpha typings, keeping the public surface stable across SDK bumps.

Integration smoke-testing against real community plugins is deferred to the example issue (#428) per the issue's test plan — real plugins need a live AudioContext.

## Test plan

- [x] TDD: 10 new tests written first and watched fail — import + default-export resolution, cache hit, failure eviction + retry, unusable-module error, createInstance args + descriptor exposure, apiVersion rejection (destroys instance), instrument-only rejection (destroys instance), initialState application, idempotent destroy, state/param delegation
- [x] `cd packages/dawcore-wam && npx vitest run` — 18/18 (8 host + 10 loader)
- [x] `pnpm --filter @dawcore/wam typecheck` + `build`
- [x] `pnpm -w lint` — 0 errors
