### PR TITLE
feat(core): shared probeRangeSupport util for HTTP range-support detection (#532)

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -19,6 +19,7 @@ Framework-agnostic types, pure functions, and utilities shared across all packag
 | `clipTimeHelpers.ts` | Sample→seconds converters: `clipStartTime`, `clipEndTime`, `clipOffsetTime`, `clipDurationTime`, `clipPixelWidth` |
 | `fades.ts` | Fade curve generators (linear, exponential, logarithmic, sCurve) — pure functions for Web Audio `AudioParam` |
 | `keyboard.ts` | `KeyboardShortcut` interface + `handleKeyboardEvent` — framework-agnostic shortcut handler |
+| `probeRangeSupport.ts` | `probeRangeSupport(url, fetchImpl?)` + `RangeSupport` type — detect HTTP range-request support (`GET` `Range: bytes=0-1`, `cache:'no-store'`, abort the body; `206`→supported / `200`→unsupported / throw→unknown). Positive-failure-only: CORS-opaque/network throw is `unknown`, not a failure. Injectable `fetch` for tests |
 | `constants.ts` | `MAX_CANVAS_WIDTH` (1000px virtual scroll chunk size) |
 | `utils/conversions.ts` | Unit converters: `samplesToSeconds`, `secondsToSamples`, `samplesToPixels`, `pixelsToSamples`, `pixelsToSeconds`, `secondsToPixels` |
 | `utils/dBUtils.ts` | Decibel utilities: `gainToDb`, `dBToNormalized`, `normalizedToDb`, `gainToNormalized` |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waveform-playlist/core",
-  "version": "12.3.0",
+  "version": "12.4.0",
   "description": "Core types, interfaces and utilities for waveform-playlist",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/__tests__/probeRangeSupport.test.ts
+++ b/packages/core/src/__tests__/probeRangeSupport.test.ts
@@ -21,13 +21,18 @@ describe('probeRangeSupport', () => {
     await expect(probeRangeSupport('https://host/audio.mp3', impl)).resolves.toBe('supported');
   });
 
-  it('sends a GET with Range: bytes=0-1', async () => {
+  it('sends a cache-bypassing GET with Range: bytes=0-1, and aborts (206 path)', async () => {
     const { impl, calls } = fetchReturning(206);
     await probeRangeSupport('https://host/audio.mp3', impl);
     expect(calls).toHaveLength(1);
     const init = calls[0].init!;
     expect(init.method).toBe('GET');
     expect((init.headers as Record<string, string>).Range).toBe('bytes=0-1');
+    // Bypass the HTTP cache — a cached full 200 must not be mistaken for the
+    // server ignoring Range (RFC 7234 allows satisfying a range from a cached 200).
+    expect(init.cache).toBe('no-store');
+    // Abort runs on every path (here the 206 / 'supported' path), not just 200.
+    expect((init.signal as AbortSignal).aborted).toBe(true);
   });
 
   it('returns "unsupported" on 200 (host ignored Range, returned full body)', async () => {

--- a/packages/core/src/__tests__/probeRangeSupport.test.ts
+++ b/packages/core/src/__tests__/probeRangeSupport.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { probeRangeSupport } from '../probeRangeSupport';
+
+/**
+ * Minimal fetch stub: resolves to a Response-shaped object with the given
+ * status, capturing each call's init so tests can assert the Range header and
+ * that the request signal was aborted. No real network.
+ */
+function fetchReturning(status: number) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const impl = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return { status } as unknown as Response;
+  });
+  return { impl, calls };
+}
+
+describe('probeRangeSupport', () => {
+  it('returns "supported" on 206 (host honored Range)', async () => {
+    const { impl } = fetchReturning(206);
+    await expect(probeRangeSupport('https://host/audio.mp3', impl)).resolves.toBe('supported');
+  });
+
+  it('sends a GET with Range: bytes=0-1', async () => {
+    const { impl, calls } = fetchReturning(206);
+    await probeRangeSupport('https://host/audio.mp3', impl);
+    expect(calls).toHaveLength(1);
+    const init = calls[0].init!;
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Range).toBe('bytes=0-1');
+  });
+
+  it('returns "unsupported" on 200 (host ignored Range, returned full body)', async () => {
+    const { impl } = fetchReturning(200);
+    await expect(probeRangeSupport('https://host/audio.mp3', impl)).resolves.toBe('unsupported');
+  });
+
+  it('aborts the request so a non-range full file is never downloaded', async () => {
+    const { impl, calls } = fetchReturning(200);
+    await probeRangeSupport('https://host/audio.mp3', impl);
+    const signal = calls[0].init!.signal as AbortSignal;
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('returns "unknown" when fetch throws (network error / CORS-opaque cross-origin)', async () => {
+    const impl = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    await expect(probeRangeSupport('https://other-origin/audio.mp3', impl)).resolves.toBe(
+      'unknown'
+    );
+  });
+
+  it('returns "unknown" on other statuses (e.g. 404)', async () => {
+    const { impl } = fetchReturning(404);
+    await expect(probeRangeSupport('https://host/missing.mp3', impl)).resolves.toBe('unknown');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './utils';
 export * from './clipTimeHelpers';
 export * from './fades';
 export * from './keyboard';
+export * from './probeRangeSupport';

--- a/packages/core/src/probeRangeSupport.ts
+++ b/packages/core/src/probeRangeSupport.ts
@@ -1,0 +1,49 @@
+export type RangeSupport = 'supported' | 'unsupported' | 'unknown';
+
+type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Probe whether an audio host honors HTTP range requests, so an on-demand
+ * player can decide its seeking policy. Range *detection* lives here; range
+ * *policy* (disable the scrubber, surface an error, play from start) stays with
+ * the consuming component — the detection is generic, the UX is per-component.
+ *
+ * Sends `GET` with `Range: bytes=0-1` and reads only the status line, aborting
+ * the body immediately: on a non-range host the `200` carries the entire
+ * (possibly hours-long) file, which must never be downloaded just to detect the
+ * failure.
+ *
+ * - `206` → `'supported'`
+ * - `200` (host ignored Range, returned full body) → `'unsupported'`
+ * - any throw (network error / CORS-opaque cross-origin) or other status → `'unknown'`
+ *
+ * **Positive-failure only:** only an observed `200` asserts a failure. A
+ * CORS-opaque probe is `'unknown'`, NOT a failure — native `<audio>` seeking
+ * works cross-origin *without* CORS, so seeking should stay enabled. A naive
+ * "no 206 ⇒ failure" would false-positive on every CORS-opaque host.
+ *
+ * @param url       The audio URL to probe.
+ * @param fetchImpl Injectable fetch (defaults to the global `fetch`) — pass a
+ *                  stub in tests so no real network is hit.
+ */
+export async function probeRangeSupport(
+  url: string,
+  fetchImpl: FetchLike = fetch
+): Promise<RangeSupport> {
+  const controller = new AbortController();
+  try {
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { Range: 'bytes=0-1' },
+      signal: controller.signal,
+    });
+    if (res.status === 206) return 'supported';
+    if (res.status === 200) return 'unsupported';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  } finally {
+    // Never consume the body — abort the moment we have the status line.
+    controller.abort();
+  }
+}

--- a/packages/core/src/probeRangeSupport.ts
+++ b/packages/core/src/probeRangeSupport.ts
@@ -24,7 +24,8 @@ type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
  *
  * @param url       The audio URL to probe.
  * @param fetchImpl Injectable fetch (defaults to the global `fetch`) — pass a
- *                  stub in tests so no real network is hit.
+ *                  stub in tests so no real network is hit, and pass an explicit
+ *                  implementation on runtimes without a global `fetch`.
  */
 export async function probeRangeSupport(
   url: string,
@@ -35,6 +36,9 @@ export async function probeRangeSupport(
     const res = await fetchImpl(url, {
       method: 'GET',
       headers: { Range: 'bytes=0-1' },
+      // Bypass the HTTP cache: RFC 7234 lets a UA satisfy a range request from a
+      // cached full 200, which would falsely read as the server ignoring Range.
+      cache: 'no-store',
       signal: controller.signal,
     });
     if (res.status === 206) return 'supported';


### PR DESCRIPTION
## Summary

Adds a framework-agnostic `probeRangeSupport(url, fetchImpl?)` util to `@waveform-playlist/core` so any on-demand player can detect whether an audio host honors HTTP range requests — without re-implementing the easy-to-get-wrong CORS + positive-failure semantics, and without coupling the check to a playout engine. Closes #532.

Range support is a property of the **URL/host**, not the playout mechanism, so it lives in `core` (a pure HTTP util, no decode dependency) and is shared by the React surface and `@dawcore/*`. Detection lives here; **policy (UX) stays per-component**.

```ts
export type RangeSupport = 'supported' | 'unsupported' | 'unknown';
export function probeRangeSupport(
  url: string,
  fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>
): Promise<RangeSupport>;
```

### Semantics
- `GET` with `Range: bytes=0-1`, **`cache: 'no-store'`**, and the body **aborted** the moment the status line is read — a non-range host's `200` carries the entire (possibly hours-long) file and must never be downloaded just to detect the failure.
- `206` → `supported`; `200` (host ignored Range) → `unsupported`; any throw (network / **CORS-opaque cross-origin**) or other status → `unknown`.
- **Positive-failure only:** only an observed `200` asserts a failure. A CORS-opaque probe is `unknown`, not a failure — native `<audio>` seeking works cross-origin without CORS, so seeking stays enabled. (A naive "no 206 ⇒ failure" would false-positive on every CORS-opaque host.)

### Beyond the issue's reference impl
Added **`cache: 'no-store'`** (code review): RFC 7234 lets a UA satisfy a range request from a *cached full 200* without upgrading to 206, which would false-read as the server ignoring `Range`. Bypassing the cache makes the probe observe the server, not cache state.

## Test plan
- [x] 6 unit tests (injected `fetch`, no real network): `206`→supported; sends cache-bypassing `GET` + `Range` and aborts (206 path); `200`→unsupported; abort on 200 path; throw→unknown; 404→unknown
- [x] full `core` suite **350 passing**; `typecheck` clean; `pnpm -w lint` **0 errors**; `dist/index.d.ts` exports `probeRangeSupport` + `RangeSupport`
- [x] `@waveform-playlist/core` bumped `12.3.0 → 12.4.0` (additive minor)

## Follow-on
`<daw-player>` (#454) and the `<radio-archive>` prototype consume the shared util (prototype drops its local `range-probe.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
