### PR TITLE
chore(deps): override joi to 17.13.4 (Dependabot #245)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "pnpm": {
     "overrides": {
+      "joi@<17.13.4": "17.13.4",
       "serialize-javascript@<7.0.5": "7.0.5",
       "uuid@<11.1.1": "^11.1.1",
       "webpack": "5.104.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  joi@<17.13.4: 17.13.4
   serialize-javascript@<7.0.5: 7.0.5
   uuid@<11.1.1: ^11.1.1
   webpack: 5.104.1
@@ -4205,7 +4206,7 @@ packages:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 17.13.4
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-helmet-async: /@slorber/react-helmet-async@1.3.0(react-dom@19.2.7)(react@19.2.7)
@@ -4240,7 +4241,7 @@ packages:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 17.13.4
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-helmet-async: /@slorber/react-helmet-async@1.3.0(react-dom@19.2.7)(react@19.2.7)
@@ -4275,7 +4276,7 @@ packages:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 17.13.4
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-helmet-async: /@slorber/react-helmet-async@1.3.0(react-dom@19.2.7)(react@19.2.7)
@@ -4309,7 +4310,7 @@ packages:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 17.13.4
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-helmet-async: /@slorber/react-helmet-async@1.3.0(react-dom@19.2.7)(react@19.2.7)
@@ -4438,7 +4439,7 @@ packages:
       '@docusaurus/utils': 3.10.1(postcss@8.5.15)(react-dom@19.2.7)(react@19.2.7)
       '@docusaurus/utils-common': 3.10.1(postcss@8.5.15)(react-dom@19.2.7)(react@19.2.7)
       fs-extra: 11.3.5
-      joi: 17.13.3
+      joi: 17.13.4
       js-yaml: 4.2.0
       lodash: 4.18.1
       tslib: 2.8.1
@@ -4469,7 +4470,7 @@ packages:
       '@docusaurus/utils': 3.9.2(postcss@8.5.15)(react-dom@19.2.7)(react@19.2.7)
       '@docusaurus/utils-common': 3.9.2(postcss@8.5.15)(react-dom@19.2.7)(react@19.2.7)
       fs-extra: 11.3.5
-      joi: 17.13.3
+      joi: 17.13.4
       js-yaml: 4.2.0
       lodash: 4.18.1
       tslib: 2.8.1
@@ -12643,8 +12644,8 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  /joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+  /joi@17.13.4:
+    resolution: {integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==}
     dependencies:
       '@hapi/hoek': 9.3.0
       '@hapi/topo': 5.1.0


### PR DESCRIPTION
## Problem

Dependabot flagged two transitive-dependency alerts on `main`:

- **#245 (medium)** — `joi <17.13.4` ([GHSA-q7cg-457f-vx79](https://github.com/advisories/GHSA-q7cg-457f-vx79)): uncaught `RangeError` on deeply nested input via recursive `link()` schemas. Pulled in only by `@docusaurus/types` (website build tooling).
- **#244 (low)** — `esbuild >=0.27.3 <0.28.1` ([GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr)): arbitrary file read via esbuild's dev server on Windows. Transitive dev dep of `tsup`/`vite`/`vitest`.

## Fix

**joi** → forced to the patched `17.13.4` via `pnpm.overrides` (same pattern as the existing `serialize-javascript`/`uuid` entries). It's a same-minor patch that satisfies Docusaurus's range; the lockfile now resolves a single `joi@17.13.4` everywhere.

**esbuild** → **intentionally left open** (no code change):
- Dev-only dependency — never shipped to consumers.
- The vulnerability is **Windows-only**; development happens on macOS.
- The vulnerable code path is esbuild's own `serve` HTTP dev server, which `tsup` (bundling) and `vite` (transforms) don't invoke.
- No clean upstream bump exists — `vite@7.3.5` and `tsup@8.5.1` (latest) both pin `esbuild: ^0.27.0`, so forcing 0.28.1 would be an unsupported override. The alert will clear on a routine dep bump once the tooling adopts esbuild 0.28.

## Test plan
- [x] `pnpm install` clean — lockfile resolves only `joi@17.13.4`
- [x] `pnpm --filter website build` green (joi is Docusaurus's config validator)