### PR TITLE
docs(spec): document openEffectGui/closeEffectGui in WC migration spec

### DIFF
--- a/docs/specs/web-components-migration.md
+++ b/docs/specs/web-components-migration.md
@@ -384,6 +384,8 @@ editor.removeEffect(effectId: string): void
 editor.setEffectParams(effectId: string, params: Record<string, number>): void
 editor.setEffectBypassed(effectId: string, bypassed: boolean): void
 editor.moveEffect(effectId: string, newIndex: number): void
+editor.openEffectGui(effectId: string, container: HTMLElement): Promise<HTMLElement> // Mount a master-chain effect's GUI into a consumer-provided container
+editor.closeEffectGui(effectId: string): void                                        // Detach the GUI (cached for reopen)
 // Offline rendering
 editor.exportAudio(options?: ExportOptions): Promise<AudioBuffer>
 // MIDI loading
@@ -468,6 +470,8 @@ track.removeEffect(effectId: string): void
 track.setEffectParams(effectId: string, params: Record<string, number>): void
 track.setEffectBypassed(effectId: string, bypassed: boolean): void
 track.moveEffect(effectId: string, newIndex: number): void
+track.openEffectGui(effectId: string, container: HTMLElement): Promise<HTMLElement>  // Mount a per-track effect's GUI into a consumer-provided container
+track.closeEffectGui(effectId: string): void                                         // Detach the GUI (cached for reopen)
 ```
 
 When `arm()` is called without a `deviceId`, it uses the default input device. The method requests mic permission via `getUserMedia()` and stores the stream for use when recording starts. Calling `arm()` on an already-armed track with a different `deviceId` switches the input device.
@@ -880,6 +884,22 @@ Richer effects come from plugin standards rather than a large built-in set:
 - `addFaustEffect(dspCode, { name? })` compiles Faust DSP source in the browser to a WAM (optional `@dawcore/faust` peer).
 
 Chain operations never branch on entry kind — native and plugin entries support the same bypass/reorder/remove/params surface.
+
+### Effect GUIs
+
+Effect editor GUIs are **host-agnostic** — the consumer supplies the container element the panel mounts into. The same two methods are available on both `<daw-editor>` (master chain) and `<daw-track>` (per-track chain):
+
+- `openEffectGui(effectId, container)` mounts the effect's GUI into `container` and resolves with the mounted element. WAM plugins render their own GUI (`createGui`); native effects — and WAM plugins that ship no custom GUI — get a generic parameter panel built from the registry param definitions. A panel edit routes through the same path as `setEffectParams`, so it applies the change AND dispatches `daw-effect-change`.
+- `closeEffectGui(effectId)` detaches the panel but **caches** it — reopening remounts the same element, preserving GUI state. The GUI is destroyed only when the effect is removed from the chain. Calling `closeEffectGui` on a never-opened id warns but never throws; an error-placeholder entry refuses to open.
+
+```javascript
+// Open a WAM plugin's GUI into your own container element
+const panel = document.getElementById('plugin-panel');
+await track.openEffectGui(wamId, panel);
+
+// Detach (cached — reopen is cheap and preserves state)
+track.closeEffectGui(wamId);
+```
 
 ### Effect Registry
 


### PR DESCRIPTION
## Summary

Docs-only sync to the Web Components migration spec. The Effect GUI lifecycle (`openEffectGui` / `closeEffectGui`, #423) ships on both `<daw-editor>` (master chain) and `<daw-track>` (per-track chain) and the `examples/dawcore-wam` demo's "GUI" button depends on it — but the methods were absent from `docs/specs/web-components-migration.md`, even though the WAM/Faust section already claimed plugin GUIs were "supported" without showing how to open one.

Surfaced while scoping a wam-demo enhancement (per-track effect racks for dropped tracks). That feature is on hold pending a separate public per-track-by-id API (#522); this PR closes the unrelated *documentation* drift it exposed.

## Changes

- `<daw-editor>` API block: add `openEffectGui(effectId, container)` / `closeEffectGui(effectId)`.
- `<daw-track>` API block: same two methods (per-track chain).
- New **Effect GUIs** subsection in `## Effects` documenting:
  - host-agnostic container contract (consumer supplies the mount element),
  - cached detach-on-close lifecycle (reopen remounts; destroyed only on removal),
  - generic parameter fallback panel for native effects / GUI-less WAM plugins,
  - panel edits routing through `setEffectParams` → `daw-effect-change`.

## Test plan

- Docs-only; no code or build/lint scope affected (repo-root `docs/specs/` is not part of the Docusaurus site and is outside `pnpm lint`'s `packages/**` scope).
- Verified the documented methods exist in source: `openEffectGui`/`closeEffectGui` on `<daw-editor>` and `_trackOpenEffectGui`/`_trackCloseEffectGui` (the `<daw-track>` delegation) in `packages/dawcore/src/elements/daw-editor.ts`.
- Behavioral claims (cached close, fallback panel, never-opened-id warns, `daw-effect-change` on panel edit) cross-checked against the dawcore effects notes.
