### PR TITLE
fix: make useAnnotationKeyboardControls usable without WaveformPlaylistProvider (+ regression guards)

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/browser",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Browser bundle for waveform-playlist with React",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -49,6 +49,7 @@
     "@types/node": "^20.19.42",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
+    "jsdom": "^28.1.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.6"

--- a/packages/browser/src/WaveformPlaylistContext.tsx
+++ b/packages/browser/src/WaveformPlaylistContext.tsx
@@ -1778,3 +1778,11 @@ export const usePlaylistData = () => {
   }
   return context;
 };
+
+/**
+ * Like {@link usePlaylistData} but returns `null` instead of throwing when there
+ * is no WaveformPlaylistProvider ancestor. Use this in hooks/components that may
+ * also run in the MediaElement path (MediaElementPlaylistProvider), where the
+ * WebAudio playlist context is absent.
+ */
+export const usePlaylistDataOptional = () => useContext(PlaylistDataContext);

--- a/packages/browser/src/__tests__/jsdom-polyfills.ts
+++ b/packages/browser/src/__tests__/jsdom-polyfills.ts
@@ -1,0 +1,13 @@
+// Minimal browser globals that jsdom omits but the waveform-playlist render graph
+// references at module-load time (e.g. @dnd-kit/dom's ResizeNotifier). Imported
+// FIRST in tests that pull in WaveformPlaylistContext so these exist before the
+// transitive module graph evaluates.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof (globalThis as Record<string, unknown>).ResizeObserver === 'undefined') {
+  (globalThis as Record<string, unknown>).ResizeObserver = ResizeObserverStub;
+}

--- a/packages/browser/src/__tests__/peerDependencies.test.ts
+++ b/packages/browser/src/__tests__/peerDependencies.test.ts
@@ -1,0 +1,39 @@
+// Guard against the `workspace:*` peer-dependency footgun.
+//
+// pnpm rewrites `workspace:*` to the EXACT current version of the sibling package
+// at publish time. For PEER dependencies between sibling packages that produces
+// mutually-unsatisfiable exact pins (e.g. annotations@x pinning browser==13.1.0
+// while browser@y pins annotations==12.0.1), which breaks `npm install` for
+// downstream consumers with ERESOLVE.
+//
+// Cross-package peerDependencies must therefore use a RANGE (`workspace:^` or
+// `workspace:~`), never `workspace:*`.
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// packages/browser/src/__tests__ -> packages/
+const packagesDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function findExactWorkspacePeerPins(): string[] {
+  const offenders: string[] = [];
+  for (const pkg of readdirSync(packagesDir)) {
+    const pkgJsonPath = join(packagesDir, pkg, 'package.json');
+    if (!existsSync(pkgJsonPath)) continue;
+    const json = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+    const peers: Record<string, string> = json.peerDependencies ?? {};
+    for (const [dep, range] of Object.entries(peers)) {
+      if (range === 'workspace:*') {
+        offenders.push(`${json.name} → peerDependencies["${dep}"]: ${range}`);
+      }
+    }
+  }
+  return offenders;
+}
+
+describe('cross-package peerDependencies', () => {
+  it('never use `workspace:*` (use `workspace:^` so they publish as ranges)', () => {
+    expect(findExactWorkspacePeerPins()).toEqual([]);
+  });
+});

--- a/packages/browser/src/__tests__/useAnnotationKeyboardControls.context.test.ts
+++ b/packages/browser/src/__tests__/useAnnotationKeyboardControls.context.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+//
+// Regression test for the MediaElement path.
+//
+// useAnnotationKeyboardControls is a general-purpose annotation keyboard hook and
+// must work WITHOUT a WaveformPlaylistProvider (e.g. inside MediaElementPlaylistProvider).
+// A v11 refactor made it call usePlaylistData() unconditionally to read
+// samplesPerPixel/sampleRate, which THROWS outside WaveformPlaylistProvider — crashing
+// every MediaElement consumer that uses keyboard annotation controls.
+//
+// Rendered via react-dom/server because the throw happens during the render phase
+// (no DOM needed; useKeyboardShortcuts only touches window inside an effect).
+import './jsdom-polyfills'; // must be first — sets globals the import graph needs
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { useAnnotationKeyboardControls } from '../hooks/useAnnotationKeyboardControls';
+
+const annotations = [
+  { id: 'a', start: 0, end: 1, lines: ['one'] },
+  { id: 'b', start: 1, end: 2, lines: ['two'] },
+];
+
+// Render the hook with NO WaveformPlaylistProvider and capture its return value.
+function renderHookOutsideProvider(overrides: Record<string, unknown> = {}) {
+  let api: ReturnType<typeof useAnnotationKeyboardControls> | undefined;
+  function Harness() {
+    api = useAnnotationKeyboardControls({
+      annotations,
+      activeAnnotationId: 'a',
+      onAnnotationsChange: () => {},
+      duration: 10,
+      linkEndpoints: false,
+      // MediaElement consumers pass these explicitly (no WaveformPlaylist context):
+      samplesPerPixel: 1000,
+      sampleRate: 44100,
+      ...overrides,
+    });
+    return null;
+  }
+  renderToString(createElement(Harness));
+  return api!;
+}
+
+describe('useAnnotationKeyboardControls without WaveformPlaylistProvider (MediaElement path)', () => {
+  it('does not throw during render when no WaveformPlaylistProvider is present', () => {
+    expect(() => renderHookOutsideProvider()).not.toThrow();
+  });
+
+  it('navigation still works without the provider', () => {
+    const onActiveAnnotationChange = vi.fn();
+    const api = renderHookOutsideProvider({ onActiveAnnotationChange });
+    api.selectNext();
+    expect(onActiveAnnotationChange).toHaveBeenCalledWith('b');
+  });
+});

--- a/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
+++ b/packages/browser/src/hooks/useAnnotationKeyboardControls.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useEffect } from 'react';
 import type { AnnotationData } from '@waveform-playlist/core';
-import { usePlaylistData } from '../WaveformPlaylistContext';
+import { usePlaylistDataOptional } from '../WaveformPlaylistContext';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 
 const LINK_THRESHOLD = 0.01; // Consider edges "linked" if within 10ms
@@ -21,6 +21,14 @@ interface UseAnnotationKeyboardControlsOptions {
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
   /** Optional: callback to start playback at a time with optional duration */
   onPlay?: (startTime: number, duration?: number) => void;
+  /**
+   * Pixels-per-sample for auto-scroll positioning. Falls back to the
+   * WaveformPlaylistProvider context when omitted (WebAudio path). Pass
+   * explicitly when used outside that provider (e.g. the MediaElement path).
+   */
+  samplesPerPixel?: number;
+  /** Sample rate for auto-scroll positioning. Falls back to context. */
+  sampleRate?: number;
 }
 
 /**
@@ -65,8 +73,16 @@ export function useAnnotationKeyboardControls({
   enabled = true,
   scrollContainerRef,
   onPlay,
+  samplesPerPixel: samplesPerPixelProp,
+  sampleRate: sampleRateProp,
 }: UseAnnotationKeyboardControlsOptions) {
-  const { samplesPerPixel, sampleRate } = usePlaylistData();
+  // Auto-scroll positioning needs samplesPerPixel/sampleRate. Prefer explicit
+  // props (works in the MediaElement path); otherwise read them from the
+  // WaveformPlaylistProvider context when present. usePlaylistDataOptional()
+  // returns null instead of throwing, so this hook is safe outside that provider.
+  const playlistData = usePlaylistDataOptional();
+  const samplesPerPixel = samplesPerPixelProp ?? playlistData?.samplesPerPixel;
+  const sampleRate = sampleRateProp ?? playlistData?.sampleRate;
 
   const activeIndex = useMemo(() => {
     if (!activeAnnotationId) return -1;

--- a/packages/browser/src/index.tsx
+++ b/packages/browser/src/index.tsx
@@ -12,6 +12,7 @@ export {
   usePlaylistState,
   usePlaylistControls,
   usePlaylistData,
+  usePlaylistDataOptional,
 } from './WaveformPlaylistContext';
 export type { WaveformTrack, TrackState, FrameData } from './WaveformPlaylistContext';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.31)
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.41)(postcss@8.5.15)(typescript@5.9.3)


### PR DESCRIPTION
## Problem

`useAnnotationKeyboardControls` crashes any **MediaElement** consumer
(`MediaElementPlaylistProvider`) the moment it's used:

```
Error: usePlaylistData must be used within WaveformPlaylistProvider
  at usePlaylistData (WaveformPlaylistContext.tsx:1777)
  at useAnnotationKeyboardControls (useAnnotationKeyboardControls.ts:69)
```

The v11 "read `sampleRate` from context, not props" refactor changed the hook to call
`usePlaylistData()` unconditionally. That hook **throws** outside
`WaveformPlaylistProvider` — but `useAnnotationKeyboardControls` is a general-purpose
annotation-keyboard hook also used in the MediaElement path (which has no WebAudio
playlist context). It previously took `samplesPerPixel`/`sampleRate` as props, so the
refactor was a silent breaking change for MediaElement consumers.

`samplesPerPixel`/`sampleRate` are only used for **optional auto-scroll** positioning
(both call sites guard with `if (!samplesPerPixel || !sampleRate) return`), so the hard
dependency on the WebAudio context was unnecessary.

## Fix

- **`usePlaylistDataOptional()`** — new accessor that returns `null` instead of throwing
  when there's no `WaveformPlaylistProvider`. Exported for MediaElement-path consumers.
- **`useAnnotationKeyboardControls`** again accepts optional `samplesPerPixel`/`sampleRate`
  props (restoring the pre-v11 API), falling back to the WaveformPlaylist context when
  omitted. Navigation and boundary editing (which use `duration`, a prop) work in both
  paths; only auto-scroll needs the sample geometry, and it degrades gracefully.

Backward compatible: WebAudio consumers that pass nothing still read from context.

## Regression tests (browser package)

1. **`useAnnotationKeyboardControls.context.test.ts`** — renders the hook with **no**
   `WaveformPlaylistProvider` (via `react-dom/server`) and asserts it (a) doesn't throw
   and (b) still navigates (`selectNext` → `onActiveAnnotationChange`). This fails on
   `main` with the exact crash above.
2. **`peerDependencies.test.ts`** — scans every package and fails if any
   `peerDependencies` entry uses `workspace:*` (the exact-pin footgun fixed in #508),
   enforcing `workspace:^`. Verified it goes red when a `workspace:*` peer is reintroduced.

Adds `jsdom` as a browser devDep (already used by the `spectrogram` package) for the
hook render test; a small `jsdom-polyfills` shim supplies `ResizeObserver` for the
import graph.

## Version

Bumps `@waveform-playlist/browser` `13.1.2` → `13.1.3` (also publicly exports
`usePlaylistDataOptional`).

## Why now

Surfaced upgrading a downstream app (mimikaki) to 13.x — its main player uses
`useAnnotationKeyboardControls` inside `MediaElementPlaylistProvider` and crashed on mount.
