### PR TITLE
docs: root README lists all current demos + rule to keep it that way

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ pnpm publish --filter @waveform-playlist/NEW-PACKAGE --no-git-checks --access pu
 
 **Moving/Renaming Doc Pages:** Run `pnpm --filter website build` after moving docs — Docusaurus broken link checker will find all internal links that need updating.
 
+**Root README.md lists every demo:** Whenever an example page or a new `examples/*` app is added, update the root README.md's examples section (run commands + per-page lists) in the same PR. The README is the front door — a demo that isn't listed there doesn't exist for most visitors.
+
 **Avoid Duplicating Code in Example Pages:** Example pages (`website/src/pages/examples/`) should link to guide docs for code walkthroughs, not inline full code blocks. Duplication creates maintenance burden when APIs change.
 
 **LLM-Readable Docs:**

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Run the examples locally:
 ```bash
 pnpm example:dawcore-native  # Native Web Audio — localhost:5173
 pnpm example:dawcore-tone    # Tone.js backend — localhost:5174
+pnpm example:dawcore-wam     # WAM 2.0 plugins + Faust — localhost:5175
 ```
 
 **dawcore-native** example pages:
@@ -224,6 +225,7 @@ pnpm example:dawcore-tone    # Tone.js backend — localhost:5174
 - [`automation.html`](examples/dawcore-native/automation.html) — Tempo automation with step, linear, and curve presets
 - [`analyser.html`](examples/dawcore-native/analyser.html) — Spectrum analyser connected to master output
 - [`spectrogram.html`](examples/dawcore-native/spectrogram.html) — Per-track FFT spectrograms via `render-mode="spectrogram"` with color-map and frequency-scale controls
+- [`effects.html`](examples/dawcore-native/effects.html) — Per-track and master insert effects (`native-*` registry) with live parameter sliders, bypass, and `daw-effect-*` event log
 
 **dawcore-tone** example pages:
 
@@ -237,6 +239,10 @@ pnpm example:dawcore-tone    # Tone.js backend — localhost:5174
 - [`midi.html`](examples/dawcore-tone/midi.html) — Programmatic MIDI clips with piano-roll render mode and Tone.js PolySynth
 - [`midi-load.html`](examples/dawcore-tone/midi-load.html) — Load `.mid` files (URL or file picker) via `editor.loadMidi()` and play them through Tone.js PolySynth
 - [`soundfont.html`](examples/dawcore-tone/soundfont.html) — MIDI through SoundFont samples: `SoundFontCache.fromUrl()` + `createToneAdapter({ soundFontCache })`, with PolySynth fallback when the `.sf2` fails to load
+
+**dawcore-wam** example pages:
+
+- [`index.html`](examples/dawcore-wam/index.html) — WAM 2.0 plugin hosting end to end: load community plugins by URL or from the [webaudiomodules.com](https://www.webaudiomodules.com/) library, open plugin GUIs, reorder/bypass chains, save and restore chains (including state) via localStorage, export the mix to WAV through `exportAudio()`, and compile Faust DSP to a live effect in the browser (`@dawcore/faust`) — plus pre-compiled Faust effects served from this repo
 
 **Spec & roadmap:** [`docs/specs/web-components-migration.md`](docs/specs/web-components-migration.md) — full element catalogue, attribute/property/event tables, programmatic API contracts, theming tokens, and migration phases.
 


### PR DESCRIPTION
The root README's examples section had drifted: the effects demo (#440) and the entire `examples/dawcore-wam` app (#444, #446 — WAM plugins, library picker, GUIs, persistence, WAV export, in-browser Faust compilation) were missing.

- Adds both to the README (run command + page descriptions)
- Adds a CLAUDE.md documentation rule: **whenever a demo/example page is added, the root README's examples section must be updated in the same PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)