### PR TITLE
feat(examples): latency-offset (seconds) input on recording demos

### DIFF
--- a/examples/dawcore-native/record.html
+++ b/examples/dawcore-native/record.html
@@ -67,6 +67,10 @@
       <option value="">No mic access</option>
     </select>
     <span id="mic-status" style="font-size:0.7rem;font-family:'Courier New',monospace;color:#888;"></span>
+    <label style="font-size:0.7rem;font-family:'Courier New',monospace;color:#888;display:flex;align-items:center;gap:4px;" title="Override the auto-computed outputLatency compensation with a value in SECONDS. Leave empty for auto.">
+      latency (s)
+      <input id="latency-input" type="number" step="0.001" min="0" placeholder="auto" style="width:70px;background:#1a1a2e;color:#e0d4c8;border:1px solid currentColor;padding:4px;font:inherit;" />
+    </label>
   </div>
 
   <daw-editor
@@ -227,9 +231,12 @@
 
       // Read actual channel count from stream, matching openDAW's approach
       const streamChannels = editor.recordingStream.getAudioTracks()[0]?.getSettings()?.channelCount;
+      // Optional manual latency override (seconds) — empty = auto-computed.
+      const latencyRaw = document.getElementById('latency-input').value;
       await editor.startRecording(editor.recordingStream, {
         overdub: true,
         ...(streamChannels && { channelCount: streamChannels }),
+        ...(latencyRaw !== '' && { latencyOffset: Number(latencyRaw) }),
       });
     }, { capture: true }); // capture phase to run before the button's own handler
 

--- a/examples/dawcore-tone/record.html
+++ b/examples/dawcore-tone/record.html
@@ -69,6 +69,10 @@
       <option value="">No mic access</option>
     </select>
     <span id="mic-status" style="font-size:0.7rem;font-family:'Courier New',monospace;color:#888;"></span>
+    <label style="font-size:0.7rem;font-family:'Courier New',monospace;color:#888;display:flex;align-items:center;gap:4px;" title="Override the auto-computed latency compensation with a value in SECONDS. Leave empty for auto.">
+      latency (s)
+      <input id="latency-input" type="number" step="0.001" min="0" placeholder="auto" style="width:70px;background:#1a1a2e;color:#e0d4c8;border:1px solid currentColor;padding:4px;font:inherit;" />
+    </label>
   </div>
 
   <daw-editor
@@ -225,9 +229,12 @@
       }
 
       const streamChannels = editor.recordingStream.getAudioTracks()[0]?.getSettings()?.channelCount;
+      // Optional manual latency override (seconds) — empty = auto-computed.
+      const latencyRaw = document.getElementById('latency-input').value;
       await editor.startRecording(editor.recordingStream, {
         overdub: true,
         ...(streamChannels && { channelCount: streamChannels }),
+        ...(latencyRaw !== '' && { latencyOffset: Number(latencyRaw) }),
       });
     }, { capture: true });
 

--- a/website/docs/react/guides/recording.md
+++ b/website/docs/react/guides/recording.md
@@ -415,6 +415,10 @@ function RecordToPlaylist() {
 
 When recording, there is typically a small delay between when audio enters the microphone and when it is captured. By default, `useIntegratedRecording` automatically compensates for this delay using `AudioContext.outputLatency` plus Tone.js scheduler lookahead (~0.1 s).
 
+:::tip Try it live
+The [recording example](pathname:///waveform-playlist/examples/recording) has a **Latency (s)** input in its toolbar — enter a value in seconds and record to apply the override, or leave it empty for the auto-computed value.
+:::
+
 ### Overriding with a Measured Latency
 
 If you have measured the actual round-trip latency of your audio interface (for example via a loopback test), you can supply that value directly with the `latencyOffset` option (in **seconds**):

--- a/website/src/components/examples/RecordingExample.tsx
+++ b/website/src/components/examples/RecordingExample.tsx
@@ -79,6 +79,29 @@ const ToolbarSection = styled.div<{ $grow?: boolean; $noBorder?: boolean }>`
   ${(props) => props.$grow && 'flex-shrink: 1;'}
 `;
 
+const LatencyField = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Courier New', Monaco, monospace;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--gray-9);
+  text-transform: uppercase;
+  white-space: nowrap;
+`;
+
+const LatencyInput = styled.input`
+  width: 64px;
+  padding: 3px 6px;
+  background: var(--color-surface);
+  border: 1px solid var(--gray-6);
+  border-radius: 4px;
+  color: var(--gray-12);
+  font-family: 'Courier New', Monaco, monospace;
+  font-size: 0.75rem;
+`;
+
 const MeterLabel = styled.span`
   font-family: 'Courier New', Monaco, monospace;
   font-size: 0.6875rem;
@@ -170,6 +193,11 @@ const RecordingControlsInner: React.FC<RecordingControlsInnerProps> = ({
   // Flag to auto-start recording after creating a new track
   const [shouldAutoStartRecording, setShouldAutoStartRecording] = useState(false);
 
+  // Optional manual latency-offset override, in SECONDS (matches the API unit).
+  // undefined = auto-computed (outputLatency + Tone lookAhead). Set this to try
+  // an externally-measured round-trip latency (issue #502).
+  const [latencyOffset, setLatencyOffset] = useState<number | undefined>(undefined);
+
   // Capture timeline position at record start for live preview positioning
   const recordStartTimeRef = useRef(0);
 
@@ -194,7 +222,11 @@ const RecordingControlsInner: React.FC<RecordingControlsInnerProps> = ({
     changeDevice,
     error,
     recordingPeaks,
-  } = useIntegratedRecording(tracks, setTracks, selectedTrackId, { currentTime, channelCount: 2 });
+  } = useIntegratedRecording(tracks, setTracks, selectedTrackId, {
+    currentTime,
+    channelCount: 2,
+    latencyOffset,
+  });
 
   // Sample rate info — flag potential resampling between mic and AudioContext
   const micSampleRate = stream?.getAudioTracks()[0]?.getSettings()?.sampleRate ?? null;
@@ -532,6 +564,24 @@ const RecordingControlsInner: React.FC<RecordingControlsInnerProps> = ({
           )}
         </ToolbarSection>
 
+        {/* Latency offset override (seconds) */}
+        <ToolbarSection>
+          <LatencyField title="Override the auto-computed latency compensation (outputLatency + lookAhead) with a value in seconds. Leave empty for auto. Set an externally-measured round-trip latency for best alignment (#502).">
+            Latency&nbsp;(s)
+            <LatencyInput
+              type="number"
+              step="0.001"
+              min="0"
+              placeholder="auto"
+              value={latencyOffset ?? ''}
+              disabled={isRecording}
+              onChange={(e) =>
+                setLatencyOffset(e.target.value === '' ? undefined : Number(e.target.value))
+              }
+            />
+          </LatencyField>
+        </ToolbarSection>
+
         {/* Meters */}
         <ToolbarSection $grow>
           <MeterGroup>
@@ -593,6 +643,9 @@ const RecordingControlsInner: React.FC<RecordingControlsInnerProps> = ({
                   durationSamples: Math.floor(duration * sampleRate),
                   peaks: recordingPeaks,
                   bits: 16,
+                  // Same override the hook uses, so the live preview matches the
+                  // finalized clip (otherwise preview uses the auto value).
+                  latencyOffset,
                 }
               : undefined
           }


### PR DESCRIPTION
## Summary

Follow-up to #515: there were docs for the configurable recording `latencyOffset`, but no demo where people could *try setting it*. This adds an input on every recording demo so it's hands-on. The input is in **seconds** to match the API unit exactly (no ms↔s conversion to get wrong).

## Changes

- **React recording example** (`website/src/components/examples/RecordingExample.tsx`) — a `Latency (s)` toolbar input (empty = auto). Wired to **both** `useIntegratedRecording({ latencyOffset })` and the `recordingState.latencyOffset` prop on `<Waveform>`, so the live preview and finalized clip stay in sync.
- **dawcore demos** (`examples/dawcore-native/record.html`, `examples/dawcore-tone/record.html`) — a `latency (s)` input passed to `editor.startRecording({ latencyOffset })`.
- **Recording guide** (`website/docs/react/guides/recording.md`) — a "try it live" pointer to the example.

Semantics (unchanged, from #515): empty → auto-computed (`outputLatency` + Tone lookahead); a value → absolute replacement, in seconds.

## Test plan

- [x] **dawcore native demo, live in Chrome (real mic):** set the input to `0.5`, recorded → `recording-complete: latency-skip=500.0ms` (vs the ~22ms auto), clip at `start: 0`. The override flows through `startRecording` → core `resolveRecordingOffsetSamples` end-to-end.
- [x] **React example mounts** with the `Latency (s)` input (placeholder `auto`) — verified rendered on the live Docusaurus server; no console errors. Same `latencyOffset` → `resolveRecordingOffsetSamples` path the dawcore test exercised, plus #515's unit tests cover the resolver.
- [x] Types clean (the post-merge stale-`dist` errors cleared after rebuilding `recording`/`browser`); no new ESLint issues in the changed files (the 3 pre-existing `website/src` warnings are unrelated and outside CI lint scope).

dawcore-tone uses the identical wiring as native (verified) via the Tone adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
