### PR TITLE
fix(transport): bound non-loop scheduler by play endTime

### DIFF
--- a/packages/transport/src/__tests__/scheduler.test.ts
+++ b/packages/transport/src/__tests__/scheduler.test.ts
@@ -156,4 +156,38 @@ describe('Scheduler (tick-based)', () => {
     scheduler.advance(0);
     expect(listener.consumed.length).toBeGreaterThan(count1);
   });
+
+  it('setPlayEnd: lookahead never generates at or beyond the play-end bound', () => {
+    // Big lookahead so a single advance() would otherwise overshoot far past the bound.
+    const scheduler = createScheduler(10);
+    const listener = createMockListener();
+    scheduler.addListener(listener);
+    scheduler.setPlayEnd(960 as Tick); // bound = tick 960 (events at step 480)
+    scheduler.advance(0);
+    // Ticks 0 and 480 are < 960; the boundary tick 960 (and beyond) is excluded.
+    expect(listener.consumed.map((e) => e.tick)).toEqual([0, 480]);
+  });
+
+  it('setPlayEnd: further advances generate nothing once the bound is reached', () => {
+    const scheduler = createScheduler(10);
+    const listener = createMockListener();
+    scheduler.addListener(listener);
+    scheduler.setPlayEnd(960 as Tick);
+    scheduler.advance(0);
+    const afterFirst = listener.consumed.length;
+    scheduler.advance(1.0);
+    expect(listener.consumed.length).toBe(afterFirst); // nothing past the bound
+  });
+
+  it('setPlayEnd(null) restores unbounded scheduling', () => {
+    const scheduler = createScheduler(10);
+    const listener = createMockListener();
+    scheduler.addListener(listener);
+    scheduler.setPlayEnd(960 as Tick);
+    scheduler.advance(0);
+    const bounded = listener.consumed.length;
+    scheduler.setPlayEnd(null);
+    scheduler.advance(0);
+    expect(listener.consumed.length).toBeGreaterThan(bounded); // generates past 960 again
+  });
 });

--- a/packages/transport/src/core/scheduler.ts
+++ b/packages/transport/src/core/scheduler.ts
@@ -17,6 +17,7 @@ export class Scheduler<T extends SchedulerEvent> {
   private _loopEnabled = false;
   private _loopStart = 0; // integer ticks
   private _loopEnd = 0; // integer ticks
+  private _playEnd: number | null = null; // integer ticks; hard end bound (non-loop)
   private _onLoop:
     | ((loopStartSeconds: number, loopEndSeconds: number, currentTimeSeconds: number) => void)
     | undefined;
@@ -70,6 +71,15 @@ export class Scheduler<T extends SchedulerEvent> {
     this.setLoop(enabled, startTick, endTick);
   }
 
+  /** Hard end bound (ticks) for non-loop playback: the lookahead window never
+   *  generates events at or beyond this tick, so audio (metronome clicks, clips)
+   *  can't be scheduled past the playback end and sound a beat into the next
+   *  (nonexistent) bar. Null = unbounded. Set from Transport.play()'s endTime; the
+   *  loop path is unaffected (loopEnd already bounds it). */
+  setPlayEnd(endTick: Tick | null): void {
+    this._playEnd = endTick == null ? null : Math.round(endTick);
+  }
+
   /** Reset scheduling cursor. Takes seconds (from Clock), converts to ticks. */
   reset(timeSeconds: number): void {
     this._rightEdge = this._tempoMap.secondsToTicks(timeSeconds);
@@ -112,9 +122,12 @@ export class Scheduler<T extends SchedulerEvent> {
       return;
     }
 
-    if (targetTick > this._rightEdge) {
-      this._generateAndConsume(this._rightEdge, targetTick);
-      this._rightEdge = targetTick;
+    // Clamp the lookahead window to the play-end bound so nothing is generated at or
+    // beyond it (generate() uses `tick < toTick`, so the boundary tick is excluded).
+    const bound = this._playEnd !== null && targetTick > this._playEnd ? this._playEnd : targetTick;
+    if (bound > this._rightEdge) {
+      this._generateAndConsume(this._rightEdge, bound);
+      this._rightEdge = bound;
     }
   }
 

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -165,6 +165,9 @@ export class Transport {
     this._scheduler.reset(currentTime);
 
     this._endTime = endTime;
+    this._scheduler.setPlayEnd(
+      endTime !== undefined ? this._tempoMap.secondsToTicks(endTime) : null
+    );
 
     this._clock.start();
 
@@ -209,6 +212,7 @@ export class Transport {
     this._silenceAll();
     this._playing = false;
     this._endTime = undefined;
+    this._scheduler.setPlayEnd(null);
     if (wasPlaying) {
       this._emit('stop');
     }
@@ -233,6 +237,7 @@ export class Transport {
     // Clear stale endTime — seeking past a previous endTime shouldn't
     // cause immediate stop on the next play()
     this._endTime = undefined;
+    this._scheduler.setPlayEnd(null);
 
     // Resume playback only if was playing normally (not counting in)
     if (wasPlaying && !wasCountingIn) {
@@ -789,6 +794,9 @@ export class Transport {
     this._countingIn = true;
     this._playing = true;
     this._endTime = endTime;
+    this._scheduler.setPlayEnd(
+      endTime !== undefined ? this._tempoMap.secondsToTicks(endTime) : null
+    );
 
     const playPositionTick = this._tempoMap.secondsToTicks(currentTime);
     const meter = this._meterMap.getMeter(playPositionTick);


### PR DESCRIPTION
## Problem

`Transport.play(0, endTime)` (one-pass playback with auto-stop) could sound a metronome click — or clip audio — a beat **into the next bar**, past the playback end.

The Timer stops playback when `time >= endTime`, but the scheduler's **non-loop** path generates events up to `time + lookahead` (~200ms) with **no `endTime` clamp** (`scheduler.ts`). So the boundary downbeat is scheduled ~200ms early via `source.start(when)`, and by the time `stop()`→`silence()` runs it has already started — an audible phantom downbeat. The **loop** path was already bounded by `loopEnd`, which is why looping / continuous playback (e.g. the metronome example) never showed this.

Reproduced in a downstream app (sight-reading metronome): a 1-bar 4/4 exercise sounded 9 clicks (4 count-in + 4 in-bar + **1 phantom** next-bar downbeat) instead of 8.

## Fix

- Add `Scheduler.setPlayEnd(endTick: Tick | null)` — a hard end bound for non-loop playback.
- Clamp the non-loop `advance()` window to it, so nothing is generated at/beyond the end. `generate()` uses `tick < toTick`, so the boundary tick is excluded (the last in-bar beat still fires; the next-bar downbeat never does).
- Wire it from `Transport` `play()` / `stop()` / `seek()` / count-in, alongside `_endTime`.
- Loop path unchanged (`loopEnd` already bounds it).

Now nothing — metronome **or** clip audio — is scheduled past the playback end; no race with `stop()`.

## Test plan
- [x] Scheduler unit tests **12/12** (3 new: bound excludes boundary tick + beyond; no generation once bound reached; `setPlayEnd(null)` restores unbounded)
- [x] Full transport suite **259/259** (count-in, loop, metronome-player unaffected)
- [x] `tsc --noEmit` clean · `tsup` build OK