### PR TITLE
feat(dawcore): public track enumeration (trackId) + daw-track-removed event (#525)

### DIFF
--- a/docs/specs/web-components-migration.md
+++ b/docs/specs/web-components-migration.md
@@ -319,7 +319,7 @@ file-drop            Boolean   false    Accept dropped audio/MIDI files
 **Properties (JS only):**
 ```typescript
 editor.adapter: PlayoutAdapter       // Required — consumer-provided audio backend (#378)
-editor.tracks: TrackDescriptor[]     // Editor-level track descriptors (not engine ClipTracks)
+editor.tracks: TrackWithId[]         // {trackId, name, …} for every track incl. element-less (dropped/programmatic); the trackId keys the per-track APIs (addTrackEffect, removeTrack, updateTrack, …)
 editor.isPlaying: boolean            // Playback state
 editor.isRecording: boolean          // Recording state (any track recording)
 editor.armedTrackIds: string[]       // Track IDs with record-armed attribute
@@ -429,6 +429,7 @@ editor.loadFiles(files: File[] | FileList, options?: LoadFilesOptions): Promise<
 'daw-files-load-error'  // Decode/parse failed: detail: {file: File, error: string}
 // Programmatic mutation
 'daw-track-ready'       // Track finished loading: detail: {trackId}
+'daw-track-removed'     // Track removed (DOM removal / removeTrack / controls): detail: {trackId} — fired after editor.tracks reflects the removal
 'daw-track-error'       // Track failed to load: detail: {trackId, error}
 'daw-clip-ready'        // Clip finished loading: detail: {trackId, clipId}
 'daw-clip-error'        // Clip failed to load: detail: {trackId, clipId, error}

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -229,7 +229,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 
 ## Typed Events
 
-- **`DawEventMap`** in `src/events.ts` — all 12 custom events with typed details. Use `new CustomEvent<DetailType>(...)` at dispatch sites.
+- **`DawEventMap`** in `src/events.ts` — all custom events with typed details. Use `new CustomEvent<DetailType>(...)` at dispatch sites.
 - **`LoadFilesResult`** — named return type for `loadFiles()`, exported from index.
 - **`PointerEngineContract`** in `interactions/pointer-handler.ts` — narrow engine interface (5 methods). `PointerHandlerHost._engine` uses this, not `PlaylistEngine` directly.
 - Always dispatch `daw-track-select` event on both engine and no-engine paths.

--- a/packages/dawcore/CLAUDE.md
+++ b/packages/dawcore/CLAUDE.md
@@ -124,6 +124,7 @@
 ## Programmatic Track + Clip API
 
 - **Imperative methods on `<daw-editor>`** — `editor.ready()` (build engine without tracks), `addTrack(config)`, `removeTrack(id)`, `updateTrack(id, partial)`, `addClip(trackId, config)`, `removeClip(trackId, clipId)`, `updateClip(trackId, clipId, partial)`. All thin wrappers around DOM mutation — they build `<daw-track>` / `<daw-clip>` elements and let the existing event pipeline handle loading. Both declarative DOM mutation and these methods feed the same `_loadTrack` / `_loadAndAppendClip` path.
+- **`editor.tracks` returns `TrackWithId[]`** (`{ trackId, ...descriptor }`) — the public enumeration of trackId + name for EVERY track incl. element-less (drag-dropped / programmatic) ones. The only public way to map a name to the `trackId` the per-track-by-id APIs (`addTrackEffect`, `removeTrack`, `updateTrack`, …) are keyed by — the id is otherwise just the internal `_tracks` Map key.
 - **Treat `editor.engine` as read-only from consumer code** — `engine.setTracks` directly works for rendering (peaks-sync reads `clip.audioBuffer`) but skips `_tracks` descriptor population, so `<daw-track-controls>` shows "Untitled" / default volume. Use the editor methods for mutation; reach into `engine` only for taps (`masterOutputNode`, analyzers).
 - **DOM ↔ engine clip-id alignment** — `clip.id = clipDesc.clipId` in `_loadTrack` aligns engine clip ids with `<daw-clip>.clipId`. Required for `editor.removeClip(trackId, clipId)` lookups. `ClipDescriptor.clipId` is optional (file drops, recording-clip don't set it; engine auto-generates).
 - **`<daw-clip>` lifecycle events** — `daw-clip-connected` (deferred via `setTimeout(0)`) and `daw-clip-update` (fires only after first render, on any reflected property change). Editor's `_onClipConnected` skips during initial track load (`_engineTracks` doesn't have the parent yet); late-append goes through `_loadAndAppendClip`.
@@ -230,6 +231,7 @@ Custom properties on `<daw-editor>` or any ancestor, inherited through Shadow DO
 ## Typed Events
 
 - **`DawEventMap`** in `src/events.ts` — all custom events with typed details. Use `new CustomEvent<DetailType>(...)` at dispatch sites.
+- **`daw-track-removed`** (detail `{ trackId }`) — outbound removal notification, symmetric with `daw-track-ready`. Dispatched from `_onTrackRemoved` ONLY when `existed && this.isConnected`: capture `existed = this._tracks.has(trackId)` at the TOP (cleanup mutates `_tracks` before the dispatch), and gate on `isConnected` per pattern #36 (reachable on a detached editor via `removeTrack`'s element-less branch). The MutationObserver calls `_onTrackRemoved` even for a `<daw-track>` removed before its deferred `daw-track-connected` ran (never registered) — exactly what the `existed` gate filters.
 - **`LoadFilesResult`** — named return type for `loadFiles()`, exported from index.
 - **`PointerEngineContract`** in `interactions/pointer-handler.ts` — narrow engine interface (5 methods). `PointerHandlerHost._engine` uses this, not `PlaylistEngine` directly.
 - Always dispatch `daw-track-select` event on both engine and no-engine paths.

--- a/packages/dawcore/src/__tests__/daw-editor-track-enumeration.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-track-enumeration.test.ts
@@ -104,4 +104,31 @@ describe('<daw-editor> track enumeration', () => {
     // editor.tracks reflects the removal by the time the event fires
     expect(editor.tracks).toHaveLength(0);
   });
+
+  it('does not fire daw-track-removed for a <daw-track> removed before it connected', async () => {
+    const onRemoved = vi.fn();
+    editor.addEventListener('daw-track-removed', onRemoved as EventListener);
+
+    // Append then synchronously remove — the deferred daw-track-connected
+    // (setTimeout 0) never runs, so the track is never registered in _tracks.
+    const track = document.createElement('daw-track') as DawTrackElement;
+    editor.appendChild(track);
+    track.remove();
+    await flush(); // MutationObserver processes the removal
+
+    // Symmetric with daw-track-ready: a track that never became ready must not
+    // emit a removal.
+    expect(onRemoved).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch daw-track-removed on a detached editor (pattern #36)', async () => {
+    const track = await appendTrack('Kick');
+    const onRemoved = vi.fn();
+    editor.addEventListener('daw-track-removed', onRemoved as EventListener);
+
+    editor.remove(); // detach — a bubbling/composed event can't reach ancestors now
+    editor.removeTrack(track.trackId); // element-less path → _onTrackRemoved synchronously
+
+    expect(onRemoved).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dawcore/src/__tests__/daw-editor-track-enumeration.test.ts
+++ b/packages/dawcore/src/__tests__/daw-editor-track-enumeration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
+import type { DawEditorElement } from '../elements/daw-editor';
+import type { DawTrackElement } from '../elements/daw-track';
+
+beforeAll(async () => {
+  await import('../elements/daw-editor');
+  await import('../elements/daw-track');
+  await import('../elements/daw-clip');
+});
+
+function mockGainNode() {
+  return { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+}
+
+function makeMockAdapter() {
+  const ctx = {
+    sampleRate: 48000,
+    state: 'suspended' as AudioContextState,
+    destination: { connect: vi.fn(), disconnect: vi.fn() },
+    createGain: vi.fn(() => mockGainNode()),
+    resume: vi.fn().mockResolvedValue(undefined),
+    decodeAudioData: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const transport = {
+    connectTrackOutput: vi.fn(),
+    disconnectTrackOutput: vi.fn(),
+    connectMasterOutput: vi.fn(),
+    disconnectMasterOutput: vi.fn(),
+    masterOutputNode: mockGainNode(),
+  };
+  return {
+    audioContext: ctx as unknown as AudioContext,
+    ppqn: 960,
+    transport,
+    setTracks: vi.fn(),
+    updateTrack: vi.fn(),
+    removeTrack: vi.fn(),
+    setTempo: vi.fn(),
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seek: vi.fn(),
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+    isPlaying: vi.fn().mockReturnValue(false),
+  };
+}
+
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let editor: DawEditorElement;
+let adapter: ReturnType<typeof makeMockAdapter>;
+
+beforeEach(() => {
+  vi.stubGlobal('devicePixelRatio', 1);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor = document.createElement('daw-editor') as any;
+  adapter = makeMockAdapter();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (editor as any).adapter = adapter;
+  document.body.appendChild(editor);
+});
+
+afterEach(() => {
+  editor.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function appendTrack(name = ''): Promise<DawTrackElement> {
+  const track = document.createElement('daw-track') as DawTrackElement;
+  if (name) track.setAttribute('name', name);
+  editor.appendChild(track);
+  await flush();
+  return track;
+}
+
+describe('<daw-editor> track enumeration', () => {
+  it('editor.tracks includes the trackId (and name) for each track', async () => {
+    const a = await appendTrack('Kick');
+    const b = await appendTrack('Bass');
+
+    expect(editor.tracks.map((t) => ({ trackId: t.trackId, name: t.name }))).toEqual([
+      { trackId: a.trackId, name: 'Kick' },
+      { trackId: b.trackId, name: 'Bass' },
+    ]);
+  });
+
+  it('daw-track-removed fires with the trackId when a track is removed', async () => {
+    const track = await appendTrack('Kick');
+    const onRemoved = vi.fn();
+    editor.addEventListener('daw-track-removed', onRemoved as EventListener);
+
+    track.remove();
+    await flush(); // MutationObserver processes the child removal
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+    expect((onRemoved.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      trackId: track.trackId,
+    });
+    // editor.tracks reflects the removal by the time the event fires
+    expect(editor.tracks).toHaveLength(0);
+  });
+});

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -1054,6 +1054,9 @@ export class DawEditorElement extends LitElement implements MidiLoaderHost {
     this._loadTrack(trackId, descriptor);
   };
   private _onTrackRemoved(trackId: string) {
+    // Captured before the cleanup below mutates _tracks — gates the outbound
+    // event so it only fires for a track that was actually registered.
+    const existed = this._tracks.has(trackId);
     this._trackElements.delete(trackId);
     this._effectsManager?.disposeTrackChain(trackId);
     // Clean up per-clip data before removing the track (need clip IDs from engine tracks)
@@ -1088,13 +1091,17 @@ export class DawEditorElement extends LitElement implements MidiLoaderHost {
     }
     // Outbound notification (symmetric with daw-track-ready) — fired after
     // _tracks is updated so handlers reading editor.tracks see the removal.
-    this.dispatchEvent(
-      new CustomEvent<DawTrackIdDetail>('daw-track-removed', {
-        bubbles: true,
-        composed: true,
-        detail: { trackId },
-      })
-    );
+    // Only for a track that was registered, and never on a detached editor
+    // (a bubbling/composed event can't reach ancestors — CLAUDE.md pattern #36).
+    if (existed && this.isConnected) {
+      this.dispatchEvent(
+        new CustomEvent<DawTrackIdDetail>('daw-track-removed', {
+          bubbles: true,
+          composed: true,
+          detail: { trackId },
+        })
+      );
+    }
   }
   private _onTrackUpdate = (e: CustomEvent) => {
     const trackId = e.detail?.trackId as string;

--- a/packages/dawcore/src/elements/daw-editor.ts
+++ b/packages/dawcore/src/elements/daw-editor.ts
@@ -14,6 +14,7 @@ import type {
 } from '@waveform-playlist/core';
 import type {
   TrackDescriptor,
+  TrackWithId,
   ClipDescriptor,
   DomClipDescriptor,
   TrackConfig,
@@ -853,8 +854,11 @@ export class DawEditorElement extends LitElement implements MidiLoaderHost {
   _setSelectedTrackId(trackId: string | null) {
     this._selectedTrackId = trackId;
   }
-  get tracks(): TrackDescriptor[] {
-    return [...this._tracks.values()];
+  get tracks(): TrackWithId[] {
+    return [...this._tracks.entries()].map(([trackId, descriptor]) => ({
+      trackId,
+      ...descriptor,
+    }));
   }
   get selectedTrackId(): string | null {
     return this._selectedTrackId;
@@ -1082,6 +1086,15 @@ export class DawEditorElement extends LitElement implements MidiLoaderHost {
       this._currentTime = 0;
       this._stopPlayhead();
     }
+    // Outbound notification (symmetric with daw-track-ready) — fired after
+    // _tracks is updated so handlers reading editor.tracks see the removal.
+    this.dispatchEvent(
+      new CustomEvent<DawTrackIdDetail>('daw-track-removed', {
+        bubbles: true,
+        composed: true,
+        detail: { trackId },
+      })
+    );
   }
   private _onTrackUpdate = (e: CustomEvent) => {
     const trackId = e.detail?.trackId as string;

--- a/packages/dawcore/src/events.ts
+++ b/packages/dawcore/src/events.ts
@@ -198,6 +198,7 @@ export interface DawEventMap {
   'daw-track-connected': CustomEvent<DawTrackConnectedDetail>;
   'daw-track-update': CustomEvent<DawTrackIdDetail>;
   'daw-track-ready': CustomEvent<DawTrackIdDetail>;
+  'daw-track-removed': CustomEvent<DawTrackIdDetail>;
   'daw-track-error': CustomEvent<DawTrackErrorDetail>;
   'daw-files-load-error': CustomEvent<DawFilesLoadErrorDetail>;
   'daw-play': CustomEvent<void>;

--- a/packages/dawcore/src/index.ts
+++ b/packages/dawcore/src/index.ts
@@ -71,6 +71,7 @@ export {
 
 export type {
   TrackDescriptor,
+  TrackWithId,
   ClipDescriptor,
   DomClipDescriptor,
   DropClipDescriptor,

--- a/packages/dawcore/src/types.ts
+++ b/packages/dawcore/src/types.ts
@@ -22,6 +22,11 @@ export interface TrackDescriptor {
   clips: ClipDescriptor[];
 }
 
+/** A `TrackDescriptor` plus its `trackId` — the shape returned by `editor.tracks`
+ *  so consumers can map a track's name to the `trackId` the per-track APIs
+ *  (`addTrackEffect`, `removeTrack`, `updateTrack`, …) are keyed by. */
+export type TrackWithId = TrackDescriptor & { trackId: string };
+
 /**
  * Common fields shared by all clip descriptors regardless of source.
  */


### PR DESCRIPTION
Closes #525.

## Summary

The per-track public APIs on `<daw-editor>` are keyed by `trackId` (`removeTrack`, `updateTrack`, and the per-track effects API from #524). But there was no public way to **enumerate** `(trackId, name)` for all tracks — `editor.tracks` returned `name` without `trackId`, `daw-track-ready` carried `trackId` without `name`, and only the internal `_tracks` Map had both. This adds the discovery half.

## Changes

- **`editor.tracks` now returns `TrackWithId[]`** (`{ trackId, ...descriptor }`) — covers element-less (drag-dropped / programmatic) tracks, not just declared ones. Additive: `TrackWithId extends TrackDescriptor`, so existing consumers reading `name`/`volume`/etc. are unaffected. New `TrackWithId` type exported from the package.
- **New `daw-track-removed` event** (detail `{ trackId }`, typed in `DawEventMap`), symmetric with `daw-track-ready`, dispatched from `_onTrackRemoved` **after** `editor.tracks` reflects the removal — so derived UI (dropdowns, racks) can stay in sync without a `MutationObserver`. Fires for every removal path (DOM removal, `removeTrack(id)`, `<daw-track-controls>` remove → all funnel through `_onTrackRemoved`).

## Why

Unblocks the wam-demo any-track effects UI (#522): the target dropdown ("Master + every track by name → trackId") can now be built on public API instead of reaching into `editor._tracks`. This is the *discovery* half of the id-keyed API #524 added the *addressing* half of.

## Test plan

- [x] New `daw-editor-track-enumeration.test.ts`: `editor.tracks` exposes `trackId`+`name`; `daw-track-removed` fires with the trackId and `editor.tracks` is already updated when it does. Both written RED→GREEN.
- [x] Full dawcore suite green: **673 passed (60 files)** — the `editor.tracks` return-type change (additive) and the new dispatch break nothing.
- [x] `pnpm --filter @dawcore/components typecheck` clean; `pnpm lint` 0 errors; build OK (incl. DTS).

## Docs

- `docs/specs/web-components-migration.md`: `editor.tracks` type updated to `TrackWithId[]`; `daw-track-removed` added to the events list — per the same-PR spec directive.

## Follow-up

- wam-demo any-track effects UI (#522) — now buildable on public API.
- dawcore version bump + publish — deferred until the demo is finishable (covers #524 + #525 together).
