### PR TITLE
docs(claude): record Rspack bundler + Dependabot workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ pnpm publish --filter @waveform-playlist/NEW-PACKAGE --no-git-checks --access pu
 - **Lint**: `pnpm lint` - Prettier check + ESLint across all packages. **Always run before committing.** This is a root-only script; run from repo root or use `pnpm -w lint`. Fix formatting issues with `pnpm format`.
 - **`examples/**/*.html` are outside lint scope** — `pnpm lint` only covers `packages/**/src/**/*.{ts,tsx}`; prettier flags every example HTML file if run on them directly. Match the existing file style by hand, don't reformat them.
 - **New packages**: After adding a new `packages/*/package.json`, run `pnpm install` and commit `pnpm-lock.yaml`. CI uses `--frozen-lockfile` and will fail if the lockfile is stale.
+- **Transitive Dependabot alerts**: try `pnpm update -r <pkg>...` first (refreshes the lockfile within parents' existing ranges) before adding a `pnpm.overrides` entry — most alerts are just stale lockfile patches the parent range already allows. Reserve overrides for a version an intermediary pins *below* the fix (forced; may break upstream's tested range, e.g. js-yaml 3.x via gray-matter).
 - **Dev server**: `pnpm --filter website start` - Docusaurus dev server
 - **Example: dawcore-native**: `pnpm example:dawcore-native` — Vite dev server at localhost:5173 (Vite falls back to next free port when 5173 is taken; check the server's startup log for the actual URL)
 - **Example: dawcore-tone**: `pnpm example:dawcore-tone` — Vite dev server at localhost:5174 (same fallback behavior — log shows the actual port)

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -37,6 +37,7 @@ When a hero section uses `min-height: 100vh` + `align-items: center` and an elem
 - CSS calc warnings during build are pre-existing and harmless
 - Dev server: `pnpm --filter website start`
 - Build: `pnpm --filter website build`
+- **Bundler is Rspack** (Docusaurus 3.10.1 + `@docusaurus/faster`; the `future: { v4: true }` flag selects it). The `configureWebpack` hook — `babel-loader` source-transpilation + `resolve.alias` (incl. `'@dawcore/faust': false`) — works verbatim under Rspack; no config changes. Storybook (`ui-components`, `@storybook/react-webpack5`) still uses webpack — two bundlers in the monorepo, so webpack can't be removed.
 
 ## Custom Pages
 
@@ -58,6 +59,7 @@ Each example page should have OG/Twitter meta tags with a social image. Pattern:
 - Do NOT add `@docusaurus/module-type-aliases` to `tsconfig.json` `compilerOptions.types` — its `Layout` type only has `children` (no `title`/`description`), overriding our more complete local declarations
 - When adding new Docusaurus virtual module imports, add the type declaration to `docusaurus.d.ts`
 - 3 pre-existing `DefaultTheme` errors from browser package source (styled-components augmentation not picked up via webpack aliases) — these are expected
+- `pnpm --filter website typecheck` is NOT in CI (root `typecheck`/`build` cover only `./packages/*`) and has pre-existing module-resolution errors (`@waveform-playlist/midi`/`spectrogram`, Tone `BitCrusher`) — it relies on bundler aliases, not tsconfig paths. Don't chase these.
 
 ## Static Media Assets
 


### PR DESCRIPTION
Session learnings from the Docusaurus/Rspack migration and Dependabot cleanup (#504, #505, #506).

## Root `CLAUDE.md`
- **Transitive Dependabot alerts**: prefer `pnpm update -r <pkg>...` (lockfile refresh within existing ranges) over `pnpm.overrides` — most alerts are stale lockfile patches the parent range already allows. Reserve overrides for versions an intermediary pins below the fix.

## `website/CLAUDE.md`
- **Bundler is now Rspack** (Docusaurus 3.10.1 + `@docusaurus/faster`; `future.v4` selects it). `configureWebpack` + `babel-loader` + `resolve.alias` work verbatim under Rspack. Storybook still uses webpack — two bundlers, webpack not removable.
- `pnpm --filter website typecheck` isn't CI-gated and has pre-existing module-resolution errors — don't chase them.

Docs-only; no code or CI impact.