### PR TITLE
feat(media-element-playout): make peaks optional for headless/scrubber-only players

### DIFF
--- a/packages/media-element-playout/README.md
+++ b/packages/media-element-playout/README.md
@@ -105,7 +105,7 @@ class MediaElementPlayout {
 ```typescript
 interface MediaElementTrackOptions {
   source: string | HTMLAudioElement;  // URL or audio element
-  peaks: WaveformDataObject;          // Pre-computed peaks
+  peaks?: WaveformDataObject;         // Pre-computed peaks (optional — omit for scrubber-only / headless players)
   id?: string;
   name?: string;
   volume?: number;

--- a/packages/media-element-playout/__tests__/peaks-optional.test.ts
+++ b/packages/media-element-playout/__tests__/peaks-optional.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { WaveformDataObject } from '@waveform-playlist/core';
+import { MediaElementTrack } from '../src/MediaElementTrack';
+import { MediaElementPlayout } from '../src/MediaElementPlayout';
+
+/**
+ * Minimal controllable stand-in for HTMLAudioElement.
+ *
+ * Built on the global `EventTarget` so `'ended'` / `'timeupdate'` dispatch for
+ * real — no DOM environment (jsdom/happy-dom) required. `MediaElementTrack`
+ * accepts an `HTMLAudioElement` as its `source`, so injecting this mock drives
+ * every code path deterministically.
+ */
+class MockAudioElement extends EventTarget {
+  preload = '';
+  playbackRate = 1;
+  volume = 1;
+  muted = false;
+  paused = true;
+  ended = false;
+  currentTime = 0;
+  /** HTMLMediaElement reports NaN until metadata loads. */
+  duration = NaN;
+  preservesPitch = true;
+  src = '';
+  play = vi.fn(() => {
+    this.paused = false;
+    return Promise.resolve();
+  });
+  pause = vi.fn(() => {
+    this.paused = true;
+  });
+  load = vi.fn();
+}
+
+function asAudioElement(mock: MockAudioElement): HTMLAudioElement {
+  return mock as unknown as HTMLAudioElement;
+}
+
+/** A partial peaks object — production only reads `duration` / `sample_rate`. */
+function makePeaks(overrides: Partial<WaveformDataObject> = {}): WaveformDataObject {
+  return { sample_rate: 44100, duration: 0, ...overrides } as WaveformDataObject;
+}
+
+describe('MediaElementTrack with peaks omitted', () => {
+  it('constructs without throwing and exposes peaks as null', () => {
+    const el = new MockAudioElement();
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    expect(track.peaks).toBeNull();
+  });
+
+  it('duration returns the audio element duration when available', () => {
+    const el = new MockAudioElement();
+    el.duration = 123;
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    expect(track.duration).toBe(123);
+  });
+
+  it('duration falls back to 0 (no throw) when the element duration is unavailable', () => {
+    const el = new MockAudioElement(); // duration === NaN
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    expect(() => track.duration).not.toThrow();
+    expect(track.duration).toBe(0);
+  });
+
+  it('play() and pause() operate', () => {
+    const el = new MockAudioElement();
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    track.play(0);
+    expect(el.play).toHaveBeenCalled();
+    expect(el.paused).toBe(false);
+    track.pause();
+    expect(el.pause).toHaveBeenCalled();
+    expect(el.paused).toBe(true);
+  });
+
+  it('seekTo() clamps without throwing when the element duration is unavailable', () => {
+    const el = new MockAudioElement(); // duration === NaN
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    expect(() => track.seekTo(30)).not.toThrow();
+    expect(el.currentTime).toBe(0);
+  });
+
+  it('seekTo() seeks within a known element duration', () => {
+    const el = new MockAudioElement();
+    el.duration = 100;
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    track.seekTo(30);
+    expect(el.currentTime).toBe(30);
+  });
+
+  it('setPlaybackRate() updates the element', () => {
+    const el = new MockAudioElement();
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    track.setPlaybackRate(1.5);
+    expect(el.playbackRate).toBe(1.5);
+    expect(track.playbackRate).toBe(1.5);
+  });
+
+  it('forwards timeupdate and ended events', () => {
+    const el = new MockAudioElement();
+    const track = new MediaElementTrack({ source: asAudioElement(el) });
+    const onTime = vi.fn();
+    const onStop = vi.fn();
+    track.setOnTimeUpdateCallback(onTime);
+    track.setOnStopCallback(onStop);
+
+    el.currentTime = 12.5;
+    el.dispatchEvent(new Event('timeupdate'));
+    expect(onTime).toHaveBeenCalledWith(12.5);
+
+    el.dispatchEvent(new Event('ended'));
+    expect(onStop).toHaveBeenCalled();
+  });
+});
+
+describe('MediaElementPlayout with peaks omitted', () => {
+  it('addTrack() works and sampleRate returns the 44100 default', () => {
+    const playout = new MediaElementPlayout();
+    const el = new MockAudioElement();
+    playout.addTrack({ source: asAudioElement(el) });
+    expect(() => playout.sampleRate).not.toThrow();
+    expect(playout.sampleRate).toBe(44100);
+  });
+
+  it('play()/pause()/seekTo() drive the underlying track', () => {
+    const playout = new MediaElementPlayout();
+    const el = new MockAudioElement();
+    el.duration = 60;
+    playout.addTrack({ source: asAudioElement(el) });
+
+    playout.play(undefined, 0);
+    expect(el.play).toHaveBeenCalled();
+
+    playout.seekTo(10);
+    expect(el.currentTime).toBe(10);
+
+    playout.pause();
+    expect(el.pause).toHaveBeenCalled();
+  });
+});
+
+describe('MediaElementTrack with peaks provided (backward compatibility)', () => {
+  it('exposes the provided peaks object', () => {
+    const el = new MockAudioElement();
+    const peaks = makePeaks({ duration: 200, sample_rate: 48000 });
+    const track = new MediaElementTrack({ source: asAudioElement(el), peaks });
+    expect(track.peaks).toBe(peaks);
+  });
+
+  it('duration falls back to peaks.duration when the element duration is unavailable', () => {
+    const el = new MockAudioElement(); // duration === NaN
+    const peaks = makePeaks({ duration: 200 });
+    const track = new MediaElementTrack({ source: asAudioElement(el), peaks });
+    expect(track.duration).toBe(200);
+  });
+
+  it('MediaElementPlayout.sampleRate reflects the provided peaks sample_rate', () => {
+    const playout = new MediaElementPlayout();
+    const el = new MockAudioElement();
+    playout.addTrack({ source: asAudioElement(el), peaks: makePeaks({ sample_rate: 48000 }) });
+    expect(playout.sampleRate).toBe(48000);
+  });
+});

--- a/packages/media-element-playout/package.json
+++ b/packages/media-element-playout/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "keywords": [
     "waveform",
@@ -43,7 +44,8 @@
   ],
   "devDependencies": {
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.6"
   },
   "dependencies": {
     "@waveform-playlist/core": "workspace:*"

--- a/packages/media-element-playout/src/MediaElementPlayout.ts
+++ b/packages/media-element-playout/src/MediaElementPlayout.ts
@@ -248,7 +248,7 @@ export class MediaElementPlayout {
   get sampleRate(): number {
     // HTMLAudioElement doesn't expose sample rate directly
     // Return a common default - peaks will have the actual sample rate
-    return this.track?.peaks.sample_rate ?? 44100;
+    return this.track?.peaks?.sample_rate ?? 44100;
   }
 
   /**

--- a/packages/media-element-playout/src/MediaElementTrack.ts
+++ b/packages/media-element-playout/src/MediaElementTrack.ts
@@ -16,8 +16,9 @@ interface VendorPrefixedPitch {
 export interface MediaElementTrackOptions {
   /** The audio source - can be a URL, Blob URL, or HTMLAudioElement */
   source: string | HTMLAudioElement;
-  /** Pre-computed waveform data for visualization (required - no AudioBuffer decoding) */
-  peaks: WaveformDataObject;
+  /** Pre-computed waveform data for visualization. Optional — omit for
+   *  scrubber-only / headless players that don't render a waveform. */
+  peaks?: WaveformDataObject;
   /** Track ID */
   id?: string;
   /** Track name for display */
@@ -62,7 +63,7 @@ export interface MediaElementTrackOptions {
 export class MediaElementTrack {
   private audioElement: HTMLAudioElement;
   private ownsElement: boolean; // Whether we created the element (need to clean up)
-  private _peaks: WaveformDataObject;
+  private _peaks: WaveformDataObject | null;
   private _id: string;
   private _name: string;
   private _playbackRate: number = 1;
@@ -79,7 +80,7 @@ export class MediaElementTrack {
   private _fadeOut: FadeConfig | undefined;
 
   constructor(options: MediaElementTrackOptions) {
-    this._peaks = options.peaks;
+    this._peaks = options.peaks ?? null;
     this._id = options.id ?? `track-${Date.now()}`;
     this._name = options.name ?? 'Track';
     this._playbackRate = options.playbackRate ?? 1;
@@ -441,7 +442,7 @@ export class MediaElementTrack {
     return this._name;
   }
 
-  get peaks(): WaveformDataObject {
+  get peaks(): WaveformDataObject | null {
     return this._peaks;
   }
 
@@ -450,7 +451,7 @@ export class MediaElementTrack {
   }
 
   get duration(): number {
-    return this.audioElement.duration || this._peaks.duration;
+    return this.audioElement.duration || this._peaks?.duration || 0;
   }
 
   get isPlaying(): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.42)(jsdom@25.0.1)
 
   packages/midi:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #529. Makes `peaks` **optional** in `@waveform-playlist/media-element-playout` so a consumer can drive pure `HTMLAudioElement` playback (play / pause / seek / rate / `timeupdate` / `ended`) **without** supplying pre-computed waveform data.

This unblocks the first **headless** consumer of the media-element engine — the `@dawcore` Radio pack's `<radio-archive>` element (prototyped in a separate repo), which streams 1–2 hr shows and renders a plain scrubber with chapter markers and **no waveform**. Producing peaks for such a feed means decoding the entire file — exactly what media-element streaming exists to avoid. Rather than stub a fake `WaveformDataObject`, this fixes the coupling at the source.

The change is a small, backward-compatible relaxation: existing callers that pass `peaks` are unaffected at runtime.

## Changes

**`MediaElementTrack.ts`**
- `MediaElementTrackOptions.peaks` is now optional (`peaks?: WaveformDataObject`).
- `_peaks` stored as `WaveformDataObject | null` (`options.peaks ?? null`); `get peaks()` widened to `WaveformDataObject | null`.
- `get duration()` guarded: `this.audioElement.duration || this._peaks?.duration || 0` — degrades to the element's duration, then `0`, instead of dereferencing absent peaks.

**`MediaElementPlayout.ts`**
- `get sampleRate()` guarded: `this.track?.peaks?.sample_rate ?? 44100`.

**Tests / tooling**
- Adds the package's first unit suite: `__tests__/peaks-optional.test.ts` (13 tests). Tests inject a mock `HTMLAudioElement` (built on Node's `EventTarget`) via the `source` option, so they drive real production paths with no DOM environment.
- Adds `vitest` devDep + `"test": "vitest run"` script (matches the `dawcore-wam` / `midi` convention); updates `pnpm-lock.yaml`.
- README options table now documents `peaks` as optional.

## Backward compatibility

- Runtime behavior with `peaks` provided is identical to before.
- The only in-repo consumer of the engine, `packages/browser`, always passes decoded `peaks` and never reads `track.peaks` or `playout.sampleRate` — unaffected (typecheck verified).
- The `get peaks()` return type widening to `| null` is a **type-level** breaking change for any external TS consumer that reads the getter and dereferences it without a null guard. Runtime is unaffected. A version bump for `@waveform-playlist/media-element-playout` should accompany the eventual publish (separate `chore(release)` step).

## Test plan

- [x] `npx vitest run` in `packages/media-element-playout` — 13/13 pass.
- [x] RED→GREEN verified: 4 assertions failed against pre-change code (`Cannot read properties of undefined (reading 'duration'/'sample_rate')`), all pass after the fix.
- [x] `pnpm --filter @waveform-playlist/media-element-playout typecheck` — passes.
- [x] `pnpm --filter @waveform-playlist/browser typecheck` (downstream consumer, resolves via rebuilt `dist/`) — passes.
- [x] `prettier --check` + `eslint` on changed `src/` — clean.
- [x] `pnpm --filter @waveform-playlist/media-element-playout build` — `dist/` rebuilt successfully.

## Out of scope

- `<daw-player>` element (#454).
- Waveform rendering changes.
- HTTP range-support detection (206-vs-200) — being prototyped in `<radio-archive>`; may return as a separate proposal.
