### PR TITLE
fix(website): deploy broken by @shren/faust2wam Node builtins in the webpack graph

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -206,6 +206,12 @@ const config: Config = {
               symlinks: true,
               extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
               alias: {
+                // The website never uses Faust compilation, and
+                // @shren/faust2wam's single dist bundle references Node
+                // builtins (fs, url) that webpack 5 won't polyfill. Keep the
+                // whole ~8MB chain out of the bundle; dawcore reaches it only
+                // through a guarded dynamic import (addFaustEffect).
+                '@dawcore/faust': false,
                 // These packages we transpile from source
                 '@waveform-playlist/browser': path.resolve(__dirname, '../packages/browser/src'),
                 '@waveform-playlist/core': path.resolve(__dirname, '../packages/core/src'),


### PR DESCRIPTION
Main's Deploy Website workflow has been failing since the Faust integration (#446) reached main: webpack follows dawcore's dynamic `import('@dawcore/faust')` into `@shren/faust2wam`, whose dist references Node builtins (`fs`, `url`) that webpack 5 doesn't polyfill.

The website never uses Faust compilation — alias `@dawcore/faust` to `false` in the website webpack config, keeping the ~8MB compiler chain out of the bundle entirely. dawcore reaches it only through a guarded dynamic import with an actionable error message.

**Verified:** `pnpm --filter website build` succeeds locally (previously failed with the two module-not-found errors from the deploy log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)