### PR TITLE
docs: pre-publish README sweep across @dawcore packages

### DIFF
--- a/packages/dawcore-faust/README.md
+++ b/packages/dawcore-faust/README.md
@@ -2,13 +2,17 @@
 
 In-browser [Faust](https://faust.grame.fr/) DSP compilation to [WAM 2.0](https://github.com/webaudiomodules) plugins for the dawcore family. Write a filter in a few lines of Faust, compile it in the browser, and hear it instantly — no toolchain, no build step, no hosting.
 
-This package is framework-agnostic (no Lit, no React). `@dawcore/components` consumes it as an **optional peer dependency** — `<daw-track>.addFaustEffect()` dynamic-imports it on first use, so consumers who never compile Faust load **zero compiler bytes** (the Faust compiler is ~2.5 MB gzipped of WebAssembly, bundled inside [`@shren/faust2wam`](https://github.com/webaudiomodules/faust2wam)).
+This package is framework-agnostic (no Lit, no React). `@dawcore/components` consumes it as an **optional peer dependency** — `<daw-track>.addFaustEffect()` dynamic-imports it on first use, so consumers who never compile Faust load **zero compiler bytes** (the Faust compiler is ~2.5 MB gzipped of WebAssembly, bundled inside [`@shren/faust2wam`](https://www.npmjs.com/package/@shren/faust2wam)).
 
 ## Installation
 
 ```bash
 npm install @dawcore/faust
 ```
+
+That's the only install — `@shren/faust2wam` (the compiler) is a regular dependency of this package, so your package manager pulls it in automatically.
+
+`@dawcore/components` declares this package as an *optional* peer dependency, so add it to your own dependencies (as above, alongside `@dawcore/wam`) to enable `addFaustEffect` on `<daw-editor>` and `<daw-track>`.
 
 ## Using with `@dawcore/components`
 
@@ -66,7 +70,33 @@ const plugin = await createWamInstanceFromFactory(compiled.factory, audioContext
 
 Notes:
 
-- The generated plugin is a standard WAM 2.0 effect — everything in [`@dawcore/wam`'s README](../dawcore-wam) about Faust-generated plugins (flat parameter-map state, auto-generated GUI, descriptor shape) applies.
+- The generated plugin is a standard WAM 2.0 effect — everything in [`@dawcore/wam`'s README](https://www.npmjs.com/package/@dawcore/wam) about Faust-generated plugins (flat parameter-map state, auto-generated GUI, descriptor shape) applies.
 - Factory-created instances have no `url` and cannot be cloned with `cloneInstanceInto` — recompile the DSP on the target context instead (this is what dawcore's offline export does).
 - Effects only — Faust polyphonic instruments are out of scope.
-- Prefer ahead-of-time compilation? The faust2wam CLI produces a static WAM bundle loadable via plain `addWamPlugin(url)` with zero compiler bytes shipped — see [`@dawcore/wam`'s "Custom effects with Faust"](../dawcore-wam#custom-effects-with-faust).
+- Prefer ahead-of-time compilation? The `faust2wam` CLI (`npm i -D @shren/faust2wam`, then `npx faust2wam lowpass.dsp out/lowpass`) produces a static WAM bundle loadable via plain `addWamPlugin(url)` with zero compiler bytes shipped — see [`@dawcore/wam`'s "Custom effects with Faust"](https://www.npmjs.com/package/@dawcore/wam#custom-effects-with-faust).
+
+## Under the hood: `@shren/faust2wam`
+
+`compileFaustToWam` is a thin, cache-managed wrapper around [`@shren/faust2wam`](https://www.npmjs.com/package/@shren/faust2wam)'s browser API — its default export `generate(dspCode, name)`, which resolves to a WebAudioModule class. If you want the compiler without this wrapper, install it directly (`npm install @shren/faust2wam`) and call it yourself:
+
+```typescript
+// Lazy import — see the bundle note below.
+const { default: generate } = await import('@shren/faust2wam');
+
+const WamClass = await generate(dspCode, 'My Lowpass');
+const wam = await WamClass.createInstance(hostGroupId, audioContext);
+audioNodeChain.connect(wam.audioNode);
+```
+
+What this wrapper adds on top: input validation, a shared in-flight compiler load (concurrent first compiles share one download; failed loads are evicted for retry), and a factory shape check — while keeping Faust's compile diagnostics untouched.
+
+**Bundle-size implication:** `@shren/faust2wam`'s `dist/index.js` is a single **~8 MB self-contained ESM bundle** (~2.5 MB gzipped) — the libfaust compiler WASM and the Faust standard libraries are inlined as base64 data URIs, so nothing is fetched from a CDN and no assets need hosting. Always load it through a **dynamic `import()`** so your bundler splits it into its own chunk that's only fetched when the user actually compiles Faust; a static top-level import lands all ~8 MB in your main bundle. `compileFaustToWam` does the lazy import for you — that chunk isolation is most of the reason this package exists.
+
+## Examples & Documentation
+
+- [`examples/dawcore-wam/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-wam) — the "Faust (compile in browser)" section is a runnable textarea-to-plugin demo (`pnpm example:dawcore-wam`)
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)
+
+## License
+
+MIT

--- a/packages/dawcore-midi/README.md
+++ b/packages/dawcore-midi/README.md
@@ -1,14 +1,49 @@
 # @dawcore/midi
 
-Framework-agnostic MIDI file loading and parsing for the dawcore family.
+Framework-agnostic MIDI file loading and parsing for the dawcore family. No React, no DOM, no Lit — pure functions built on `@tonejs/midi`.
 
 Used by `@dawcore/components` (the Lit web component layer, via `editor.loadMidi()`) and `@waveform-playlist/midi` (the React `useMidiTracks` hook).
 
-## Exports
+## Installation
 
-- `parseMidiFile(data, options?)` — parse a MIDI `ArrayBuffer`
-- `parseMidiUrl(url, options?, signal?)` — fetch and parse a `.mid` URL
+```bash
+npm install @dawcore/midi
+```
+
+No peer dependencies. `@dawcore/components` declares this package as an *optional* peer dependency — add it to your own dependencies to enable `editor.loadMidi()` (it's dynamic-imported on first call, so non-MIDI users ship zero parser bytes).
+
+## Quick Start
+
+```typescript
+import { parseMidiUrl, parseMidiFile } from '@dawcore/midi';
+
+// Fetch and parse a .mid URL (optional AbortSignal for cancellation)
+const midi = await parseMidiUrl('/media/song.mid');
+// midi: { tracks, duration, name, bpm, timeSignature }
+
+for (const track of midi.tracks) {
+  // track: { name, notes, duration, channel, instrument, programNumber }
+  console.log(track.name, track.notes.length + ' notes');
+}
+
+// Or parse an ArrayBuffer you already have (e.g. from a File input)
+const buffer = await file.arrayBuffer();
+const parsed = parseMidiFile(buffer, { flatten: true }); // merge all tracks into one
+```
+
+Note timings are in seconds, already tempo-adjusted by `@tonejs/midi`. Tracks without notes are filtered out.
+
+## API
+
+- `parseMidiFile(data: ArrayBuffer, options?)` — parse MIDI data into `ParsedMidi`
+- `parseMidiUrl(url: string, options?, signal?)` — fetch and parse a `.mid` URL
+- Options: `{ flatten?: boolean }` — merge all MIDI tracks into a single track
 - Types: `ParsedMidi`, `ParsedMidiTrack`, `ParseMidiOptions`, `MidiLoadOptions`, `MidiLoadResult`
+
+## Examples & Documentation
+
+- [`examples/dawcore-tone/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-tone) — MIDI piano-roll rendering and playback (`pnpm example:dawcore-tone`)
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)
 
 ## License
 

--- a/packages/dawcore-spectrogram/README.md
+++ b/packages/dawcore-spectrogram/README.md
@@ -1,14 +1,58 @@
 # @dawcore/spectrogram
 
-Framework-agnostic spectrogram computation, worker, and viewport-aware rendering orchestrator for the dawcore family.
+Framework-agnostic spectrogram computation, Web Worker, and viewport-aware rendering orchestrator for the dawcore family.
 
-Used by `@dawcore/components` (the Lit web component layer) and `@waveform-playlist/spectrogram` (the React Provider).
+Used by `@dawcore/components` (the Lit web component layer, behind `<daw-track render-mode="spectrogram">`) and `@waveform-playlist/spectrogram` (the React Provider).
 
-## Exports
+## Installation
 
-- `computeSpectrogram`, `getColorMap`, `getFrequencyScale` — pure computation
-- `createSpectrogramWorker`, `createSpectrogramWorkerPool` — worker factories
-- `SpectrogramOrchestrator` (via `./orchestrator` subpath) — viewport/abort/tier/grouping logic
+```bash
+npm install @dawcore/spectrogram
+```
+
+No peer dependencies. If you use `@dawcore/components`, you don't install this directly — it's a regular dependency of that package.
+
+## Quick Start
+
+```typescript
+import { computeSpectrogram, getColorMap } from '@dawcore/spectrogram';
+
+// Pure, synchronous FFT — magnitudes per time/frequency bin
+const data = computeSpectrogram(audioBuffer, { fftSize: 2048 });
+const lut = getColorMap('magma');
+```
+
+For rendering inside an app, use the worker and orchestrator instead of blocking the main thread:
+
+```typescript
+import { SpectrogramOrchestrator } from '@dawcore/spectrogram/orchestrator';
+
+const orchestrator = new SpectrogramOrchestrator({
+  workerFactory: () =>
+    new Worker(new URL('@dawcore/spectrogram/worker/spectrogram.worker', import.meta.url), {
+      type: 'module',
+    }),
+  config: { fftSize: 2048 },
+});
+
+orchestrator.registerClip(/* audio data */);
+orchestrator.registerCanvas(/* OffscreenCanvas + metadata */);
+orchestrator.setViewport(/* visible range */);
+orchestrator.addEventListener('viewport-ready', (e) => console.log(e));
+```
+
+The orchestrator renders in three tiers (visible viewport first, then a 25% overscan buffer, then the rest during idle time), aborts stale work when the viewport, config, or color map changes, and groups contiguous chunks so non-adjacent regions never trigger one oversized FFT.
+
+## Entry Points
+
+- `@dawcore/spectrogram` — `computeSpectrogram`, `computeSpectrogramMono`, `getColorMap`, `getFrequencyScale`, worker factories (`createSpectrogramWorker`, `createSpectrogramWorkerPool`, `SpectrogramAbortError`), and the orchestrator re-exports
+- `@dawcore/spectrogram/worker/spectrogram.worker` — the Worker module URL target (resolve with `new URL(..., import.meta.url)`)
+- `@dawcore/spectrogram/orchestrator` — `SpectrogramOrchestrator` and helpers (`classifyViewport`, `groupContiguousChunks`, `ColorLUTCache`) without the computation/worker graph, for consumers with their own FFT pipeline
+
+## Examples & Documentation
+
+- [`examples/dawcore-native/spectrogram.html`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-native) — spectrogram tracks in `<daw-editor>` (`pnpm example:dawcore-native`)
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
 
 ## License
 

--- a/packages/dawcore-wam/README.md
+++ b/packages/dawcore-wam/README.md
@@ -10,6 +10,8 @@ This package is framework-agnostic (no Lit, no React). `@dawcore/components` con
 npm install @dawcore/wam
 ```
 
+`@dawcore/components` declares this package as an *optional* peer dependency, so package managers won't install it for you — add it to your own dependencies (as above) to enable the WAM methods on `<daw-editor>` and `<daw-track>`. Standalone use (any Web Audio app) needs no other packages.
+
 ## Using with `@dawcore/components`
 
 The typical path: install this package next to `@dawcore/components` and use the WAM methods on `<daw-editor>` (master chain) and `<daw-track>` (per-track chain). Host initialization is implicit — the first `addWamPlugin()` call sets up the WAM host on the editor's AudioContext.
@@ -53,7 +55,7 @@ See [`examples/dawcore-wam/`](https://github.com/naomiaro/waveform-playlist/tree
 
 ## Custom effects with Faust
 
-You don't have to wait for someone to publish the effect you need — [Faust](https://faust.grame.fr/) is a DSP language that compiles to a standard WAM 2.0 bundle via [faust2wam](https://github.com/webaudiomodules/faust2wam). The generated plugins load through `addWamPlugin(url)` with **zero special handling**: descriptor validation, chain insertion, bypass, the auto-generated GUI, `getState()`/`setState()` persistence, and offline export all work out of the box.
+You don't have to wait for someone to publish the effect you need — [Faust](https://faust.grame.fr/) is a DSP language that compiles to a standard WAM 2.0 bundle via [`@shren/faust2wam`](https://www.npmjs.com/package/@shren/faust2wam). The generated plugins load through `addWamPlugin(url)` with **zero special handling**: descriptor validation, chain insertion, bypass, the auto-generated GUI, `getState()`/`setState()` persistence, and offline export all work out of the box.
 
 The complete workflow, starting from a one-line lowpass filter:
 
@@ -66,12 +68,11 @@ process = fi.lowpass(2, hslider("cutoff", 1000, 20, 20000, 1));
 
 (That's a mono filter. Track chains are stereo, so in practice duplicate it across both channels: `cutoff = hslider("cutoff", 1000, 20, 20000, 1); process = fi.lowpass(2, cutoff), fi.lowpass(2, cutoff);` — or reach for the stereo demos in the standard library like `dm.zita_light` or `dm.flanger_demo`.)
 
-**2. Compile it** with the faust2wam CLI (Node 16+, no Faust toolchain needed — the compiler ships as WebAssembly):
+**2. Compile it** with the `faust2wam` CLI from npm (no Faust toolchain needed — the compiler ships as WebAssembly):
 
 ```bash
-git clone https://github.com/webaudiomodules/faust2wam
-cd faust2wam && npm install
-node faust2wam.js lowpass.dsp out/lowpass
+npm install -D @shren/faust2wam
+npx faust2wam lowpass.dsp out/lowpass
 ```
 
 **3. Host the bundle** — `out/lowpass/` is a self-contained static directory (`index.js`, `descriptor.json`, `dsp-module.wasm`, dsp metadata, and vendored `sdk/`, `sdk-parammgr/`, `faustwasm/`, `faust-ui/` runtimes). Serve it from any static host; cross-origin hosting needs `Access-Control-Allow-Origin` headers (see the CORS note above). The `fftw/` and `host/` directories and the `.map`/`.d.ts` files are only needed for `-fft` plugins and standalone testing — safe to omit when hosting plain effects.
@@ -91,7 +92,7 @@ Faust-generated plugins are well-behaved WAM citizens; quirks observed (none nee
 - The GUI element sizes itself from faust-ui's computed `minWidth`/`minHeight` (inline styles, scrollable container) — it lays out fine in a normal document flow without a fixed-size plugin window.
 - Parameter names/addresses derive from the DSP source (`declare name` + control labels), and the descriptor identifier becomes `fr.grame.faust.<name>` with vendor `Faust User`.
 
-**No build step at all?** [`@dawcore/faust`](../dawcore-faust) compiles Faust DSP source **in the browser** — paste code, get a live plugin. `<daw-track>.addFaustEffect(dspCode)` uses it (optional peer dep, ~2.5 MB gzipped compiler loaded on first use only) and instantiates the result through this package's `createWamInstanceFromFactory`.
+**No build step at all?** [`@dawcore/faust`](https://www.npmjs.com/package/@dawcore/faust) compiles Faust DSP source **in the browser** — paste code, get a live plugin. It wraps `@shren/faust2wam`'s browser API (the same `generate()` the CLI uses). `<daw-track>.addFaustEffect(dspCode)` uses it (optional peer dep, ~2.5 MB gzipped compiler loaded on first use only) and instantiates the result through this package's `createWamInstanceFromFactory`.
 
 ## Standalone Usage
 
@@ -141,7 +142,7 @@ const { entries, warnings } = await fetchWamLibrary(
 
 An entry's `url` feeds straight into `createWamInstance(url, ...)`. Descriptor validation still happens at load time — manifests can lie.
 
-**Factories without URLs** — when you already hold a WebAudioModule class (e.g. one generated in-browser by [`@dawcore/faust`](../dawcore-faust)), instantiate it through the same validate/wrap pipeline with `createWamInstanceFromFactory`:
+**Factories without URLs** — when you already hold a WebAudioModule class (e.g. one generated in-browser by [`@dawcore/faust`](https://www.npmjs.com/package/@dawcore/faust)), instantiate it through the same validate/wrap pipeline with `createWamInstanceFromFactory`:
 
 ```typescript
 import { createWamInstanceFromFactory } from '@dawcore/wam';
@@ -230,3 +231,12 @@ offlinePlugin.destroy();
 ```
 
 This is how `<daw-editor>.exportAudio()` renders WAM chains offline: each persisted entry is re-instantiated on the `OfflineAudioContext` with its saved state, and all offline instances are destroyed after rendering.
+
+## Examples & Documentation
+
+- [`examples/dawcore-wam/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-wam) — end-to-end demo (`pnpm example:dawcore-wam`)
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)
+
+## License
+
+MIT

--- a/packages/dawcore/README.md
+++ b/packages/dawcore/README.md
@@ -10,12 +10,16 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 - **Drag interactions** — Move clips, trim boundaries, split at playhead
 - **Keyboard shortcuts** — Play/pause, split, undo/redo via `<daw-keyboard-shortcuts>`
 - **Undo/redo** — Full transaction-based undo with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z
-- **File drop** — Drag audio files onto the editor to add tracks
+- **File drop** — Drag audio files onto the editor to add tracks (enable with the `file-drop` attribute)
 - **Recording** — Live mic recording with waveform preview, pause/resume, cancelable clip creation
 - **Pre-computed peaks** — Instant waveform rendering from `.dat` files before audio decodes
-- **MIDI tracks** — Programmatic MIDI clips render as piano-roll via `<daw-piano-roll>`. Playback via Tone.js adapter (native MIDI synth deferred). See [MIDI Tracks](#midi-tracks).
+- **MIDI tracks** — Declarative or programmatic MIDI clips render as piano-roll. Playback via the Tone.js adapter. See [MIDI Tracks](#midi-tracks).
+- **MIDI file loading** — `editor.loadMidi(urlOrFile)` parses a `.mid` file into piano-roll tracks via the optional `@dawcore/midi` peer
+- **Spectrogram rendering** — `<daw-track render-mode="spectrogram">` renders FFT spectrograms via `@dawcore/spectrogram`
 - **Track controls** — Volume, pan, mute, solo per track via `<daw-track-controls>`
-- **Effects chains** — Per-track and master effect chains with built-in `native-*` effects and WAM 2.0 plugins via `@dawcore/wam`. See [Effects](#effects).
+- **Effects chains** — Per-track and master effect chains with built-in `native-*` effects, WAM 2.0 plugins via `@dawcore/wam`, and in-browser-compiled Faust DSP via `@dawcore/faust`. See [Effects](#effects).
+- **Effect GUIs and persistence** — Mount plugin GUIs into your own panels; snapshot and restore whole chains. See [Effect GUIs](#effect-guis) and [Effects Persistence](#effects-persistence).
+- **Offline export** — `editor.exportAudio()` renders the session (clips, mix, all effect chains) to an `AudioBuffer`. See [Offline Export](#offline-export).
 - **Transport access** — Tempo, metronome, count-in, meter, effects via `@dawcore/transport`
 - **CSS theming** — Dark mode by default, fully customizable via CSS custom properties
 - **Native Web Audio** — Uses `@dawcore/transport` for playback scheduling. No Tone.js dependency.
@@ -26,21 +30,27 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 npm install @dawcore/components
 ```
 
-Peer dependencies:
+Required peer dependencies:
+
 ```bash
 npm install @waveform-playlist/core @waveform-playlist/engine
 ```
 
 Audio backend (choose one — see [Choosing an Audio Backend](#choosing-an-audio-backend)):
+
 ```bash
 npm install @dawcore/transport          # Native Web Audio (recommended)
 # or
 npm install @waveform-playlist/playout tone  # Tone.js
 ```
 
-Optional (for recording):
+Optional peer dependencies — each is dynamic-imported on first use, so you only install (and ship) what you use:
+
 ```bash
-npm install @waveform-playlist/worklets
+npm install @waveform-playlist/worklets  # recording
+npm install @dawcore/midi                # editor.loadMidi()
+npm install @dawcore/wam                 # WAM 2.0 plugins (addWamPlugin) + generic effect GUIs
+npm install @dawcore/faust @dawcore/wam  # in-browser Faust compilation (addFaustEffect)
 ```
 
 ## Quick Start
@@ -94,7 +104,7 @@ adapter.transport.setCountIn(true);
 
 ### Tone.js (effects, MIDI synths)
 
-Uses Tone.js for audio processing. Single tempo/meter only. **Required for MIDI playback** — the native adapter has no MIDI synth yet, so MIDI clips render as piano-roll but are silent.
+Uses Tone.js for audio processing. Single tempo/meter only. **Required for MIDI playback** — the native adapter has no MIDI synth, so MIDI clips render as piano-roll but play silently on it.
 
 ```bash
 npm install @waveform-playlist/playout tone
@@ -129,7 +139,7 @@ For multiple clips per track with independent positioning:
 
 ## MIDI Tracks
 
-Programmatic MIDI clips render as piano-roll. Playback requires the Tone.js adapter (the native adapter has no MIDI synth yet). Use the `editor.addTrack({ midi })` sugar for the simplest path:
+Programmatic MIDI clips render as piano-roll. Playback requires the Tone.js adapter (the native adapter has no MIDI synth). Use the `editor.addTrack({ midi })` sugar for the simplest path:
 
 ```javascript
 import { createToneAdapter } from '@waveform-playlist/playout';
@@ -165,7 +175,7 @@ This expands to a `<daw-track render-mode="piano-roll">` containing a `<daw-clip
 </script>
 ```
 
-A clip is treated as MIDI iff `clip.midiNotes != null`. MIDI clips skip audio fetch + decode + peak generation. Trim handles and split-at-playhead are inert on MIDI clips for now (note slicing is a follow-up). Move drag works.
+A clip is treated as MIDI iff `clip.midiNotes != null`. MIDI clips skip audio fetch + decode + peak generation. Move drag works on MIDI clips; trim handles and split-at-playhead are inert on them.
 
 **Theming:** the piano-roll honors `--daw-piano-roll-note-color` (default `#2a7070`), `--daw-piano-roll-selected-note-color` (default `#3d9e9e`), and `--daw-piano-roll-background` (default `#1a1a2e`).
 
@@ -393,26 +403,39 @@ Core orchestrator. Attributes:
 
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `samples-per-pixel` | number | `1024` | Zoom level |
-| `sample-rate` | number | `48000` | AudioContext sample rate hint |
-| `wave-height` | number | `100` | Track waveform height in pixels |
+| `samples-per-pixel` | number | `1024` | Zoom level (clamped to the pre-computed peaks floor when one is active) |
+| `wave-height` | number | `128` | Track waveform height in pixels |
 | `timescale` | boolean | `false` | Show time ruler |
 | `clip-headers` | boolean | `false` | Show clip name headers |
+| `clip-header-height` | number | `20` | Clip header height in pixels |
 | `interactive-clips` | boolean | `false` | Enable drag/trim/split |
+| `file-drop` | boolean | `false` | Accept audio files dropped onto the editor |
 | `mono` | boolean | `false` | Merge stereo to mono display |
-| `eager-resume` | boolean | `false` | Resume AudioContext on first user gesture |
+| `bar-width` / `bar-gap` | number | `1` / `0` | Waveform bar rendering style |
+| `indefinite-playback` | boolean | `false` | Keep ruler/timeline filling the viewport with no clips |
+| `scale-mode` | string | `'temporal'` | `'temporal'` (seconds) or `'beats'` (tick-linear grid) |
+| `ticks-per-pixel` | number | `24` | Zoom level in beats mode |
+| `snap-to` | string | `'off'` | Grid snapping in beats mode (`'bar'`, `'beat'`, `'1/2'`…`'1/16'`, `'off'`) |
+| `eager-resume` | string | — | Resume AudioContext on first gesture; bare attribute targets the editor, or pass `"document"` / a CSS selector |
 
-JS properties: `audioContext`, `recordingStream`, `engine`.
+JS properties: `adapter` (required `PlayoutAdapter`), `recordingStream`, `bpm`, `ppqn`, `timeSignature`, `meterEntries`, `secondsToTicks` / `ticksToSeconds` (variable-tempo callbacks), `spectrogramConfig`, `spectrogramColorMap`. Read-only: `engine`, `audioContext` (from the adapter), `tracks`, `selection`, `selectedTrackId`, `currentTime`, `canUndo` / `canRedo`, `isRecording`.
 
-Methods: `loadFiles(fileList)`, `splitAtPlayhead()`, plus the master-chain effects API (see [Effects](#effects)).
+Methods:
+
+- Playback: `play(startTime?)`, `pause()`, `stop()`, `togglePlayPause()`, `seekTo(time)`
+- Loading: `loadFiles(files)`, `loadMidi(urlOrFile, options?)`, `ready()`
+- Tracks & clips: `addTrack(config)`, `removeTrack(id)`, `updateTrack(id, partial)`, `addClip(trackId, config)`, `removeClip(trackId, clipId)`, `updateClip(trackId, clipId, partial)`
+- Editing: `splitAtPlayhead()`, `undo()`, `redo()`, `setSelection(start, end)`
+- Recording: `startRecording(stream?, options?)`, `stopRecording()`, `pauseRecording()`, `resumeRecording()`, `togglePauseRecording()`
+- Effects & export: the master-chain effects API (see [Effects](#effects)), `getEffectsState()` / `setEffectsState(entries)`, `openEffectGui()` / `closeEffectGui()`, `exportAudio(options?)`
 
 ### `<daw-track>`
 
-Declarative track data. Attributes: `src`, `name`, `volume`, `pan`, `muted`, `soloed`, `mono`, `render-mode` (`'waveform' | 'piano-roll'`, default `'waveform'`). Also exposes the per-track effects API (see [Effects](#effects)).
+Declarative track data. Attributes: `src`, `name`, `volume`, `pan`, `muted`, `soloed`, `render-mode` (`'waveform' | 'piano-roll' | 'spectrogram'`, default `'waveform'`). JS property: `spectrogramConfig` (per-track spectrogram override). Also exposes the per-track effects API (see [Effects](#effects)).
 
 ### `<daw-clip>`
 
-Declarative clip data. Attributes: `src`, `peaks-src`, `start`, `duration`, `offset`, `gain`, `midi-channel`, `midi-program`. JS-only property: `midiNotes: MidiNoteData[] | null` (note arrays are too large for attributes).
+Declarative clip data. Attributes: `src`, `peaks-src`, `start`, `duration`, `offset`, `gain`, `name`, `color`, `midi-channel`, `midi-program`. JS-only property: `midiNotes: MidiNoteData[] | null` (note arrays are too large for attributes).
 
 ### `<daw-piano-roll>`
 
@@ -460,12 +483,16 @@ editor.addEventListener('daw-recording-complete', (e) => {
 // Effects (track events bubble up to the editor)
 editor.addEventListener('daw-effect-add', (e) => console.log(e.detail));
 editor.addEventListener('daw-effect-change', (e) => console.log(e.detail));
+// also: daw-effect-remove, daw-effect-bypass, daw-effect-reorder
 
 // Errors
 editor.addEventListener('daw-track-error', (e) => console.error(e.detail));
 editor.addEventListener('daw-error', (e) => console.error(e.detail));
 editor.addEventListener('daw-files-load-error', (e) => console.error(e.detail));
+editor.addEventListener('daw-effect-error', (e) => console.error(e.detail));
 ```
+
+All events and their `detail` payloads are typed in the exported `DawEventMap`.
 
 ## Custom AudioContext
 
@@ -478,6 +505,13 @@ editor.adapter = adapter;
 ```
 
 Set the adapter before tracks load. The provided context is used for decoding, playback, and recording.
+
+## Examples & Documentation
+
+- [`examples/dawcore-native/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-native) — native transport: basics, multi-clip, metronome, beats grid, beat maps, effects, spectrogram, recording (`pnpm example:dawcore-native`)
+- [`examples/dawcore-tone/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-tone) — Tone.js adapter: MIDI, SoundFont playback (`pnpm example:dawcore-tone`)
+- [`examples/dawcore-wam/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-wam) — WAM plugins end-to-end + in-browser Faust compilation (`pnpm example:dawcore-wam`)
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)
 
 ## License
 

--- a/packages/dawcore/package.json
+++ b/packages/dawcore/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@dawcore/faust": ">=0.0.1",
     "@dawcore/midi": ">=0.0.1",
-    "@dawcore/transport": ">=0.0.7",
+    "@dawcore/transport": ">=0.0.13",
     "@dawcore/wam": ">=0.0.1",
     "@waveform-playlist/core": ">=12.0.0",
     "@waveform-playlist/engine": ">=13.3.0",

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -55,9 +55,12 @@ import { NativePlayoutAdapter } from '@dawcore/transport';
 const audioContext = new AudioContext({ sampleRate: 48000 });
 const adapter = new NativePlayoutAdapter(audioContext);
 
-// Use as daw-editor's adapter factory
+// Use as daw-editor's playout adapter
 const editor = document.querySelector('daw-editor');
-editor.adapterFactory = () => new NativePlayoutAdapter(audioContext);
+editor.adapter = adapter;
+
+// Transport-specific APIs stay available on your adapter reference
+adapter.transport.setMetronomeEnabled(true);
 ```
 
 ### Metronome
@@ -216,7 +219,8 @@ new Transport(audioContext: AudioContext, options?: TransportOptions)
 - `setLoopSamples(enabled, startSample: Sample, endSample: Sample)` — Set loop region in samples (convenience)
 
 **Tempo & Meter:**
-- `setTempo(bpm, atTick?, options?)` / `getTempo(atTick?: Tick)` — options: `{ interpolation: 'step' | 'linear' | { type: 'curve', slope } }`
+- `setTempo(bpm, atTick?, options?)` / `getTempo(atTick?: Tick)` — options: `{ interpolation: 'step' | 'linear' | { type: 'curve', slope } }`. Returns `boolean`: a defaulted `atTick` is the single-BPM convenience path and is refused (with a warning) when the tempo map has more than one entry — pass an explicit `atTick` to modify a tempo curve.
+- `removeTempo(atTick: Tick)` — remove the tempo entry at a tick (the tick-0 entry cannot be removed)
 - `clearTempos()` — remove all tempo entries
 - `setMeter(numerator, denominator, atTick?: Tick)` / `getMeter(atTick?: Tick)`
 - `removeMeter(atTick: Tick)` / `clearMeters()`
@@ -239,10 +243,12 @@ new Transport(audioContext: AudioContext, options?: TransportOptions)
 - `disconnectTrackOutput(trackId)` — Remove per-track effects chain
 - `connectMasterOutput(node)` — Insert master bus effects chain
 - `disconnectMasterOutput()` — Remove master bus effects chain
+- `masterOutputNode` (getter) — Master gain node, for parallel taps (analyzers, recorders) that should survive chain connect/disconnect
 
 **Events:**
 - `on(event, callback)` / `off(event, callback)`
-- Events: `play`, `pause`, `stop`, `loop`, `tempochange`, `meterchange`, `countIn`, `countInEnd`
+- Events: `play`, `pause`, `stop`, `seek`, `loop`, `tempochange`, `meterchange`, `countIn`, `countInEnd`
+- `seek` payload: `{ seconds: number }`
 - `tempochange` payload: `{ bpm: number, atTick: Tick }`
 - `meterchange` payload: `{ numerator: number, denominator: number, atTick: Tick }`
 - `countIn` payload: `{ beat: number, totalBeats: number }`
@@ -258,15 +264,27 @@ new NativePlayoutAdapter(audioContext: AudioContext, options?: TransportOptions)
 
 Implements `PlayoutAdapter` from `@waveform-playlist/engine`. All methods delegate to the internal `Transport` instance.
 
-- `adapter.transport` — Direct access to the `Transport` for tempo, metronome, and effects APIs
+- `adapter.transport` — Direct access to the `Transport` for tempo, metronome, count-in, and effects APIs
+- `adapter.ppqn` — Tick resolution, read by the engine on construction
+- `adapter.masterOutputNode` — Master gain node for parallel taps (analyzers, recorders)
+- `adapter.init()` — Resumes a suspended AudioContext and waits for the hardware pipeline to warm up (Safari needs this before clips scheduled at time 0 play on time)
+- `setTempo(bpm, atTick?)`, `setMeter(numerator, denominator, atTick?)`, `ticksToSeconds(tick)`, `secondsToTicks(seconds)` — tempo/meter surface the engine uses for tick-based timeline math
+
+## Examples
+
+[`examples/dawcore-native/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-native) pairs this transport with the `@dawcore/components` editor: metronome, tempo automation, mixed meter, beat-map grids, effects, and recording pages (`pnpm example:dawcore-native`).
 
 ## Architecture
 
-See [TRANSPORT.md](./TRANSPORT.md) for the full architecture guide.
+See [TRANSPORT.md](https://github.com/naomiaro/waveform-playlist/blob/main/packages/transport/TRANSPORT.md) for the full architecture guide.
 
 ## How It Works
 
-See [EDUCATIONAL.md](./EDUCATIONAL.md) for an in-depth explanation of the math and timing models behind audio transport systems.
+See [EDUCATIONAL.md](https://github.com/naomiaro/waveform-playlist/blob/main/packages/transport/EDUCATIONAL.md) for an in-depth explanation of the math and timing models behind audio transport systems.
+
+## Documentation
+
+Full guides at [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/).
 
 ## License
 


### PR DESCRIPTION
Pre-publish audit + refresh of every `@dawcore/*` README ahead of the npm publish. Every documented export, method, signature, and event was verified against `src/` and each package's CLAUDE.md.

## Per-package changes

### `@dawcore/transport` (`packages/transport`)
- **Fixed a broken Quick Start snippet**: `editor.adapterFactory = () => ...` doesn't exist on `<daw-editor>` — replaced with the real `editor.adapter = adapter` API.
- Added the `seek` event (`{ seconds }` payload) to the events list — it ships in 0.0.13 for the WAM transport bridge but was undocumented.
- Documented `removeTempo(atTick)` (tick-0 entry is protected), the `setTempo` boolean return + multi-entry guard (#407), and the `masterOutputNode` getter (parallel taps survive chain connect/disconnect).
- Expanded the `NativePlayoutAdapter` section with the adapter surface the engine actually uses: `ppqn`, `masterOutputNode`, `init()` (Safari warmup), and the `setTempo`/`setMeter`/`ticksToSeconds`/`secondsToTicks` query surface.
- TRANSPORT.md / EDUCATIONAL.md links converted to absolute GitHub URLs (those files aren't in the npm tarball, so relative links 404 on npmjs.com); added Examples + docs-site links.

### `@dawcore/components` (`packages/dawcore`)
- **Removed the stale `sample-rate` attribute** from the `<daw-editor>` table (removed when the adapter became required) and **fixed `wave-height` default** (`128`, was documented as `100`).
- Completed the attribute table: `clip-header-height`, `file-drop`, `bar-width`/`bar-gap`, `indefinite-playback`, `scale-mode`, `ticks-per-pixel`, `snap-to` (with real values), and corrected `eager-resume` (string target selector, not a boolean).
- Rewrote JS properties (stale "`audioContext`, `recordingStream`, `engine`" → `adapter` required, read-only `audioContext`/`engine`, `bpm`/`ppqn`/`meterEntries`/tick callbacks, etc.) and the methods list (playback, loading incl. `loadMidi`/`ready`, tracks & clips, editing, recording, effects/persistence/GUIs/`exportAudio`).
- `<daw-track>`: removed the nonexistent `mono` attribute, added `'spectrogram'` to `render-mode`, documented `spectrogramConfig`. `<daw-clip>`: added `name`, `color`.
- Installation now spells out required peers vs. the four optional dynamic-import peers (`worklets`, `@dawcore/midi`, `@dawcore/wam`, `@dawcore/faust`) and what each enables.
- Features list now covers `loadMidi`, spectrogram rendering, Faust effects, GUIs/persistence, and offline export; events section gained `daw-effect-error` + the full effect event list and a `DawEventMap` pointer.
- Removed release-status phrasing ("native MIDI synth deferred", "note slicing is a follow-up", "no MIDI synth yet") — behavior is now described as it is.
- Added Examples & Documentation footer (dawcore-native / dawcore-tone / dawcore-wam + docs site).

### `@dawcore/midi` (`packages/dawcore-midi`)
- Expanded from a 15-line stub to the standard structure: Installation (no peers; optional-peer note for `@dawcore/components`), a runnable Quick Start (`parseMidiUrl` / `parseMidiFile` with the real `ParsedMidi`/`ParsedMidiTrack` shapes), API list with the `flatten` option, examples + docs links.

### `@dawcore/spectrogram` (`packages/dawcore-spectrogram`)
- Expanded from a 15-line stub: Installation, Quick Start for both the pure `computeSpectrogram` path and the worker + `SpectrogramOrchestrator` path (three-tier render, generation abort), and the three entry points (`.`, `/worker/spectrogram.worker`, `/orchestrator`) with what each ships.

### `@dawcore/wam` (`packages/dawcore-wam`)
- **Owner-requested**: the "Custom effects with Faust" CLI workflow now uses the npm route — `npm install -D @shren/faust2wam` + `npx faust2wam lowpass.dsp out/lowpass` — instead of clone-and-run, linking [@shren/faust2wam on npm](https://www.npmjs.com/package/@shren/faust2wam).
- Installation now explains the optional-peer relationship: consumers of `@dawcore/components` must add `@dawcore/wam` to their own dependencies.
- Relative `../dawcore-faust` links → npm package URLs (relative links 404 on npmjs.com); noted that `@dawcore/faust` wraps the same `generate()` the CLI uses; added Examples & Documentation + a previously missing License section.

### `@dawcore/faust` (`packages/dawcore-faust`)
- New "Under the hood: `@shren/faust2wam`" section: consumers do **not** install the compiler themselves (it's a regular dependency of this package); standalone `generate(dspCode, name)` usage for people who want it without the wrapper; and the bundle-size implication — the compiler is a single ~8 MB self-contained ESM bundle (~2.5 MB gzipped, WASM + stdlibs inlined as data URIs), so it must stay behind a dynamic `import()` for chunk isolation, which `compileFaustToWam` handles.
- `@shren/faust2wam` links now point at the npm package; AOT note shows the npm CLI invocation; relative `../dawcore-wam` links → npm URLs; Installation clarifies the optional-peer wiring with `@dawcore/components`; added Examples & Documentation + License sections.

## Not changed
- `website/static/llms.txt` — audited against the README fixes; already current (effects/WAM/Faust/export, transport hooks all described accurately).
- One observation for a possible follow-up (not a README issue): `packages/dawcore/package.json` declares `@dawcore/transport: >=0.0.7` as the peer range, while the master-chain effects API needs `>= 0.0.13` (the README states this requirement explicitly).

## Test plan
- [x] `pnpm -w lint` — 0 errors (READMEs are outside prettier/eslint scope; 357 pre-existing warnings untouched)
- [x] Every documented export grep-verified against each package's `src/index.ts`
- [x] Defaults/attributes verified against `daw-editor.ts`, `daw-track.ts`, `daw-clip.ts`, `transport.ts`, `adapter.ts`
- [x] `connectMasterOutput` version claim verified via git history (shipped in 0.0.13)
- [x] No "coming soon" / "not in this release" / "yet" phrasing remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
