### PR TITLE
docs(playout): rawContext is a standardized-audio-context ponyfill (#503)

### DIFF
--- a/packages/playout/README.md
+++ b/packages/playout/README.md
@@ -1,0 +1,21 @@
+# @waveform-playlist/playout
+
+Tone.js-based `PlayoutAdapter` for [`@waveform-playlist/engine`](https://www.npmjs.com/package/@waveform-playlist/engine) — drives playback, recording, and effects on a shared global audio context. Used by `@waveform-playlist/browser` (the React surface). For native Web Audio (no Tone.js), see `@dawcore/transport`.
+
+## Audio context is a standardized-audio-context ponyfill
+
+`getGlobalContext()` / `getGlobalAudioContext()` return Tone.js's global context, whose `rawContext` is **always** a [`standardized-audio-context`](https://github.com/chrisguttandin/standardized-audio-context) ponyfill — **not** a native `BaseAudioContext` / `AudioContext`. This is deliberate: the ponyfill normalizes cross-browser differences (e.g. Firefox `AudioWorkletNode` / `AudioParam`).
+
+Consequences for integration:
+
+- `getGlobalAudioContext() instanceof window.AudioContext` is `false`.
+- The **native** `AudioWorkletNode` constructor rejects it — `new AudioWorkletNode(getGlobalAudioContext(), 'my-processor')` throws `TypeError: parameter 1 is not of type 'BaseAudioContext'` (same in Chrome and Firefox).
+
+Third-party worklet code should not hardcode the native constructor. Inject the `AudioWorkletNode` constructor and the module loader (the dependency-injection pattern from [`chrisguttandin/limiter-audio-worklet`](https://github.com/chrisguttandin/limiter-audio-worklet) — paired with [`limiter-audio-worklet-processor`](https://github.com/chrisguttandin/limiter-audio-worklet-processor)), or import `AudioWorkletNode` from `standardized-audio-context`, so the code works on a native **or** ponyfilled context. `@waveform-playlist/worklets` follows this exact pattern:
+
+```ts
+// caller supplies addModule for whichever context type is in use
+await addRecordingWorkletModule((url) => ctx.audioWorklet.addModule(url));
+```
+
+If you genuinely need a native `AudioContext`, own it yourself via the web-components adapter surface (`@dawcore/*`), which uses native Web Audio rather than Tone.

--- a/website/docs/react/guides/recording.md
+++ b/website/docs/react/guides/recording.md
@@ -735,6 +735,24 @@ This usually means the worklet file couldn't be loaded. Check:
 
 This is harmless and occurs when the worklet is loaded multiple times (e.g., hot reloading during development). The hook handles this gracefully.
 
+### Integrating third-party AudioWorklet code
+
+Recording (and the rest of `@waveform-playlist/playout`) runs on a shared global audio context from `getGlobalContext()` / `getGlobalAudioContext()`. That context is Tone.js's, and its `rawContext` is **always** a [`standardized-audio-context`](https://github.com/chrisguttandin/standardized-audio-context) ponyfill — **not** a native `BaseAudioContext` / `AudioContext`. This is deliberate: the ponyfill normalizes cross-browser Web Audio differences (e.g. Firefox `AudioWorkletNode` / `AudioParam`).
+
+Two consequences for third-party Web Audio code you run alongside the playlist:
+
+- `getGlobalAudioContext() instanceof window.AudioContext` is `false`.
+- The **native** `AudioWorkletNode` constructor rejects it — `new AudioWorkletNode(getGlobalAudioContext(), 'my-processor')` throws `TypeError: parameter 1 is not of type 'BaseAudioContext'` (same in Chrome and Firefox).
+
+So don't hardcode the native constructor. Use the dependency-injection pattern from [`chrisguttandin/limiter-audio-worklet`](https://github.com/chrisguttandin/limiter-audio-worklet) — accept the `AudioWorkletNode` constructor and the module loader as parameters — or import `AudioWorkletNode` from `standardized-audio-context`, so your code works on a native **or** ponyfilled context. That is exactly what `@waveform-playlist/worklets` does:
+
+```ts
+// caller supplies addModule for whichever context type is in use
+await addRecordingWorkletModule((url) => ctx.audioWorklet.addModule(url));
+```
+
+If you genuinely need a native `AudioContext`, own it yourself via the web-components surface (`@dawcore/*`), which uses native Web Audio rather than Tone.
+
 ## Browser Compatibility
 
 Recording requires:


### PR DESCRIPTION
Documents the behaviour from #503: @waveform-playlist/playout's `getGlobalContext()`/`getGlobalAudioContext()` always return Tone's context, whose `rawContext` is a [standardized-audio-context](https://github.com/chrisguttandin/standardized-audio-context) ponyfill — never a native `BaseAudioContext`. So `instanceof window.AudioContext` is false and the native `new AudioWorkletNode(ctx, ...)` constructor throws.

The fix (and what `@waveform-playlist/worklets` already does): inject the `AudioWorkletNode` constructor + module loader (the [Guttandin pattern](https://github.com/chrisguttandin/limiter-audio-worklet)) or import `AudioWorkletNode` from `standardized-audio-context`.

- new `packages/playout/README.md` (npm-visible)
- subsection in the recording guide's **AudioWorklet Setup**

Fulfils the documentation commitment from the #503 reply. Website build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)