### PR TITLE
feat(wam): wam-transport event bridge from the native transport (#425)

### DIFF
--- a/packages/dawcore-wam/CLAUDE.md
+++ b/packages/dawcore-wam/CLAUDE.md
@@ -32,6 +32,10 @@
 - Invalid entries skip with `[waveform-playlist]`-prefixed messages collected into `warnings` (never fail the manifest); unreachable/invalid-JSON/unrecognized-shape/zero-valid-entries reject. Entry `url` feeds straight into `createWamInstance` — descriptor validation stays at load time.
 - Real-world fixture manifests live as constants in `__tests__/library.test.ts` with source URLs in comments.
 
+## Transport Bridge (`src/transport-bridge.ts`, #425)
+
+`createWamTransportBridge(transport, getPluginNodes)` — broadcasts `wam-transport` events ({playing, tempo, timeSig, currentBar, currentBarStarted}) to all live plugin nodes on play/pause/stop/seek/tempochange/meterchange. **Variable-tempo boundary crossings emit no transport event** — a rAF watcher (active only while playing) compares tempo/meter at the playhead each frame and rebroadcasts on change. `currentBarStarted` is AudioContext time: `ctx.currentTime - (transportSeconds - barStartSeconds)`. Structural `TransportQueryLike` keeps the transport package plugin-free; `WamTransportNode.scheduleEvents` is optional (the loader's structural node type can't require it) and guarded. dawcore's `EffectsManager` creates the bridge lazily on first `addWamPlugin`, feeds it the live-node Set (entries' dispose closures self-remove), and skips it silently when the adapter transport lacks the query surface.
+
 ## Reference Implementation
 
 wam-studio (local checkout at `~/Code/wam-studio`) — `public/src/Models/Plugin.ts` shows the full plugin lifecycle: `createInstance(hostGroupId, ctx)`, GUI/audio lifecycle split (`createGui`/`destroyGui` independent of `audioNode.destroy()`), and `cloneInto(offlineCtx, groupId)` for offline rendering via getState/setState transfer.

--- a/packages/dawcore-wam/__tests__/transport-bridge.test.ts
+++ b/packages/dawcore-wam/__tests__/transport-bridge.test.ts
@@ -156,6 +156,22 @@ describe('createWamTransportBridge', () => {
     expect(node.scheduleEvents).toHaveBeenCalledTimes(2);
   });
 
+  it('a bridge created while ALREADY playing starts watching immediately', () => {
+    const transport = makeMockTransport();
+    transport._playing = true; // play fired before the bridge existed
+    const node = makeMockNode();
+    createWamTransportBridge(transport, () => [node]);
+
+    // Creation broadcasts the current state (plugins sync without a new play)...
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(1);
+
+    // ...and the boundary watcher is live.
+    transport._tempo = 75;
+    pumpFrame();
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(2);
+    expect(lastEvent(node).data.tempo).toBe(75);
+  });
+
   it('stops the watcher on stop and unsubscribes everything on dispose', () => {
     const transport = makeMockTransport();
     const node = makeMockNode();

--- a/packages/dawcore-wam/__tests__/transport-bridge.test.ts
+++ b/packages/dawcore-wam/__tests__/transport-bridge.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createWamTransportBridge } from '../src/transport-bridge';
+
+type Listener = (...args: unknown[]) => void;
+
+function makeMockTransport() {
+  const listeners = new Map<string, Set<Listener>>();
+  const transport = {
+    audioContext: { currentTime: 100 },
+    _playing: false,
+    _tempo: 120,
+    _meter: { numerator: 4, denominator: 4 },
+    _seconds: 10,
+    isPlaying: vi.fn(function (this: void) {
+      return transport._playing;
+    }),
+    getCurrentTime: vi.fn(() => transport._seconds),
+    getTempo: vi.fn(() => transport._tempo),
+    getMeter: vi.fn(() => transport._meter),
+    secondsToTicks: vi.fn((s: number) => Math.round(s * 960 * 2)), // 120bpm: 2 beats/s
+    ticksToSeconds: vi.fn((t: number) => t / (960 * 2)),
+    tickToBar: vi.fn(() => 6), // pretend we're in bar 6
+    barToTick: vi.fn(() => 8 * 960 * 2), // bar 6 began at 8s worth of ticks
+    on: vi.fn((event: string, cb: Listener) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(cb);
+    }),
+    off: vi.fn((event: string, cb: Listener) => {
+      listeners.get(event)?.delete(cb);
+    }),
+    emit(event: string) {
+      for (const cb of listeners.get(event) ?? []) cb();
+    },
+  };
+  return transport;
+}
+
+function makeMockNode() {
+  return { scheduleEvents: vi.fn() };
+}
+
+let rafCallbacks: Array<(t: number) => void>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: (t: number) => void) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function pumpFrame() {
+  const snapshot = [...rafCallbacks];
+  rafCallbacks = [];
+  for (const cb of snapshot) cb(performance.now());
+}
+
+function lastEvent(node: ReturnType<typeof makeMockNode>) {
+  const calls = node.scheduleEvents.mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+describe('createWamTransportBridge', () => {
+  it('broadcasts a correctly shaped wam-transport event on play', () => {
+    const transport = makeMockTransport();
+    const node = makeMockNode();
+    createWamTransportBridge(transport, () => [node]);
+
+    transport._playing = true;
+    transport.emit('play');
+
+    const event = lastEvent(node);
+    expect(event.type).toBe('wam-transport');
+    expect(event.data).toEqual({
+      playing: true,
+      tempo: 120,
+      timeSigNumerator: 4,
+      timeSigDenominator: 4,
+      currentBar: 6,
+      // bar began 2s ago in transport time (10s - 8s) → audio time 100 - 2 = 98
+      currentBarStarted: 98,
+    });
+  });
+
+  it('broadcasts playing:false on stop and pause', () => {
+    const transport = makeMockTransport();
+    const node = makeMockNode();
+    createWamTransportBridge(transport, () => [node]);
+
+    transport._playing = false;
+    transport.emit('stop');
+    expect(lastEvent(node).data.playing).toBe(false);
+
+    transport.emit('pause');
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebroadcasts on tempochange, meterchange, and seek', () => {
+    const transport = makeMockTransport();
+    const node = makeMockNode();
+    createWamTransportBridge(transport, () => [node]);
+
+    transport._tempo = 140;
+    transport.emit('tempochange');
+    expect(lastEvent(node).data.tempo).toBe(140);
+
+    transport._meter = { numerator: 3, denominator: 4 };
+    transport.emit('meterchange');
+    expect(lastEvent(node).data.timeSigNumerator).toBe(3);
+
+    transport.emit('seek');
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(3);
+  });
+
+  it('notifyNodeAdded sends a fresh event to just that node', () => {
+    const transport = makeMockTransport();
+    const existing = makeMockNode();
+    const bridge = createWamTransportBridge(transport, () => [existing]);
+
+    const added = makeMockNode();
+    bridge.notifyNodeAdded(added);
+
+    expect(added.scheduleEvents).toHaveBeenCalledTimes(1);
+    expect(existing.scheduleEvents).not.toHaveBeenCalled();
+    expect(lastEvent(added).type).toBe('wam-transport');
+  });
+
+  it('detects a tempo-map boundary crossing during playback and rebroadcasts', () => {
+    const transport = makeMockTransport();
+    const node = makeMockNode();
+    createWamTransportBridge(transport, () => [node]);
+
+    transport._playing = true;
+    transport.emit('play');
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(1);
+
+    // Playback crosses into a 90bpm segment — no transport event fires,
+    // only the playing watcher can notice.
+    transport._tempo = 90;
+    pumpFrame();
+
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(2);
+    expect(lastEvent(node).data.tempo).toBe(90);
+
+    // No further change → no further broadcast.
+    pumpFrame();
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops the watcher on stop and unsubscribes everything on dispose', () => {
+    const transport = makeMockTransport();
+    const node = makeMockNode();
+    const bridge = createWamTransportBridge(transport, () => [node]);
+
+    transport._playing = true;
+    transport.emit('play');
+    transport._playing = false;
+    transport.emit('stop');
+    const countAfterStop = node.scheduleEvents.mock.calls.length;
+
+    transport._tempo = 80;
+    pumpFrame();
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(countAfterStop);
+
+    bridge.dispose();
+    transport.emit('play');
+    transport.emit('tempochange');
+    expect(node.scheduleEvents).toHaveBeenCalledTimes(countAfterStop);
+    expect(transport.off).toHaveBeenCalled();
+  });
+});

--- a/packages/dawcore-wam/src/index.ts
+++ b/packages/dawcore-wam/src/index.ts
@@ -17,3 +17,10 @@ export type {
   WamManifestResponse,
   FetchWamLibraryOptions,
 } from './library';
+export { createWamTransportBridge } from './transport-bridge';
+export type {
+  WamTransportData,
+  WamTransportNode,
+  WamTransportBridge,
+  TransportQueryLike,
+} from './transport-bridge';

--- a/packages/dawcore-wam/src/loader.ts
+++ b/packages/dawcore-wam/src/loader.ts
@@ -24,6 +24,7 @@ export interface WamPluginAudioNode extends AudioNode {
   setParameterValues?(
     values: Record<string, { id: string; value: number; normalized: boolean }>
   ): Promise<void>;
+  scheduleEvents?(...events: Array<{ type: string; time: number; data?: unknown }>): void;
 }
 
 interface WamModuleLike {

--- a/packages/dawcore-wam/src/transport-bridge.ts
+++ b/packages/dawcore-wam/src/transport-bridge.ts
@@ -152,6 +152,12 @@ export function createWamTransportBridge(
   transport.on('tempochange', onChange);
   transport.on('meterchange', onChange);
 
+  // The bridge is created lazily (first plugin added) — if playback already
+  // started, the play event that would have armed the watcher has passed.
+  if (transport.isPlaying()) {
+    onPlay();
+  }
+
   return {
     notifyNodeAdded(node: WamTransportNode): void {
       if (disposed) return;

--- a/packages/dawcore-wam/src/transport-bridge.ts
+++ b/packages/dawcore-wam/src/transport-bridge.ts
@@ -1,0 +1,176 @@
+const PREFIX = '[waveform-playlist] ';
+
+/** Payload of a `wam-transport` event, per the WAM 2.0 host conventions. */
+export interface WamTransportData {
+  playing: boolean;
+  tempo: number;
+  timeSigNumerator: number;
+  timeSigDenominator: number;
+  currentBar: number;
+  /** AudioContext time at which the current bar began. */
+  currentBarStarted: number;
+}
+
+/**
+ * Structural view of @dawcore/transport's Transport — only the read-only
+ * query/event surface the bridge needs. The transport package stays
+ * plugin-free; this bridge reads from it.
+ */
+export interface TransportQueryLike {
+  readonly audioContext: { readonly currentTime: number };
+  isPlaying(): boolean;
+  getCurrentTime(): number;
+  getTempo(atTick?: number): number;
+  getMeter(atTick?: number): { numerator: number; denominator: number };
+  secondsToTicks(seconds: number): number;
+  ticksToSeconds(tick: number): number;
+  tickToBar(tick: number): number;
+  barToTick(bar: number): number;
+  on(event: string, cb: () => void): void;
+  off(event: string, cb: () => void): void;
+}
+
+/** The slice of a WamNode the bridge schedules events on. Optional because
+ *  the loader's structural WamPluginAudioNode can't require it. */
+export interface WamTransportNode {
+  scheduleEvents?(...events: Array<{ type: string; time: number; data: WamTransportData }>): void;
+}
+
+export interface WamTransportBridge {
+  /** Push the current transport state to one node (e.g. a plugin added mid-playback). */
+  notifyNodeAdded(node: WamTransportNode): void;
+  /** Push the current transport state to all nodes. */
+  broadcastNow(): void;
+  dispose(): void;
+}
+
+/**
+ * Broadcasts `wam-transport` events to all live plugin nodes so tempo-synced
+ * effects (delays, LFOs, arpeggiators) lock to the timeline.
+ *
+ * Rebroadcast triggers: play, pause, stop, seek, tempochange, meterchange —
+ * plus a rAF watcher active only while playing, which catches tempo/meter
+ * map boundary crossings that emit no transport event (variable-tempo
+ * sessions).
+ */
+export function createWamTransportBridge(
+  transport: TransportQueryLike,
+  getPluginNodes: () => WamTransportNode[]
+): WamTransportBridge {
+  let disposed = false;
+  let rafId: number | null = null;
+  let lastTempo: number | null = null;
+  let lastNumerator: number | null = null;
+  let lastDenominator: number | null = null;
+
+  const computeData = (): WamTransportData => {
+    const seconds = transport.getCurrentTime();
+    const tick = transport.secondsToTicks(seconds);
+    const tempo = transport.getTempo(tick);
+    const meter = transport.getMeter(tick);
+    const currentBar = transport.tickToBar(tick);
+    const barStartSeconds = transport.ticksToSeconds(transport.barToTick(currentBar));
+    return {
+      playing: transport.isPlaying(),
+      tempo,
+      timeSigNumerator: meter.numerator,
+      timeSigDenominator: meter.denominator,
+      currentBar,
+      currentBarStarted: transport.audioContext.currentTime - (seconds - barStartSeconds),
+    };
+  };
+
+  const send = (node: WamTransportNode, data: WamTransportData): void => {
+    try {
+      node.scheduleEvents?.({
+        type: 'wam-transport',
+        time: transport.audioContext.currentTime,
+        data,
+      });
+    } catch (err) {
+      console.warn(PREFIX + 'wam-transport broadcast failed for a plugin node: ' + String(err));
+    }
+  };
+
+  const broadcast = (): void => {
+    const data = computeData();
+    lastTempo = data.tempo;
+    lastNumerator = data.timeSigNumerator;
+    lastDenominator = data.timeSigDenominator;
+    for (const node of getPluginNodes()) {
+      send(node, data);
+    }
+  };
+
+  // Watcher: catches tempo/meter map boundary crossings during playback,
+  // which fire no transport event. Active only while playing.
+  const watch = (): void => {
+    rafId = null;
+    if (disposed || !transport.isPlaying()) return;
+    const tick = transport.secondsToTicks(transport.getCurrentTime());
+    const tempo = transport.getTempo(tick);
+    const meter = transport.getMeter(tick);
+    if (
+      tempo !== lastTempo ||
+      meter.numerator !== lastNumerator ||
+      meter.denominator !== lastDenominator
+    ) {
+      broadcast();
+    }
+    rafId = requestAnimationFrame(watch);
+  };
+
+  const startWatcher = (): void => {
+    if (rafId === null) {
+      rafId = requestAnimationFrame(watch);
+    }
+  };
+
+  const stopWatcher = (): void => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+
+  const onPlay = (): void => {
+    broadcast();
+    startWatcher();
+  };
+  const onHalt = (): void => {
+    stopWatcher();
+    broadcast();
+  };
+  const onChange = (): void => {
+    broadcast();
+  };
+
+  transport.on('play', onPlay);
+  transport.on('pause', onHalt);
+  transport.on('stop', onHalt);
+  transport.on('seek', onChange);
+  transport.on('tempochange', onChange);
+  transport.on('meterchange', onChange);
+
+  return {
+    notifyNodeAdded(node: WamTransportNode): void {
+      if (disposed) return;
+      send(node, computeData());
+    },
+    broadcastNow(): void {
+      if (disposed) return;
+      broadcast();
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      stopWatcher();
+      transport.off('play', onPlay);
+      transport.off('pause', onHalt);
+      transport.off('stop', onHalt);
+      transport.off('seek', onChange);
+      transport.off('tempochange', onChange);
+      transport.off('meterchange', onChange);
+    },
+  };
+}

--- a/packages/dawcore/src/__tests__/daw-editor-effects-state.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-effects-state.test.ts
@@ -2,12 +2,17 @@ import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vite
 import type { DawEditorElement } from '../elements/daw-editor';
 import type { DawTrackElement } from '../elements/daw-track';
 
-const { ensureWamHost, createWamInstance } = vi.hoisted(() => ({
+const { ensureWamHost, createWamInstance, createWamTransportBridge } = vi.hoisted(() => ({
   ensureWamHost: vi.fn(),
   createWamInstance: vi.fn(),
+  createWamTransportBridge: vi.fn(() => ({
+    notifyNodeAdded: vi.fn(),
+    broadcastNow: vi.fn(),
+    dispose: vi.fn(),
+  })),
 }));
 
-vi.mock('@dawcore/wam', () => ({ ensureWamHost, createWamInstance }));
+vi.mock('@dawcore/wam', () => ({ ensureWamHost, createWamInstance, createWamTransportBridge }));
 
 beforeAll(async () => {
   await import('../elements/daw-editor');

--- a/packages/dawcore/src/__tests__/daw-editor-wam-bridge.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-wam-bridge.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
+import type { DawEditorElement } from '../elements/daw-editor';
+
+const { ensureWamHost, createWamInstance, createWamTransportBridge, bridge } = vi.hoisted(() => {
+  const bridge = { notifyNodeAdded: vi.fn(), broadcastNow: vi.fn(), dispose: vi.fn() };
+  return {
+    bridge,
+    ensureWamHost: vi.fn(),
+    createWamInstance: vi.fn(),
+    createWamTransportBridge: vi.fn(() => bridge),
+  };
+});
+
+vi.mock('@dawcore/wam', () => ({ ensureWamHost, createWamInstance, createWamTransportBridge }));
+
+beforeAll(async () => {
+  await import('../elements/daw-editor');
+  await import('../elements/daw-track');
+  await import('../elements/daw-clip');
+});
+
+const PLUGIN_URL = 'https://plugins.example.com/reverb/index.js';
+
+function mockGainNode() {
+  return { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+}
+
+function makeMockPlugin() {
+  return {
+    url: PLUGIN_URL,
+    descriptor: {
+      name: 'Mock Reverb',
+      apiVersion: '2.0.0',
+      hasAudioInput: true,
+      hasAudioOutput: true,
+    },
+    audioNode: {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      scheduleEvents: vi.fn(),
+      setParameterValues: vi.fn().mockResolvedValue(undefined),
+    },
+    getState: vi.fn().mockResolvedValue({}),
+    setState: vi.fn().mockResolvedValue(undefined),
+    getParameterInfo: vi.fn().mockResolvedValue({}),
+    destroy: vi.fn(),
+  };
+}
+
+function makeMockAdapter() {
+  const ctx = {
+    sampleRate: 48000,
+    state: 'running' as AudioContextState,
+    currentTime: 0,
+    destination: { connect: vi.fn(), disconnect: vi.fn() },
+    createGain: vi.fn(() => mockGainNode()),
+    resume: vi.fn().mockResolvedValue(undefined),
+    decodeAudioData: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const transport = {
+    connectTrackOutput: vi.fn(),
+    disconnectTrackOutput: vi.fn(),
+    connectMasterOutput: vi.fn(),
+    disconnectMasterOutput: vi.fn(),
+    masterOutputNode: mockGainNode(),
+    // Query/event surface the wam-transport bridge needs:
+    audioContext: ctx,
+    isPlaying: vi.fn().mockReturnValue(false),
+    getCurrentTime: vi.fn().mockReturnValue(0),
+    getTempo: vi.fn().mockReturnValue(120),
+    getMeter: vi.fn().mockReturnValue({ numerator: 4, denominator: 4 }),
+    secondsToTicks: vi.fn().mockReturnValue(0),
+    ticksToSeconds: vi.fn().mockReturnValue(0),
+    tickToBar: vi.fn().mockReturnValue(1),
+    barToTick: vi.fn().mockReturnValue(0),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return {
+    audioContext: ctx as unknown as AudioContext,
+    ppqn: 960,
+    transport,
+    setTracks: vi.fn(),
+    updateTrack: vi.fn(),
+    setTempo: vi.fn(),
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seek: vi.fn(),
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+    isPlaying: vi.fn().mockReturnValue(false),
+  };
+}
+
+let editor: DawEditorElement;
+let adapter: ReturnType<typeof makeMockAdapter>;
+let plugin: ReturnType<typeof makeMockPlugin>;
+
+beforeEach(() => {
+  vi.stubGlobal('devicePixelRatio', 1);
+  ensureWamHost.mockReset().mockResolvedValue({ hostGroupId: 'group-1', hostGroupKey: 'key-1' });
+  plugin = makeMockPlugin();
+  createWamInstance.mockReset().mockResolvedValue(plugin);
+  createWamTransportBridge.mockClear();
+  bridge.notifyNodeAdded.mockClear();
+  bridge.dispose.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor = document.createElement('daw-editor') as any;
+  adapter = makeMockAdapter();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any).adapter = adapter;
+  document.body.appendChild(editor);
+});
+
+afterEach(() => {
+  editor.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('wam-transport bridge wiring', () => {
+  it('creates the bridge on first WAM plugin and notifies the new node', async () => {
+    await editor.addWamPlugin(PLUGIN_URL);
+
+    expect(createWamTransportBridge).toHaveBeenCalledTimes(1);
+    expect(createWamTransportBridge).toHaveBeenCalledWith(adapter.transport, expect.any(Function));
+    expect(bridge.notifyNodeAdded).toHaveBeenCalledWith(plugin.audioNode);
+  });
+
+  it('reuses one bridge across plugins and exposes live nodes via the getter', async () => {
+    await editor.addWamPlugin(PLUGIN_URL);
+    const second = makeMockPlugin();
+    createWamInstance.mockResolvedValueOnce(second);
+    const id2 = await editor.addWamPlugin(PLUGIN_URL + '?2');
+
+    expect(createWamTransportBridge).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getNodes = (createWamTransportBridge.mock.calls as any)[0][1] as () => unknown[];
+    expect(getNodes()).toEqual([plugin.audioNode, second.audioNode]);
+
+    // Removing a plugin drops its node from the live set.
+    editor.removeEffect(id2);
+    expect(getNodes()).toEqual([plugin.audioNode]);
+  });
+
+  it('disposes the bridge when the editor disconnects', async () => {
+    await editor.addWamPlugin(PLUGIN_URL);
+    editor.remove();
+
+    expect(bridge.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the bridge gracefully when the adapter transport lacks the query surface', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter.transport as any).on = undefined;
+    await expect(editor.addWamPlugin(PLUGIN_URL)).resolves.toBeTruthy();
+    expect(createWamTransportBridge).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dawcore/src/__tests__/daw-editor-wam.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-wam.test.ts
@@ -2,12 +2,17 @@ import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vite
 import type { DawEditorElement } from '../elements/daw-editor';
 import type { DawTrackElement } from '../elements/daw-track';
 
-const { ensureWamHost, createWamInstance } = vi.hoisted(() => ({
+const { ensureWamHost, createWamInstance, createWamTransportBridge } = vi.hoisted(() => ({
   ensureWamHost: vi.fn(),
   createWamInstance: vi.fn(),
+  createWamTransportBridge: vi.fn(() => ({
+    notifyNodeAdded: vi.fn(),
+    broadcastNow: vi.fn(),
+    dispose: vi.fn(),
+  })),
 }));
 
-vi.mock('@dawcore/wam', () => ({ ensureWamHost, createWamInstance }));
+vi.mock('@dawcore/wam', () => ({ ensureWamHost, createWamInstance, createWamTransportBridge }));
 
 beforeAll(async () => {
   await import('../elements/daw-editor');

--- a/packages/dawcore/src/effects/effects-manager.ts
+++ b/packages/dawcore/src/effects/effects-manager.ts
@@ -31,6 +31,9 @@ export class EffectsManager {
   private _trackChains = new Map<string, EffectsChainController>();
   /** Per-chain restore ownership — a newer setEffectsState supersedes a stale in-flight one. */
   private _restoreTokens = new WeakMap<EffectsChainController, symbol>();
+  /** Live WAM plugin nodes across all chains, fed to the wam-transport bridge. */
+  private _wamNodes = new Set<import('@dawcore/wam').WamTransportNode>();
+  private _transportBridge: { notifyNodeAdded(node: unknown): void; dispose(): void } | null = null;
 
   constructor(getAdapter: () => AdapterLike | null, masterEventTarget: EventTarget) {
     this._getAdapter = getAdapter;
@@ -146,6 +149,9 @@ export class EffectsManager {
   }
 
   disposeAll(): void {
+    this._transportBridge?.dispose();
+    this._transportBridge = null;
+    this._wamNodes.clear();
     for (const trackId of [...this._trackChains.keys()]) {
       this.disposeTrackChain(trackId);
     }
@@ -288,7 +294,10 @@ export class EffectsManager {
               console.warn(PREFIX + 'WAM setParameterValues failed: ' + String(err));
             });
           },
-          dispose: () => plugin.destroy(),
+          dispose: () => {
+            this._wamNodes.delete(node);
+            plugin.destroy();
+          },
           getState: () => plugin.getState(),
         },
         params: {},
@@ -305,6 +314,8 @@ export class EffectsManager {
       }
       throw err;
     }
+    this._wamNodes.add(node);
+    this._ensureTransportBridge(wamModule)?.notifyNodeAdded(node);
     const index = chain.entries.findIndex((e) => e.id === effectId);
     this._dispatch(target, 'daw-effect-add', {
       effectId,
@@ -315,6 +326,34 @@ export class EffectsManager {
       index,
     });
     return effectId;
+  }
+
+  /**
+   * Lazily create the wam-transport bridge so tempo-synced plugins lock to
+   * the timeline. Skipped (not an error) when the adapter's transport lacks
+   * the query/event surface — the bridge is an enhancement, not a
+   * requirement for audio processing.
+   */
+  private _ensureTransportBridge(
+    wamModule: typeof import('@dawcore/wam')
+  ): { notifyNodeAdded(node: unknown): void; dispose(): void } | null {
+    if (this._transportBridge) return this._transportBridge;
+    if (typeof wamModule.createWamTransportBridge !== 'function') return null;
+    const transport = this._getAdapter()?.transport as
+      | (EffectsTransportLike & import('@dawcore/wam').TransportQueryLike)
+      | undefined;
+    if (
+      !transport ||
+      typeof transport.on !== 'function' ||
+      typeof transport.getTempo !== 'function' ||
+      typeof transport.tickToBar !== 'function'
+    ) {
+      return null;
+    }
+    this._transportBridge = wamModule.createWamTransportBridge(transport, () => [
+      ...this._wamNodes,
+    ]);
+    return this._transportBridge;
   }
 
   /**

--- a/packages/transport/CLAUDE.md
+++ b/packages/transport/CLAUDE.md
@@ -135,6 +135,8 @@ When any track is soloed, all non-soloed tracks are muted via `TrackNode.setMute
 
 `connectTrackOutput(trackId, node)` accepts any AudioNode chain (Tone.js effects, WAM plugins, native nodes). The transport has zero knowledge of Tone.js.
 
+`seek(time)` emits a `seek` event (`{ seconds }`) — added for the wam-transport bridge (#425); generic, no plugin types.
+
 `connectMasterOutput(node)` / `disconnectMasterOutput()` are the master-bus equivalents — the chain is inserted between the master gain and `audioContext.destination` via `MasterNode.connectEffects`. Master insertion uses a **targeted** `disconnect(destination)` (not blanket `disconnect()`) so parallel taps on `masterOutputNode` (analyzers, recorders) survive chain connect/disconnect. The caller routes the chain's output to `audioContext.destination`.
 
 ## NativePlayoutAdapter

--- a/packages/transport/src/__tests__/transport.test.ts
+++ b/packages/transport/src/__tests__/transport.test.ts
@@ -264,6 +264,18 @@ describe('Transport', () => {
     expect(onPlay).not.toHaveBeenCalled();
   });
 
+  it('seek emits a seek event with the target position', () => {
+    const ctx = mockAudioContext();
+    const transport = new Transport(ctx);
+    const onSeek = vi.fn();
+    transport.on('seek', onSeek);
+
+    transport.seek(3.5);
+
+    expect(onSeek).toHaveBeenCalledTimes(1);
+    expect(onSeek).toHaveBeenCalledWith({ seconds: 3.5 });
+  });
+
   it('dispose cleans up', () => {
     const ctx = mockAudioContext();
     const transport = new Transport(ctx);

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -28,6 +28,7 @@ export interface TransportEvents {
   pause: () => void;
   stop: () => void;
   loop: () => void;
+  seek: (event: { seconds: number }) => void;
   tempochange: (event: TempoChangeEventData) => void;
   meterchange: (event: MeterChangeEventData) => void;
   countIn: (event: CountInEventData) => void;
@@ -241,6 +242,7 @@ export class Transport {
       this._clipPlayer.onPositionJump(seekTick);
       this._timer.start();
     }
+    this._emit('seek', { seconds: time });
   }
 
   getCurrentTime(): number {


### PR DESCRIPTION
Closes #425. Part of the WAM 2.0 plugin support epic #413. Builds on chain integration (#437).

## Summary

Tempo-synced WAM plugins (delays, LFOs, arpeggiators) now lock to the timeline via `wam-transport` events.

- **`createWamTransportBridge(transport, getPluginNodes)`** in `@dawcore/wam` — broadcasts `{playing, tempo, timeSigNumerator, timeSigDenominator, currentBar, currentBarStarted}` to all live plugin nodes on **play / pause / stop / seek / tempochange / meterchange**. `currentBarStarted` is in AudioContext time, derived from the transport's bar math: `ctx.currentTime − (transportSeconds − barStartSeconds)`.
- **Variable-tempo correctness**: a TempoMap/MeterMap boundary crossing during playback emits *no* transport event — the bridge runs a rAF watcher (active only while playing, stopped on pause/stop/dispose) that compares tempo + meter at the playhead each frame and rebroadcasts on change. Pinned by test: a 2-entry tempo map crossing delivers the second tempo with no transport event involved.
- **Transport stays plugin-free** (epic architecture decision): the bridge consumes a structural `TransportQueryLike` — `Transport` already had every needed query (`getTempo`/`getMeter`/`tickToBar`/`barToTick`/conversions). The one transport change is generic: **`seek()` now emits a `seek` event** (`{seconds}`) — previously seeks were invisible to listeners.
- **dawcore wiring**: `EffectsManager` lazily creates one bridge on the first `addWamPlugin`, maintains the live WAM node set (entry dispose closures self-remove), **notifies newly added plugins immediately** so they sync without waiting for the next play/seek, and disposes the bridge with the manager. Adapters whose transport lacks the query surface skip the bridge silently — it's an enhancement, not a requirement.
- Broadcast failures on a single node warn and don't break the fan-out.

## Test plan

- [x] TDD throughout (all watched fail first):
  - `@dawcore/wam` (6): event shape incl. `currentBarStarted` math, stop/pause `playing:false`, tempochange/meterchange/seek rebroadcasts, `notifyNodeAdded` targets only the new node, **boundary-crossing watcher** fires once per change and goes quiet, watcher stops on stop + full unsubscribe on dispose
  - transport (1): `seek` emits `{seconds}`
  - dawcore (4): bridge created once with live-node getter (removal drops nodes), reused across plugins, disposed on editor disconnect, skipped gracefully without the query surface
- [x] Suites: dawcore 550/550, transport 256/256, dawcore-wam 50/50
- [x] Per-package typechecks + `pnpm -w lint` (0 errors)
- [x] Both package CLAUDE.mds updated
