### PR TITLE
fix: publish cross-package peer deps as caret ranges (fixes ERESOLVE between browser + annotations)

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/annotations",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Annotation support for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "@dnd-kit/react": "^0.3.0",
-    "@waveform-playlist/browser": "workspace:*",
+    "@waveform-playlist/browser": "workspace:^",
     "react": "^18.0.0",
     "styled-components": "^6.0.0"
   }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/browser",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Browser bundle for waveform-playlist with React",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -68,8 +68,8 @@
     "@dnd-kit/abstract": "^0.3.0",
     "@dnd-kit/dom": "^0.3.0",
     "@dnd-kit/react": "^0.3.0",
-    "@waveform-playlist/annotations": "workspace:*",
-    "@waveform-playlist/recording": "workspace:*",
+    "@waveform-playlist/annotations": "workspace:^",
+    "@waveform-playlist/recording": "workspace:^",
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0",
     "styled-components": "^6.0.0",

--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/spectrogram",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "description": "React Provider + UI for spectrograms — wraps @dawcore/spectrogram",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -59,7 +59,7 @@
     "@waveform-playlist/core": "workspace:*"
   },
   "peerDependencies": {
-    "@waveform-playlist/browser": "workspace:*",
+    "@waveform-playlist/browser": "workspace:^",
     "react": "^18.0.0",
     "styled-components": "^6.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.2(react-dom@19.2.7)(react@19.2.7)
       '@waveform-playlist/annotations':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../annotations
       '@waveform-playlist/core':
         specifier: workspace:*
@@ -117,7 +117,7 @@ importers:
         specifier: workspace:*
         version: link:../playout
       '@waveform-playlist/recording':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../recording
       '@waveform-playlist/ui-components':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

Installing `@waveform-playlist/browser` **and** `@waveform-playlist/annotations` together from npm fails with `ERESOLVE`:

```
Conflicting peer dependency: @waveform-playlist/browser@13.1.0
  peer @waveform-playlist/browser@"13.1.0" from @waveform-playlist/annotations@12.0.1
  but the root project requested @waveform-playlist/browser@13.1.1
```

## Root cause

Cross-package `peerDependencies` are declared as **`workspace:*`**. pnpm rewrites `workspace:*` to the **exact** current version at publish time, so the published metadata ended up mutually unsatisfiable:

| Package | Published peer | 
|---|---|
| `annotations@12.0.1` | `@waveform-playlist/browser: 13.1.0` (exact) |
| `browser@13.1.1` | `@waveform-playlist/annotations: 12.0.1` (exact) |

`annotations@12.0.1` was published when `browser` was `13.1.0`; `browser` was then patch-bumped to `13.1.1` without re-publishing `annotations`. The two exact pins now disagree, and no install of the latest pair can satisfy both.

## Fix

Declare the cross-`@waveform-playlist` **peerDependencies** as **`workspace:^`** instead of `workspace:*`. pnpm rewrites `workspace:^` to a **caret range** (e.g. `^13.1.x`), which patch releases satisfy — so a sibling patch bump never re-breaks consumers again.

Changed peer deps:
- `annotations` → `browser`
- `browser` → `annotations`, `recording`
- `spectrogram` → `browser`

(Only `peerDependencies` are touched; hard `dependencies`/`devDependencies` exact pins are left as-is.)

## Version bumps (for republish)

The fix only reaches consumers once the packages are re-published, so each affected package gets a patch bump:

- `@waveform-playlist/annotations` `12.0.1` → `12.0.2`
- `@waveform-playlist/browser` `13.1.1` → `13.1.2`
- `@waveform-playlist/spectrogram` `13.0.2` → `13.0.3`

## Lockfile

`pnpm-lock.yaml` is updated **surgically** — only the two affected specifier lines (browser's `annotations`/`recording` peers) — so `pnpm install --frozen-lockfile` stays green **without** reverting the committed Dependabot lockfile patches. Verified locally:

```
$ pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date
```

## Publish checklist (after merge)

```
pnpm -r build          # or per affected package
pnpm publish --filter @waveform-playlist/annotations
pnpm publish --filter @waveform-playlist/browser
pnpm publish --filter @waveform-playlist/spectrogram
```

## Why now

Surfaced while upgrading a downstream app (mimikaki) from the `5.2.0-next` line to the current `13.x` release — the `ERESOLVE` blocks a clean `npm install` of `browser@13.1.x` + `annotations@12.0.x`.
