### PR TITLE
feat(dawcore-wam): library.json plugin discovery — fetchWamLibrary (#427)

### DIFF
--- a/packages/dawcore-wam/CLAUDE.md
+++ b/packages/dawcore-wam/CLAUDE.md
@@ -24,6 +24,14 @@
 - **Effect-only validation**: `apiVersion` must be `2.x`; `hasAudioInput` AND `hasAudioOutput` required — instrument-only plugins are rejected with an explanatory error (MIDI/instrument hosting is out of epic scope).
 - Wrapper `WamPluginInstance` is headless (no GUI handling — that's the GUI issue) with idempotent `destroy()`. Types are structural (`WamFactory`, `WamPluginAudioNode`) rather than the SDK's alpha typings — keeps the public surface stable across SDK bumps.
 
+## Library Discovery (`src/library.ts`)
+
+- `fetchWamLibrary(manifestUrl, { fetchFn?, baseUrl? })` → `{ entries, warnings }` — fetch + schema-validate `library.json` manifests at the boundary. `fetchFn` is injectable for tests (structural `WamManifestResponse`, no full `Response` needed); no caching by design.
+- **Common-denominator schema** (surveyed from webaudiomodules.com community `plugins.json` and pedalboard2/wam-studio libraries): top-level array OR `{ plugins: [...] }`; entries are objects (`name` + `url`/`path` required; optional description/vendor/thumbnail/keywords passed through when well-formed) or bare URL strings (name derived from URL, skipping generic segments like `index.js`/`dist`/`src`).
+- Relative plugin/thumbnail URLs resolve against the manifest URL; **`baseUrl` option exists because webaudiomodules.com keeps `path` relative to `community/plugins/`, not the manifest** — manifest-relative resolution alone 404s there.
+- Invalid entries skip with `[waveform-playlist]`-prefixed messages collected into `warnings` (never fail the manifest); unreachable/invalid-JSON/unrecognized-shape/zero-valid-entries reject. Entry `url` feeds straight into `createWamInstance` — descriptor validation stays at load time.
+- Real-world fixture manifests live as constants in `__tests__/library.test.ts` with source URLs in comments.
+
 ## Reference Implementation
 
 wam-studio (local checkout at `~/Code/wam-studio`) — `public/src/Models/Plugin.ts` shows the full plugin lifecycle: `createInstance(hostGroupId, ctx)`, GUI/audio lifecycle split (`createGui`/`destroyGui` independent of `audioNode.destroy()`), and `cloneInto(offlineCtx, groupId)` for offline rendering via getState/setState transfer.

--- a/packages/dawcore-wam/README.md
+++ b/packages/dawcore-wam/README.md
@@ -27,6 +27,53 @@ const { hostGroupId } = await ensureWamHost(audioContext);
 - Realtime contexts must be **running** (resume after a user gesture first) — host init loads an AudioWorklet module.
 - `OfflineAudioContext` is accepted while `'suspended'`: offline rendering initializes the host *before* `startRendering()`.
 
+### Plugin discovery
+
+Two standard ways to find plugins in the WAM ecosystem, both supported:
+
+**URL paste** — a direct URL to a plugin's ES module (its `index.js`) loads as-is. The descriptor is validated at load time, so a pasted URL either becomes a live plugin or fails with a clear error:
+
+```typescript
+import { createWamInstance } from '@dawcore/wam';
+
+const plugin = await createWamInstance(
+  'https://www.webaudiomodules.com/community/plugins/burns-audio/distortion/index.js',
+  audioContext,
+  hostGroupId
+);
+```
+
+**`library.json` manifests** — JSON files listing plugins with metadata, used by WAM plugin collections:
+
+```typescript
+import { fetchWamLibrary } from '@dawcore/wam';
+
+const { entries, warnings } = await fetchWamLibrary(
+  'https://www.webaudiomodules.com/community/plugins.json',
+  { baseUrl: 'https://www.webaudiomodules.com/community/plugins/' }
+);
+// entries: [{ name, url, description?, vendor?, thumbnail?, keywords? }, ...]
+// warnings: per-entry messages for invalid entries that were skipped
+```
+
+An entry's `url` feeds straight into `createWamInstance(url, ...)`. Descriptor validation still happens at load time — manifests can lie.
+
+#### Supported manifest schema
+
+`fetchWamLibrary` supports the common denominator of the public WAM collections (the [webaudiomodules.com community registry](https://www.webaudiomodules.com/community/plugins.json) with the burns-audio pack, and pedalboard2/wam-studio libraries listing wam-examples plugins). A manifest is either:
+
+- a **top-level array** of entries, or
+- an **object with a `plugins` array** of entries (extra fields like `name`, `id`, `version`, `presets`, `includes` are ignored).
+
+Each entry is either:
+
+- an **object** — `name` (required) plus a plugin URL in `url` or `path` (required). Optional fields are passed through when well-formed: `description` (string), `vendor` (string), `thumbnail` (string URL), `keywords` (string array). Unknown fields are ignored.
+- a **bare URL string** — the plugin URL; a display name is derived from the URL path (generic segments like `index.js`, `dist`, `src` are skipped, so `…/quadrafuzz/dist/index.js` becomes `quadrafuzz`).
+
+Relative plugin and thumbnail URLs are resolved against the manifest URL — or against `options.baseUrl` for registries (like webaudiomodules.com) that keep paths relative to a directory next to the manifest.
+
+Invalid entries (missing name, missing/unresolvable URL) are skipped with a per-entry message collected into `warnings` — one bad entry never fails the manifest. An unreachable manifest, invalid JSON, an unrecognized shape, or zero valid entries rejects with a `[waveform-playlist]`-prefixed error.
+
 ## Status
 
 Part of the [WAM 2.0 plugin support epic](https://github.com/naomiaro/waveform-playlist/issues/413). Plugin loading, chain integration, GUI embedding, persistence, and transport sync land in subsequent releases.

--- a/packages/dawcore-wam/__tests__/library.test.ts
+++ b/packages/dawcore-wam/__tests__/library.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchWamLibrary } from '../src/library';
+
+const MANIFEST_URL = 'https://plugins.example.com/collection/library.json';
+
+function makeResponse(
+  body: unknown,
+  init: { ok?: boolean; status?: number; statusText?: string } = {}
+) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    json: async () => body,
+  };
+}
+
+function makeFetchFn(
+  body: unknown,
+  init: { ok?: boolean; status?: number; statusText?: string } = {}
+) {
+  return vi.fn(async () => makeResponse(body, init));
+}
+
+/**
+ * Faithful copy of the first four entries of the WAM community registry
+ * (burns-audio plugin pack). Source (fetched 2026-06-10):
+ * https://www.webaudiomodules.com/community/plugins.json
+ *
+ * Note the shape: top-level array, plugin URL in "path" (relative), relative
+ * "thumbnail", plus extra fields ("identifier", "website", "category",
+ * "thumbnailDimensions") that the parser must tolerate.
+ */
+const COMMUNITY_PLUGINS_JSON = [
+  {
+    identifier: 'com.sequencerParty.audioInput',
+    name: 'Audio Input',
+    vendor: 'Sequencer Party',
+    website: 'https://sequencer.party',
+    description: 'Provides audio from external sound card input or microphone.',
+    keywords: ['utility', 'input'],
+    category: ['Effect', 'Utility'],
+    thumbnail: 'burns-audio/audio_input/screenshot.png',
+    thumbnailDimensions: { width: 642, height: 482 },
+    path: 'burns-audio/audio_input/index.js',
+  },
+  {
+    identifier: 'com.sequencerParty.simpleDistortion',
+    name: 'Simple Distortion',
+    vendor: 'Sequencer Party',
+    website: 'https://sequencer.party',
+    description: 'Simple waveshaper-based distortion with variable curve and gain',
+    keywords: ['effect', 'distortion'],
+    category: ['Effect', 'Distortion'],
+    thumbnail: 'burns-audio/distortion/screenshot.png',
+    thumbnailDimensions: { width: 316, height: 260 },
+    path: 'burns-audio/distortion/index.js',
+  },
+  {
+    identifier: 'com.sequencerParty.envmod',
+    name: 'Envelope Follower',
+    vendor: 'Sequencer Party',
+    website: 'https://sequencer.party',
+    description: 'Modulate a destination parameter with an audio signal.',
+    keywords: ['modulator', 'envelope', 'follower'],
+    category: ['Modulation', 'Modulator'],
+    thumbnail: 'burns-audio/envmod/screenshot.png',
+    thumbnailDimensions: { width: 580, height: 202 },
+    path: 'burns-audio/envmod/index.js',
+  },
+  {
+    identifier: 'com.sequencerParty.functionSeq',
+    name: 'Function Sequencer',
+    vendor: 'Sequencer Party',
+    website: 'https://sequencer.party',
+    description: 'Collaborative live-coding javascript sequencer.',
+    keywords: ['sequencer', 'javascript', 'midi'],
+    category: ['MIDI', 'Sequencer'],
+    thumbnail: 'burns-audio/functionseq/screenshot.png',
+    thumbnailDimensions: { width: 1870, height: 586 },
+    path: 'burns-audio/functionseq/index.js',
+  },
+];
+
+const COMMUNITY_MANIFEST_URL = 'https://www.webaudiomodules.com/community/plugins.json';
+
+/**
+ * Faithful copy of wam-studio's Pedalboard2 library manifest, which lists
+ * plugins from both webaudiomodules/wam-examples (wimmics, mainline.i3s
+ * builds) and the burns-audio pack. Source:
+ * https://github.com/Brotherta/wam-studio/blob/master/bank/pedalboard2/static/wamstudio_library.t.json
+ *
+ * Note the shape: top-level object with a "plugins" array of bare URL
+ * strings, plus extra fields ("$schema", "id", "version", "permissive",
+ * "presets", "includes") that the parser must tolerate. The "{{BANKURL}}"
+ * placeholders are part of the upstream template and live only in fields
+ * the parser ignores.
+ */
+const WAMSTUDIO_LIBRARY_JSON = {
+  $schema: '../../bank/pedalboard2/static/library_schema.json',
+  name: 'Wamstudio Official Pedalboard2 Library',
+  id: 'wamstudio.base',
+  version: [0, 0],
+  permissive: true,
+  plugins: [
+    'https://mainline.i3s.unice.fr/PedalEditor/Back-End/functional-pedals/published/clarinetMIDI/indexGUIStandard.js',
+    'https://mainline.i3s.unice.fr/PedalEditor/Back-End/functional-pedals/published/JUNO6v2/indexGUIStandard.js',
+    'https://wam-4tt.pages.dev/Pro54/index.js',
+    'https://mainline.i3s.unice.fr/WAMViktorNV1/viktorNV1/index.js',
+    'https://wam-4tt.pages.dev/TX81Z/index.js',
+    'https://mainline.i3s.unice.fr/WAMChorusMB/index.js',
+    'https://mainline.i3s.unice.fr/WAMAutoWahMB/index.js',
+    'https://mainline.i3s.unice.fr/WAMfreeverbMB/index.js',
+    'https://mainline.i3s.unice.fr/WAMCollisionDriveMB/index.js',
+    'https://mainline.i3s.unice.fr/PedalEditor/Back-End/functional-pedals/published/fluteForIS2/index.js',
+    'https://mainline.i3s.unice.fr/wam2/packages/faustPingPongDelay/plugin/index.js',
+    'https://mainline.i3s.unice.fr/wam2/packages/obxd/index.js',
+    'https://mainline.i3s.unice.fr/wam2/packages/pingpongdelay/dist/index.js',
+    'https://mainline.i3s.unice.fr/wam2/packages/quadrafuzz/dist/index.js',
+    'https://mainline.i3s.unice.fr/WamSampler/src/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/distortion/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/drumsampler/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/envmod/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/jx3p_editor/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/modal/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/soundfont/index.js',
+    'https://www.webaudiomodules.com/community/plugins/burns-audio/synth101/index.js',
+    'https://www.webaudiomodules.com/community/plugins/wimmics/csoundPitchShifter/dist/index.js',
+    'https://mainline.i3s.unice.fr/PedalEditor/Back-End/functional-pedals/published/untitled6/index.js',
+  ],
+  presets: {
+    'Piano Echo': {
+      description: 'A MIDI Piano with an echo effect',
+      category: 'instrument',
+      state: {
+        plugins: [
+          {
+            wam_id: 'com.sequencerParty.soundfont',
+            state: { instrument: 'acoustic_grand_piano' },
+          },
+          {
+            wam_id: 'Shihong Ren.Faust PingPongDelay',
+            state: {
+              '/PingPongDelayFaust/bypass': 0,
+              '/PingPongDelayFaust/mix': 0.5,
+              '/PingPongDelayFaust/time': 0.10000000149011612,
+              '/PingPongDelayFaust/feedback': 0.30000001192092896,
+            },
+          },
+        ],
+      },
+    },
+    'Wam API Library': {
+      description: 'A library fetching its WAM from the WAM API',
+      category: 'library',
+      state: { library: '{{BANKURL}}/wam_api_library.json', plugins: [] },
+    },
+    'Legacy Library': {
+      description: 'A library of the plugins hosted in the wam bank',
+      category: 'library',
+      state: { library: '{{BANKURL}}/plugins/library.json', plugins: [] },
+    },
+  },
+  includes: [
+    { id: 'wamstudio.pedalboard2.legacy', version: [0, 0], url: '{{BANKURL}}/local_library.json' },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchWamLibrary — manifest shapes', () => {
+  it('parses a top-level array of entry objects', async () => {
+    const fetchFn = makeFetchFn([
+      { name: 'Reverb', url: 'https://plugins.example.com/reverb/index.js' },
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledWith(MANIFEST_URL);
+    expect(warnings).toEqual([]);
+    expect(entries).toEqual([
+      { name: 'Reverb', url: 'https://plugins.example.com/reverb/index.js' },
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+  });
+
+  it('parses an object with a "plugins" array (pedalboard2 library shape)', async () => {
+    const fetchFn = makeFetchFn({
+      name: 'My Library',
+      plugins: [{ name: 'Chorus', url: 'https://plugins.example.com/chorus/index.js' }],
+    });
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(warnings).toEqual([]);
+    expect(entries).toEqual([
+      { name: 'Chorus', url: 'https://plugins.example.com/chorus/index.js' },
+    ]);
+  });
+
+  it('accepts bare URL strings as entries, deriving a name from the URL', async () => {
+    const fetchFn = makeFetchFn({
+      plugins: [
+        'https://plugins.example.com/synth101/index.js',
+        'https://plugins.example.com/quadrafuzz/dist/index.js',
+      ],
+    });
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(warnings).toEqual([]);
+    expect(entries).toEqual([
+      { name: 'synth101', url: 'https://plugins.example.com/synth101/index.js' },
+      { name: 'quadrafuzz', url: 'https://plugins.example.com/quadrafuzz/dist/index.js' },
+    ]);
+  });
+
+  it('accepts "path" as the plugin URL field (community registry shape)', async () => {
+    const fetchFn = makeFetchFn([{ name: 'Distortion', path: 'burns-audio/distortion/index.js' }]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries).toEqual([
+      {
+        name: 'Distortion',
+        url: 'https://plugins.example.com/collection/burns-audio/distortion/index.js',
+      },
+    ]);
+  });
+});
+
+describe('fetchWamLibrary — URL resolution', () => {
+  it('resolves relative plugin URLs against the manifest URL', async () => {
+    const fetchFn = makeFetchFn([
+      { name: 'Reverb', url: 'reverb/index.js' },
+      { name: 'Phaser', url: '../shared/phaser/index.js' },
+      { name: 'Flanger', url: '/root/flanger/index.js' },
+    ]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries.map((e) => e.url)).toEqual([
+      'https://plugins.example.com/collection/reverb/index.js',
+      'https://plugins.example.com/shared/phaser/index.js',
+      'https://plugins.example.com/root/flanger/index.js',
+    ]);
+  });
+
+  it('leaves absolute plugin URLs untouched', async () => {
+    const fetchFn = makeFetchFn([{ name: 'Reverb', url: 'https://other.example.org/reverb.js' }]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries[0].url).toBe('https://other.example.org/reverb.js');
+  });
+
+  it('resolves relative URLs against options.baseUrl when provided', async () => {
+    const fetchFn = makeFetchFn([{ name: 'Distortion', path: 'burns-audio/distortion/index.js' }]);
+
+    const { entries } = await fetchWamLibrary(COMMUNITY_MANIFEST_URL, {
+      fetchFn,
+      baseUrl: 'https://www.webaudiomodules.com/community/plugins/',
+    });
+
+    expect(entries[0].url).toBe(
+      'https://www.webaudiomodules.com/community/plugins/burns-audio/distortion/index.js'
+    );
+  });
+
+  it('resolves a relative thumbnail against the same base as the plugin URL', async () => {
+    const fetchFn = makeFetchFn([
+      {
+        name: 'Distortion',
+        path: 'burns-audio/distortion/index.js',
+        thumbnail: 'burns-audio/distortion/screenshot.png',
+      },
+    ]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries[0].thumbnail).toBe(
+      'https://plugins.example.com/collection/burns-audio/distortion/screenshot.png'
+    );
+  });
+});
+
+describe('fetchWamLibrary — optional fields', () => {
+  it('passes through description, vendor, thumbnail, and keywords', async () => {
+    const fetchFn = makeFetchFn([
+      {
+        name: 'Reverb',
+        url: 'https://plugins.example.com/reverb/index.js',
+        description: 'A lush hall reverb',
+        vendor: 'Example Audio',
+        thumbnail: 'https://plugins.example.com/reverb/thumb.png',
+        keywords: ['effect', 'reverb'],
+      },
+    ]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries[0]).toEqual({
+      name: 'Reverb',
+      url: 'https://plugins.example.com/reverb/index.js',
+      description: 'A lush hall reverb',
+      vendor: 'Example Audio',
+      thumbnail: 'https://plugins.example.com/reverb/thumb.png',
+      keywords: ['effect', 'reverb'],
+    });
+  });
+
+  it('drops malformed optional fields without skipping the entry', async () => {
+    const fetchFn = makeFetchFn([
+      {
+        name: 'Reverb',
+        url: 'https://plugins.example.com/reverb/index.js',
+        description: 42,
+        vendor: { name: 'nested' },
+        thumbnail: false,
+        keywords: 'effect',
+      },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(warnings).toEqual([]);
+    expect(entries).toEqual([
+      { name: 'Reverb', url: 'https://plugins.example.com/reverb/index.js' },
+    ]);
+  });
+
+  it('filters non-string items out of keywords', async () => {
+    const fetchFn = makeFetchFn([
+      {
+        name: 'Reverb',
+        url: 'https://plugins.example.com/reverb/index.js',
+        keywords: ['effect', 5, 'reverb', null],
+      },
+    ]);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries[0].keywords).toEqual(['effect', 'reverb']);
+  });
+});
+
+describe('fetchWamLibrary — invalid entries', () => {
+  it('skips entries missing a name with a per-entry warning, keeping valid ones', async () => {
+    const fetchFn = makeFetchFn([
+      { url: 'https://plugins.example.com/anonymous/index.js' },
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries).toEqual([{ name: 'Delay', url: 'https://plugins.example.com/delay/index.js' }]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('[waveform-playlist] ');
+    expect(warnings[0]).toContain('entry 0');
+    expect(warnings[0]).toContain('name');
+  });
+
+  it('skips entries missing a plugin URL with a per-entry warning', async () => {
+    const fetchFn = makeFetchFn([
+      { name: 'No URL Here' },
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('entry 0');
+    expect(warnings[0]).toContain('"No URL Here"');
+  });
+
+  it('skips entries that are neither strings nor objects', async () => {
+    const fetchFn = makeFetchFn([
+      42,
+      null,
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries).toHaveLength(1);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('entry 0');
+    expect(warnings[1]).toContain('entry 1');
+  });
+
+  it('skips entries whose plugin URL cannot be resolved', async () => {
+    const fetchFn = makeFetchFn([
+      { name: 'Broken', url: 'https://' },
+      { name: 'Delay', url: 'https://plugins.example.com/delay/index.js' },
+    ]);
+
+    const { entries, warnings } = await fetchWamLibrary(MANIFEST_URL, { fetchFn });
+
+    expect(entries).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('entry 0');
+  });
+});
+
+describe('fetchWamLibrary — manifest errors', () => {
+  it('rejects with a clear error when the manifest is unreachable', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(
+      new RegExp('\\[waveform-playlist\\][\\s\\S]*could not fetch[\\s\\S]*plugins\\.example\\.com')
+    );
+  });
+
+  it('rejects with the HTTP status when the manifest request fails', async () => {
+    const fetchFn = makeFetchFn(null, { ok: false, status: 404, statusText: 'Not Found' });
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('rejects with a clear error when the manifest is not valid JSON', async () => {
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON at position 0');
+      },
+    }));
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('rejects when the manifest has an unrecognized shape', async () => {
+    const fetchFn = makeFetchFn({ unexpected: true });
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(
+      /top-level array|"plugins" array/
+    );
+  });
+
+  it('rejects when no entries are valid, mentioning how many were skipped', async () => {
+    const fetchFn = makeFetchFn([{ name: 'No URL' }, 42]);
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(
+      /no valid plugin entries[\s\S]*2/
+    );
+  });
+
+  it('rejects an empty manifest array as having no valid entries', async () => {
+    const fetchFn = makeFetchFn([]);
+
+    await expect(fetchWamLibrary(MANIFEST_URL, { fetchFn })).rejects.toThrow(
+      /no valid plugin entries/
+    );
+  });
+});
+
+describe('fetchWamLibrary — default fetch', () => {
+  it('uses global fetch when no fetchFn is provided', async () => {
+    const stub = vi.fn(async () =>
+      makeResponse([{ name: 'Reverb', url: 'https://plugins.example.com/reverb/index.js' }])
+    );
+    vi.stubGlobal('fetch', stub);
+
+    const { entries } = await fetchWamLibrary(MANIFEST_URL);
+
+    expect(stub).toHaveBeenCalledWith(MANIFEST_URL);
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe('fetchWamLibrary — real-world manifests', () => {
+  it('parses the webaudiomodules.com community registry (burns-audio pack)', async () => {
+    const fetchFn = makeFetchFn(COMMUNITY_PLUGINS_JSON);
+
+    const { entries, warnings } = await fetchWamLibrary(COMMUNITY_MANIFEST_URL, {
+      fetchFn,
+      baseUrl: 'https://www.webaudiomodules.com/community/plugins/',
+    });
+
+    expect(warnings).toEqual([]);
+    expect(entries).toHaveLength(4);
+    expect(entries[1]).toEqual({
+      name: 'Simple Distortion',
+      url: 'https://www.webaudiomodules.com/community/plugins/burns-audio/distortion/index.js',
+      description: 'Simple waveshaper-based distortion with variable curve and gain',
+      vendor: 'Sequencer Party',
+      thumbnail:
+        'https://www.webaudiomodules.com/community/plugins/burns-audio/distortion/screenshot.png',
+      keywords: ['effect', 'distortion'],
+    });
+  });
+
+  it('parses the wam-studio pedalboard2 library (wam-examples + burns-audio plugins)', async () => {
+    const fetchFn = makeFetchFn(WAMSTUDIO_LIBRARY_JSON);
+
+    const { entries, warnings } = await fetchWamLibrary(
+      'https://wam-bank.example.com/wamstudio_library.json',
+      { fetchFn }
+    );
+
+    expect(warnings).toEqual([]);
+    expect(entries).toHaveLength(24);
+    // Bare URL strings get names derived from the URL path.
+    expect(entries[21]).toEqual({
+      name: 'synth101',
+      url: 'https://www.webaudiomodules.com/community/plugins/burns-audio/synth101/index.js',
+    });
+    // Generic segments like dist/src/plugin are skipped when deriving names.
+    expect(entries[13].name).toBe('quadrafuzz');
+    expect(entries[14].name).toBe('WamSampler');
+    expect(entries[10].name).toBe('faustPingPongDelay');
+  });
+});

--- a/packages/dawcore-wam/__tests__/library.test.ts
+++ b/packages/dawcore-wam/__tests__/library.test.ts
@@ -516,5 +516,10 @@ describe('fetchWamLibrary — real-world manifests', () => {
     expect(entries[13].name).toBe('quadrafuzz');
     expect(entries[14].name).toBe('WamSampler');
     expect(entries[10].name).toBe('faustPingPongDelay');
+    // index-prefixed filenames (indexGUIStandard.js) are generic too — the
+    // name must come from the plugin's directory, and must not collide
+    // across different plugins sharing the same entry filename.
+    expect(entries[0].name).toBe('clarinetMIDI');
+    expect(entries[1].name).toBe('JUNO6v2');
   });
 });

--- a/packages/dawcore-wam/src/index.ts
+++ b/packages/dawcore-wam/src/index.ts
@@ -9,3 +9,11 @@ export type {
   WamPluginInstance,
   CreateWamInstanceOptions,
 } from './loader';
+export { fetchWamLibrary } from './library';
+export type {
+  WamLibraryEntry,
+  WamLibraryResult,
+  WamManifestFetch,
+  WamManifestResponse,
+  FetchWamLibraryOptions,
+} from './library';

--- a/packages/dawcore-wam/src/library.ts
+++ b/packages/dawcore-wam/src/library.ts
@@ -1,0 +1,277 @@
+const PREFIX = '[waveform-playlist] ';
+
+/** Minimal structural view of a fetch Response — keeps tests free of the full Response type. */
+export interface WamManifestResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+}
+
+/** Injectable for tests — production uses global fetch. */
+export type WamManifestFetch = (url: string) => Promise<WamManifestResponse>;
+
+/** A plugin listed in a `library.json` manifest. `url` feeds straight into plugin loading. */
+export interface WamLibraryEntry {
+  name: string;
+  /** Absolute URL of the plugin's ES module (resolved against the manifest URL). */
+  url: string;
+  description?: string;
+  vendor?: string;
+  /** Absolute URL of a screenshot/thumbnail (resolved against the manifest URL). */
+  thumbnail?: string;
+  keywords?: string[];
+}
+
+export interface WamLibraryResult {
+  entries: WamLibraryEntry[];
+  /** Per-entry messages for manifest entries that were skipped as invalid. */
+  warnings: string[];
+}
+
+export interface FetchWamLibraryOptions {
+  fetchFn?: WamManifestFetch;
+  /**
+   * Base for resolving relative plugin/thumbnail URLs. Defaults to the
+   * manifest URL itself. Registries like webaudiomodules.com keep entry
+   * paths relative to a directory next to the manifest — pass it here.
+   */
+  baseUrl?: string;
+}
+
+const defaultFetch: WamManifestFetch = (url) => fetch(url);
+
+/** Path segments that name a build artifact directory, not the plugin itself. */
+const GENERIC_URL_SEGMENTS = new Set([
+  'index',
+  'main',
+  'dist',
+  'build',
+  'src',
+  'plugin',
+  'plugins',
+  'published',
+  'static',
+  'public',
+]);
+
+/**
+ * Fetch and parse a WAM `library.json` plugin manifest.
+ *
+ * Supported shapes (the common denominator of the public WAM collections —
+ * see the package README for the schema):
+ * - a top-level array of entries (webaudiomodules.com community registry), or
+ * - an object with a `plugins` array (pedalboard2/wam-studio libraries).
+ *
+ * Entries are objects (`name` + `url`/`path` required) or bare URL strings
+ * (name derived from the URL). Invalid entries are skipped with a warning in
+ * `warnings` instead of failing the manifest; unreachable manifests, invalid
+ * JSON, unrecognized shapes, and zero valid entries reject with clear errors.
+ */
+export async function fetchWamLibrary(
+  manifestUrl: string,
+  options: FetchWamLibraryOptions = {}
+): Promise<WamLibraryResult> {
+  const fetchFn = options.fetchFn ?? defaultFetch;
+  const baseUrl = options.baseUrl ?? manifestUrl;
+
+  const response = await fetchManifest(fetchFn, manifestUrl);
+  const manifest = await parseManifestJson(response, manifestUrl);
+  const rawEntries = extractRawEntries(manifest, manifestUrl);
+
+  const entries: WamLibraryEntry[] = [];
+  const warnings: string[] = [];
+  rawEntries.forEach((raw, index) => {
+    const result = parseEntry(raw, index, baseUrl);
+    if ('entry' in result) {
+      entries.push(result.entry);
+    } else {
+      warnings.push(result.warning);
+    }
+  });
+
+  if (entries.length === 0) {
+    throw new Error(
+      PREFIX +
+        'fetchWamLibrary: manifest at "' +
+        manifestUrl +
+        '" contains no valid plugin entries (' +
+        String(warnings.length) +
+        ' skipped).' +
+        (warnings.length > 0 ? ' First problem: ' + warnings[0] : '')
+    );
+  }
+
+  return { entries, warnings };
+}
+
+async function fetchManifest(
+  fetchFn: WamManifestFetch,
+  manifestUrl: string
+): Promise<WamManifestResponse> {
+  let response: WamManifestResponse;
+  try {
+    response = await fetchFn(manifestUrl);
+  } catch (err) {
+    throw new Error(
+      PREFIX +
+        'fetchWamLibrary: could not fetch manifest at "' +
+        manifestUrl +
+        '": ' +
+        errorMessage(err)
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      PREFIX +
+        'fetchWamLibrary: manifest request for "' +
+        manifestUrl +
+        '" failed with HTTP ' +
+        String(response.status) +
+        ' ' +
+        response.statusText
+    );
+  }
+  return response;
+}
+
+async function parseManifestJson(
+  response: WamManifestResponse,
+  manifestUrl: string
+): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (err) {
+    throw new Error(
+      PREFIX +
+        'fetchWamLibrary: manifest at "' +
+        manifestUrl +
+        '" is not valid JSON: ' +
+        errorMessage(err)
+    );
+  }
+}
+
+function extractRawEntries(manifest: unknown, manifestUrl: string): unknown[] {
+  if (Array.isArray(manifest)) {
+    return manifest;
+  }
+  if (manifest !== null && typeof manifest === 'object') {
+    const plugins = (manifest as { plugins?: unknown }).plugins;
+    if (Array.isArray(plugins)) {
+      return plugins;
+    }
+  }
+  throw new Error(
+    PREFIX +
+      'fetchWamLibrary: manifest at "' +
+      manifestUrl +
+      '" has an unrecognized shape. Expected a top-level array of entries or an object with a "plugins" array.'
+  );
+}
+
+type EntryParseResult = { entry: WamLibraryEntry } | { warning: string };
+
+function parseEntry(raw: unknown, index: number, baseUrl: string): EntryParseResult {
+  if (typeof raw === 'string') {
+    return parseStringEntry(raw, index, baseUrl);
+  }
+  if (raw !== null && typeof raw === 'object') {
+    return parseObjectEntry(raw as Record<string, unknown>, index, baseUrl);
+  }
+  return skip(index, 'is neither a URL string nor an object');
+}
+
+function parseStringEntry(raw: string, index: number, baseUrl: string): EntryParseResult {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return skip(index, 'is an empty URL string');
+  }
+  const url = resolveUrl(trimmed, baseUrl);
+  if (url === undefined) {
+    return skip(index, 'has an unresolvable plugin URL "' + trimmed + '"');
+  }
+  return { entry: { name: deriveNameFromUrl(url), url } };
+}
+
+function parseObjectEntry(
+  raw: Record<string, unknown>,
+  index: number,
+  baseUrl: string
+): EntryParseResult {
+  const name = typeof raw.name === 'string' ? raw.name.trim() : '';
+  if (name === '') {
+    return skip(index, 'is missing a "name"');
+  }
+
+  const rawUrl =
+    typeof raw.url === 'string' && raw.url.trim() !== ''
+      ? raw.url.trim()
+      : typeof raw.path === 'string' && raw.path.trim() !== ''
+        ? raw.path.trim()
+        : undefined;
+  if (rawUrl === undefined) {
+    return skip(index, '("' + name + '") is missing a plugin URL ("url" or "path")');
+  }
+
+  const url = resolveUrl(rawUrl, baseUrl);
+  if (url === undefined) {
+    return skip(index, '("' + name + '") has an unresolvable plugin URL "' + rawUrl + '"');
+  }
+
+  const entry: WamLibraryEntry = { name, url };
+  if (typeof raw.description === 'string') {
+    entry.description = raw.description;
+  }
+  if (typeof raw.vendor === 'string') {
+    entry.vendor = raw.vendor;
+  }
+  if (typeof raw.thumbnail === 'string') {
+    const thumbnail = resolveUrl(raw.thumbnail, baseUrl);
+    if (thumbnail !== undefined) {
+      entry.thumbnail = thumbnail;
+    }
+  }
+  if (Array.isArray(raw.keywords)) {
+    entry.keywords = raw.keywords.filter((k): k is string => typeof k === 'string');
+  }
+  return { entry };
+}
+
+function skip(index: number, reason: string): { warning: string } {
+  return {
+    warning: PREFIX + 'fetchWamLibrary: skipping entry ' + String(index) + ': ' + reason,
+  };
+}
+
+function resolveUrl(raw: string, baseUrl: string): string | undefined {
+  try {
+    const resolved = new URL(raw, baseUrl);
+    // new URL('https://') parses on some runtimes with an empty host — treat as invalid.
+    if (resolved.host === '') {
+      return undefined;
+    }
+    return resolved.href;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Derive a display name for a bare-URL entry: the last URL path segment that
+ * is not a generic file or build-directory name (index.js, dist, src, ...).
+ */
+function deriveNameFromUrl(url: string): string {
+  const segments = new URL(url).pathname.split('/').filter((s) => s !== '');
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const base = decodeURIComponent(segments[i]).replace(/\.[a-z0-9]+$/i, '');
+    if (base !== '' && !GENERIC_URL_SEGMENTS.has(base.toLowerCase())) {
+      return base;
+    }
+  }
+  return new URL(url).hostname;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/dawcore-wam/src/library.ts
+++ b/packages/dawcore-wam/src/library.ts
@@ -265,7 +265,11 @@ function deriveNameFromUrl(url: string): string {
   const segments = new URL(url).pathname.split('/').filter((s) => s !== '');
   for (let i = segments.length - 1; i >= 0; i--) {
     const base = decodeURIComponent(segments[i]).replace(/\.[a-z0-9]+$/i, '');
-    if (base !== '' && !GENERIC_URL_SEGMENTS.has(base.toLowerCase())) {
+    // index-prefixed entry filenames (index.js, indexGUIStandard.js, …) are
+    // build artifacts, not plugin names — fall through to the directory.
+    const isGeneric =
+      GENERIC_URL_SEGMENTS.has(base.toLowerCase()) || base.toLowerCase().startsWith('index');
+    if (base !== '' && !isGeneric) {
       return base;
     }
   }


### PR DESCRIPTION
## Summary

Implements plugin discovery for `@dawcore/wam` (Closes #427, part of the WAM 2.0 epic #413):

- `fetchWamLibrary(manifestUrl, { fetchFn?, baseUrl? })` in `packages/dawcore-wam/src/library.ts` — fetches and schema-validates WAM `library.json` manifests, returning `{ entries, warnings }`.
- `WamLibraryEntry` (`{ name, url, description?, vendor?, thumbnail?, keywords? }`) — an entry's `url` feeds straight into `createWamInstance(url, ...)`; descriptor validation stays at load time (manifests can lie).
- README documents the supported manifest schema and the URL-paste flow; package CLAUDE.md gets a Library Discovery section.

## Design notes

- **Common-denominator schema, surveyed from the real collections.** Two live shapes were surveyed: the [webaudiomodules.com community registry](https://www.webaudiomodules.com/community/plugins.json) (burns-audio pack — top-level array, plugin URL in `path`, relative `thumbnail`, extra fields like `identifier`/`category`) and the pedalboard2/wam-studio library format that lists wam-examples + burns-audio plugins (top-level object with a `plugins` array of bare URL strings, plus `id`/`version`/`presets`/`includes`). Both shapes are supported; unknown fields are tolerated.
- **Bare-URL-string entries get derived names.** The pedalboard2 shape has no per-entry names, so the name is derived from the URL path, skipping generic segments (`index.js`, `dist`, `src`, `plugin`, ...) — `…/quadrafuzz/dist/index.js` → `quadrafuzz`.
- **`baseUrl` option for registry-relative paths.** Relative URLs resolve against the manifest URL by default, but the community registry keeps `path` relative to `community/plugins/`, not the manifest — verified against the live server (manifest-relative resolution 404s, `plugins/`-relative returns 200). `baseUrl` makes the flagship public registry actually loadable.
- **Validation at the boundary, per repo rule.** Per-entry failures (missing name, missing/unresolvable URL, non-object/non-string entries) are skipped with `[waveform-playlist]`-prefixed messages collected into `warnings` — one bad entry never fails the manifest. Unreachable manifest, HTTP error status, invalid JSON, unrecognized shape, and zero valid entries reject with clear prefixed errors (string concatenation, no object logging).
- **Injectable `fetchFn` with a structural response type** (`WamManifestResponse`) mirrors the loader's `importFn` pattern — tests never stub a full `Response`. No manifest caching (explicit non-goal in #427).
- Test-only conventions kept: fixtures are constants in the test file with source URLs noted in comments; nothing test-only leaks into `src/index.ts`.

## Test plan

- [x] STRICT TDD: wrote `__tests__/library.test.ts` first, confirmed RED (module missing), then implemented to GREEN.
- [x] `cd packages/dawcore-wam && npx vitest run` — 44 tests pass (24 new library tests + 20 existing host/loader tests).
- [x] Two real-world public manifests parse as fixtures: webaudiomodules.com community `plugins.json` (first four entries verbatim, source URL in comment) and wam-studio's `wamstudio_library.t.json` (faithful copy, 24 plugins, source URL in comment).
- [x] Relative plugin + thumbnail URL resolution against manifest URL; `baseUrl` override; absolute URLs untouched.
- [x] Invalid entries skipped with per-entry warnings (missing name, missing URL, unresolvable URL, non-object/non-string); valid entries survive.
- [x] Malformed optional fields dropped without skipping the entry; non-string keywords filtered.
- [x] Error paths: unreachable manifest, HTTP 404, invalid JSON, unrecognized shape, zero valid entries (message includes skip count).
- [x] Default global-fetch path covered via `vi.stubGlobal`.
- [x] `pnpm typecheck` (package) passes.
- [x] `pnpm build` (package) passes (tsup CJS+ESM+DTS).
- [x] Root `pnpm -w format` + `pnpm -w lint` — 0 errors.

Closes #427. Part of epic #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
