### PR TITLE
docs(examples): MediaElement-only React starter (no playout/tone) (#510)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,11 @@ When a `@waveform-playlist/*` package has framework-agnostic logic (parsing, com
 - `examples/dawcore-native/` — Web components + NativePlayoutAdapter (moved from `packages/dawcore/dev/`)
 - `examples/dawcore-tone/` — Web components + TonePlayoutAdapter (Tone.js backend)
 - `examples/dawcore-wam/` — WAM 2.0 plugins end-to-end: community-library picker, GUIs, localStorage persistence, WAV export, plus in-browser Faust compilation (textarea → `addFaustEffect`). `@dawcore/wam` and `@dawcore/faust` are source-aliased (pure TS, no Lit decorators), which also resolves dawcore's dynamic imports of both
+- `examples/media-element-player/` — React `MediaElementPlaylistProvider` starter; depends on only `@waveform-playlist/browser` + `@waveform-playlist/media-element-playout` (no `playout`/`tone`). First React example here — see the React-example note below.
+
+**Adding a React example (not a web-component HTML page):** it must be a pnpm workspace member — add `examples/*` to `pnpm-workspace.yaml` and give the example a `package.json`, or `react`/`react-dom`/`styled-components` won't resolve (the dawcore examples sidestep this by not using React). In `vite.config.ts`: source-alias `@waveform-playlist/browser` (its `index.tsx` entry is engine-free, so the dev server never resolves `tone`/`playout`) AND set `resolve.dedupe: ['react', 'react-dom', 'styled-components']` — without dedupe the aliased packages load a second React copy → "Invalid hook call". `@dnd-kit/*` are *required* `browser` peers (they tree-shake out of a MediaElement-only bundle but must be installed). examples/ are outside `build`/`lint`/`typecheck` (all `packages/*`-only), so example `.tsx` isn't CI-checked.
+
+**Verify an example actually renders with a headless browser** (Playwright/chrome-devtools MCP), not curl — Vite serving modules `200` proves they *transform*, not that the React app *mounts* (duplicate-React "Invalid hook call" only appears at render). `curl` was also flaky in the shell tool; prefer the MCP browser or `node`'s http.
 
 ### ESLint Baseline
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,12 @@ Run the examples locally:
 pnpm example:dawcore-native  # Native Web Audio — localhost:5173
 pnpm example:dawcore-tone    # Tone.js backend — localhost:5174
 pnpm example:dawcore-wam     # WAM 2.0 plugins + Faust — localhost:5175
+pnpm example:media-element   # MediaElement-only React starter (no Tone) — localhost:5176
 ```
+
+The **[media-element-player](examples/media-element-player/)** starter is a minimal React
+single-track player using only `@waveform-playlist/browser` + `@waveform-playlist/media-element-playout`
+(no `@waveform-playlist/playout`, no `tone`) — see its [README](examples/media-element-player/README.md).
 
 **dawcore-native** example pages:
 

--- a/examples/media-element-player/README.md
+++ b/examples/media-element-player/README.md
@@ -1,0 +1,59 @@
+# MediaElement starter
+
+A minimal **single-track audio player** built on `MediaElementPlaylistProvider` —
+waveform, transport, and **pitch-preserving playback speed** (0.5×–2×).
+
+The point of this example is the dependency list. It uses **only**:
+
+- `@waveform-playlist/browser`
+- `@waveform-playlist/media-element-playout`
+- `react`, `react-dom`, `styled-components`
+
+There is **no `@waveform-playlist/playout` and no `tone`** — the MediaElement
+playback path (`HTMLAudioElement`, no Web Audio graph) needs neither. As of
+v14 those engines are optional peer dependencies, so a MediaElement-only app
+never installs or bundles them. (`@dnd-kit/*` are required peers of `browser`
+for its editing path; they tree-shake out of a MediaElement-only bundle.)
+
+## Run it (in this repo)
+
+```bash
+pnpm install
+pnpm example:media-element     # → http://localhost:5176
+```
+
+The dev server resolves the workspace packages from source (see `vite.config.ts`),
+so edits to the library are picked up without a rebuild. Audio + pre-computed
+`.dat` peaks are served from `website/static`.
+
+## What it shows
+
+- `loadWaveformData(peaksSrc)` → a `MediaElementTrackConfig` (`{ source, waveformData, name }`).
+- `MediaElementPlaylistProvider` + `MediaElementWaveform` for rendering.
+- The four context hooks: `useMediaElementAnimation`, `useMediaElementState`,
+  `useMediaElementControls`, `useMediaElementData`.
+- Pitch-preserving rate control + a preserve-pitch toggle.
+- The v14 `onError` prop surfacing init failures (e.g. a missing peer) in the UI.
+
+## Using it in your own app
+
+Install only what the MediaElement path needs:
+
+```bash
+npm install @waveform-playlist/browser @waveform-playlist/media-element-playout \
+  @dnd-kit/abstract @dnd-kit/dom @dnd-kit/react react react-dom styled-components
+```
+
+A standalone (non-monorepo) `vite.config.ts` is just the standard React setup —
+no source aliases needed, since you import the published packages:
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({ plugins: [react()] });
+```
+
+Copy `index.html` and `src/` as-is; point `AUDIO_SRC` / `PEAKS_SRC` in `src/App.tsx`
+at your own audio file and its pre-computed peaks (generate `.dat`/`.json` with
+[audiowaveform](https://github.com/bbc/audiowaveform) or the `waveform-data` library).

--- a/examples/media-element-player/index.html
+++ b/examples/media-element-player/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Waveform Playlist — MediaElement starter</title>
+  </head>
+  <body style="margin: 0; background: #16161e">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/media-element-player/package.json
+++ b/examples/media-element-player/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@waveform-playlist/example-media-element-player",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "MediaElement-only starter — single-track player with pitch-preserving speed, no Tone.js / no @waveform-playlist/playout.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@waveform-playlist/browser": "workspace:*",
+    "@waveform-playlist/media-element-playout": "workspace:*",
+    "@dnd-kit/abstract": "^0.3.0",
+    "@dnd-kit/dom": "^0.3.0",
+    "@dnd-kit/react": "^0.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "styled-components": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/media-element-player/src/App.tsx
+++ b/examples/media-element-player/src/App.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import {
+  MediaElementPlaylistProvider,
+  MediaElementWaveform,
+  loadWaveformData,
+  type MediaElementTrackConfig,
+} from '@waveform-playlist/browser';
+import { Controls } from './Controls';
+
+// Audio + pre-computed `.dat` peaks, served from website/static (Vite publicDir).
+const AUDIO_SRC = '/media/audio/AlbertKader_Ubiquitous/08_Bass.opus';
+const PEAKS_SRC = '/media/audio/AlbertKader_Ubiquitous/08_Bass.dat';
+
+const Page = styled.div`
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  color: #e6e6ea;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+`;
+
+const Header = styled.header`
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0 0 0.4rem;
+    color: #d08070;
+    font-size: 1.5rem;
+    letter-spacing: 0.02em;
+  }
+  p {
+    margin: 0;
+    color: #9a9aa6;
+    font-size: 0.95rem;
+  }
+  code {
+    font-family: 'Courier New', monospace;
+    color: #c49a6c;
+  }
+`;
+
+const Banner = styled.div`
+  padding: 0.9rem 1.1rem;
+  border: 1px solid #d08070;
+  border-radius: 0.5rem;
+  background: rgba(208, 128, 112, 0.12);
+  color: #f0c4bb;
+  font-size: 0.9rem;
+`;
+
+const Status = styled.div`
+  padding: 2rem;
+  text-align: center;
+  color: #9a9aa6;
+`;
+
+export function App() {
+  const [track, setTrack] = useState<MediaElementTrackConfig | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [preservesPitch, setPreservesPitch] = useState(true);
+
+  // Load the pre-computed waveform peaks once, then build the single-track config.
+  useEffect(() => {
+    let cancelled = false;
+    loadWaveformData(PEAKS_SRC)
+      .then((waveformData) => {
+        if (!cancelled) {
+          setTrack({ source: AUDIO_SRC, waveformData, name: 'Bass — AlbertKader “Ubiquitous”' });
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError('Failed to load waveform data: ' + String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Page>
+      <Header>
+        <h1>MediaElement starter</h1>
+        <p>
+          Single-track playback with pitch-preserving speed — no <code>tone</code>, no{' '}
+          <code>@waveform-playlist/playout</code>.
+        </p>
+      </Header>
+
+      {error && <Banner role="alert">{error}</Banner>}
+
+      {!error && !track && <Status>Loading waveform…</Status>}
+
+      {!error && track && (
+        <MediaElementPlaylistProvider
+          track={track}
+          samplesPerPixel={512}
+          waveHeight={140}
+          preservesPitch={preservesPitch}
+          barWidth={2}
+          barGap={0}
+          timescale
+          // New in v14: surface playout-init failures (e.g. a missing peer) to the UI.
+          onError={(err) => setError('Playout init failed: ' + err.message)}
+        >
+          <Controls preservesPitch={preservesPitch} onPreservesPitchChange={setPreservesPitch} />
+          <MediaElementWaveform />
+        </MediaElementPlaylistProvider>
+      )}
+    </Page>
+  );
+}

--- a/examples/media-element-player/src/Controls.tsx
+++ b/examples/media-element-player/src/Controls.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import {
+  useMediaElementAnimation,
+  useMediaElementState,
+  useMediaElementControls,
+  useMediaElementData,
+} from '@waveform-playlist/browser';
+
+const SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+function formatTime(seconds: number): string {
+  if (!isFinite(seconds) || isNaN(seconds)) return '0:00';
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+const Bar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 0.75rem;
+  background: #1f1f2b;
+  border: 1px solid #2c2c3a;
+  border-radius: 0.5rem;
+`;
+
+const Group = styled.div`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+`;
+
+const Button = styled.button<{ $active?: boolean }>`
+  padding: 0.45rem 0.8rem;
+  border: 1px solid ${(p) => (p.$active ? '#63C75F' : '#3a3a4a')};
+  border-radius: 0.3rem;
+  background: ${(p) => (p.$active ? '#63C75F' : '#26263340')};
+  color: ${(p) => (p.$active ? '#16161e' : '#e6e6ea')};
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: #63c75f;
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;
+
+const Label = styled.span`
+  font-size: 0.8rem;
+  color: #9a9aa6;
+`;
+
+const Time = styled.span`
+  font-family: 'Courier New', monospace;
+  font-size: 0.95rem;
+  color: #c49a6c;
+  min-width: 96px;
+  text-align: center;
+`;
+
+interface ControlsProps {
+  preservesPitch: boolean;
+  onPreservesPitchChange: (value: boolean) => void;
+}
+
+export function Controls({ preservesPitch, onPreservesPitchChange }: ControlsProps) {
+  const { isPlaying, currentTimeRef } = useMediaElementAnimation();
+  const { playbackRate } = useMediaElementState();
+  const { play, pause, stop, setPlaybackRate } = useMediaElementControls();
+  const { duration } = useMediaElementData();
+
+  // `currentTime` (React state) only updates on pause/stop/seek/end. For a smooth
+  // readout during playback, drive a DOM ref from `currentTimeRef` via rAF.
+  const timeRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      if (timeRef.current) {
+        timeRef.current.textContent = `${formatTime(currentTimeRef.current ?? 0)} / ${formatTime(duration)}`;
+      }
+      if (isPlaying) raf = requestAnimationFrame(tick);
+    };
+    if (isPlaying) raf = requestAnimationFrame(tick);
+    else tick();
+    return () => cancelAnimationFrame(raf);
+  }, [isPlaying, currentTimeRef, duration]);
+
+  return (
+    <Bar>
+      <Group>
+        <Button onClick={() => play()} disabled={isPlaying}>
+          ▶ Play
+        </Button>
+        <Button onClick={() => pause()} disabled={!isPlaying}>
+          ⏸ Pause
+        </Button>
+        <Button onClick={() => stop()}>⏹ Stop</Button>
+      </Group>
+
+      <Time ref={timeRef}>
+        {formatTime(currentTimeRef.current ?? 0)} / {formatTime(duration)}
+      </Time>
+
+      <Group>
+        <Label>Speed</Label>
+        {SPEEDS.map((rate) => (
+          <Button key={rate} $active={playbackRate === rate} onClick={() => setPlaybackRate(rate)}>
+            {rate}×
+          </Button>
+        ))}
+      </Group>
+
+      <Group>
+        <Label>Preserve pitch</Label>
+        <Button $active={preservesPitch} onClick={() => onPreservesPitchChange(true)}>
+          On
+        </Button>
+        <Button $active={!preservesPitch} onClick={() => onPreservesPitchChange(false)}>
+          Off
+        </Button>
+      </Group>
+    </Bar>
+  );
+}

--- a/examples/media-element-player/src/main.tsx
+++ b/examples/media-element-player/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/examples/media-element-player/tsconfig.json
+++ b/examples/media-element-player/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/media-element-player/vite.config.ts
+++ b/examples/media-element-player/vite.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+
+// MediaElement-only starter (issue #510). Resolves the workspace packages from
+// source so the dev page reflects edits without a rebuild. Note what is ABSENT:
+// there is NO alias for `@waveform-playlist/playout` and NO `tone` — the
+// MediaElement playback path needs neither. That is the whole point of this
+// example. (In a standalone app you would instead `npm install` the published
+// packages — see README.md.)
+export default defineConfig({
+  root: import.meta.dirname,
+  // Audio + pre-computed `.dat` peaks are served from the shared website assets.
+  publicDir: path.resolve(repoRoot, 'website/static'),
+  // No @vitejs/plugin-react dependency needed — esbuild compiles TSX with the
+  // automatic JSX runtime (React 17+). A standalone copy would add the plugin
+  // for Fast Refresh (see README.md).
+  esbuild: { jsx: 'automatic' },
+  resolve: {
+    // Source-aliased workspace packages import bare `react`/`styled-components`;
+    // force a single copy so hooks/context work across the alias boundary
+    // (otherwise: "Invalid hook call" from duplicate React).
+    dedupe: ['react', 'react-dom', 'styled-components'],
+    alias: {
+      '@waveform-playlist/browser': path.resolve(repoRoot, 'packages/browser/src/index.tsx'),
+      '@waveform-playlist/media-element-playout': path.resolve(
+        repoRoot,
+        'packages/media-element-playout/src/index.ts'
+      ),
+      '@waveform-playlist/core': path.resolve(repoRoot, 'packages/core/src/index.ts'),
+      '@waveform-playlist/engine': path.resolve(repoRoot, 'packages/engine/src/index.ts'),
+      '@waveform-playlist/ui-components': path.resolve(
+        repoRoot,
+        'packages/ui-components/src/index.tsx'
+      ),
+      '@waveform-playlist/loaders': path.resolve(repoRoot, 'packages/loaders/src/index.ts'),
+    },
+  },
+  // Belt-and-suspenders: never try to pre-bundle the engines this path doesn't use.
+  optimizeDeps: {
+    exclude: ['tone', '@waveform-playlist/playout'],
+  },
+  server: {
+    port: 5176,
+    open: '/',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "version:bump": "node scripts/bump-version.js",
     "example:dawcore-native": "vite --config examples/dawcore-native/vite.config.ts",
     "example:dawcore-tone": "vite --config examples/dawcore-tone/vite.config.ts",
-    "example:dawcore-wam": "vite --config examples/dawcore-wam/vite.config.ts"
+    "example:dawcore-wam": "vite --config examples/dawcore-wam/vite.config.ts",
+    "example:media-element": "vite --config examples/media-element-player/vite.config.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,46 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@20.19.42)
 
+  examples/media-element-player:
+    dependencies:
+      '@dnd-kit/abstract':
+        specifier: ^0.3.0
+        version: 0.3.2
+      '@dnd-kit/dom':
+        specifier: ^0.3.0
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: ^0.3.0
+        version: 0.3.2(react-dom@18.3.1)(react@18.3.1)
+      '@waveform-playlist/browser':
+        specifier: workspace:*
+        version: link:../../packages/browser
+      '@waveform-playlist/media-element-playout':
+        specifier: workspace:*
+        version: link:../../packages/media-element-playout
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      styled-components:
+        specifier: ^6.0.0
+        version: 6.4.2(react-dom@18.3.1)(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.31)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.16(@types/node@20.19.42)
+
   packages/annotations:
     dependencies:
       '@dnd-kit/react':
@@ -2757,7 +2797,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-    dev: true
 
   /@dnd-kit/react@0.3.2(react-dom@19.2.7)(react@18.3.1):
     resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
@@ -17020,7 +17059,7 @@ packages:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@20.19.42)
+      vite: 6.4.3(@types/node@20.19.42)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17078,57 +17117,6 @@ packages:
     dependencies:
       '@types/node': 20.19.42
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.61.1
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@7.3.5(@types/node@20.19.42):
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-    dependencies:
-      '@types/node': 20.19.42
-      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'website'
+  - 'examples/*'


### PR DESCRIPTION
## Summary

Adds a standalone **MediaElement-only React starter** at `examples/media-element-player/` — a minimal single-track player (waveform, transport, pitch-preserving speed) that demonstrates the v14 lean-install path enabled by #510.

The point is the dependency list: it uses **only** `@waveform-playlist/browser` + `@waveform-playlist/media-element-playout` (+ react/react-dom/styled-components/@dnd-kit) — **no `@waveform-playlist/playout`, no `tone`**.

## What it shows

- `loadWaveformData()` → `MediaElementTrackConfig`, rendered via `MediaElementPlaylistProvider` + `MediaElementWaveform`.
- The four context hooks (`useMediaElementAnimation` / `State` / `Controls` / `Data`).
- Play/pause/stop, a smooth rAF time readout, pitch-preserving rate buttons (0.5–2×) + a preserve-pitch toggle.
- The new v14 `onError` prop surfacing init failures (e.g. a missing peer) in the UI.

Run it: `pnpm example:media-element` → http://localhost:5176

## Notes

- **First React example under `examples/`** (the others are vanilla web-component HTML). It's added to the pnpm workspace (`examples/*`) so its lean `package.json` resolves; `vite.config.ts` source-aliases the workspace packages with `resolve.dedupe: ['react','react-dom','styled-components']` (single React copy across the alias boundary).
- The `vite.config.ts` deliberately has **no alias for `playout` and no `tone`** — and the dev server runs fine without them, which is a live re-proof of the criterion-2 decoupling from #510.
- `@dnd-kit/*` are required peers of `browser` (its editing path); they tree-shake out of a MediaElement-only production bundle. The README documents the external install + a standalone (non-monorepo) Vite setup.

## Verification

Driven in a headless browser:
- Loads audio + peaks (duration `0:16`), renders the waveform + timescale + controls.
- Play advances time and toggles transport state.
- Console clean except a harmless `favicon.ico` 404.
- The Vite dev server never attempts to resolve `tone` or `@waveform-playlist/playout`.

## Test plan

- [x] `pnpm install --frozen-lockfile` consistent
- [x] `pnpm -w lint` 0 errors (examples are outside lint scope; root `build`/`typecheck` are `packages/*`-only)
- [x] `pnpm example:media-element` runs; headless render + playback verified
- [x] No `tone` / `@waveform-playlist/playout` resolved by the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
