### PR TITLE
feat(website): <daw-player> web-components example page

### DIFF
--- a/website/docs/web-components/getting-started.md
+++ b/website/docs/web-components/getting-started.md
@@ -75,6 +75,7 @@ Runnable examples — rendered with `@dawcore/components` directly, no React in 
 
 - [**Basic**](pathname:///waveform-playlist/examples/wc-basic) — Minimal `<daw-editor>` with the native Web Audio adapter
 - [**Multiclip**](pathname:///waveform-playlist/examples/wc-multiclip) — Multiple `<daw-clip>` per track, drag/trim/split, pre-computed peaks via `<daw-keyboard-shortcuts>`
+- [**Player**](pathname:///waveform-playlist/examples/wc-player) — Lightweight single-track `<daw-player>`: HTMLMediaElement streaming, pre-computed peaks or scrubber fallback, playback rate
 
 ## Run it locally
 

--- a/website/src/components/examples/WcPlayerExample.tsx
+++ b/website/src/components/examples/WcPlayerExample.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import '@dawcore/components';
+import styles from './wc-example.module.css';
+
+// Custom-element JSX typing requires augmenting the global JSX namespace.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'daw-player': {
+        ref?: RefObject<DawPlayerElement | null>;
+        src?: string;
+        'peaks-src'?: string;
+        'wave-height'?: string | number;
+        timescale?: boolean;
+        class?: string;
+      };
+    }
+  }
+}
+
+const BASE = '/waveform-playlist/media/audio';
+
+/** Imperative surface of <daw-player> used by this demo. */
+interface DawPlayerElement extends HTMLElement {
+  play(): void;
+  pause(): void;
+  stop(): void;
+  setPlaybackRate(rate: number): void;
+  duration: number;
+  currentTime: number;
+}
+
+const RATES = [0.75, 1, 1.25, 1.5];
+
+export default function WcPlayerExample() {
+  const waveformRef = useRef<DawPlayerElement | null>(null);
+  const scrubberRef = useRef<DawPlayerElement | null>(null);
+  const timeRef = useRef<HTMLElement | null>(null);
+  const eventRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const player = waveformRef.current;
+    if (!player) return;
+
+    // daw-timeupdate fires per animation frame — write to the DOM directly,
+    // never setState at 60fps.
+    const onTime = (e: Event) => {
+      const { time } = (e as CustomEvent<{ time: number }>).detail;
+      if (timeRef.current) timeRef.current.textContent = time.toFixed(2) + 's';
+    };
+    const showEvent = (e: Event) => {
+      if (!eventRef.current) return;
+      const duration =
+        e.type === 'daw-ready' ? ' (duration ' + player.duration.toFixed(2) + 's)' : '';
+      eventRef.current.textContent = e.type + duration;
+      // No daw-timeupdate frames fire once stopped/paused — sync the readout
+      // here so Stop's rewind to 0 is visible.
+      if (timeRef.current) timeRef.current.textContent = player.currentTime.toFixed(2) + 's';
+    };
+
+    player.addEventListener('daw-timeupdate', onTime);
+    const logged = ['daw-ready', 'daw-play', 'daw-pause', 'daw-stop', 'daw-ended'];
+    logged.forEach((type) => player.addEventListener(type, showEvent));
+    return () => {
+      player.removeEventListener('daw-timeupdate', onTime);
+      logged.forEach((type) => player.removeEventListener(type, showEvent));
+    };
+  }, []);
+
+  return (
+    <>
+      <h3>
+        With a waveform (<code>peaks-src</code>)
+      </h3>
+      <daw-player
+        ref={waveformRef}
+        src={`${BASE}/AlbertKader_Whiptails/01_Loop1.opus`}
+        peaks-src={`${BASE}/AlbertKader_Whiptails/01_Loop1.dat`}
+        wave-height="96"
+        timescale
+        class={styles.player}
+      />
+      <div className={styles.playerControls}>
+        <button type="button" onClick={() => waveformRef.current?.play()}>
+          Play
+        </button>
+        <button type="button" onClick={() => waveformRef.current?.pause()}>
+          Pause
+        </button>
+        <button type="button" onClick={() => waveformRef.current?.stop()}>
+          Stop
+        </button>
+        <label>
+          Rate{' '}
+          <select
+            defaultValue="1"
+            onChange={(e) => waveformRef.current?.setPlaybackRate(Number(e.target.value))}
+          >
+            {RATES.map((r) => (
+              <option key={r} value={r}>
+                {r}×
+              </option>
+            ))}
+          </select>
+        </label>
+        <code ref={timeRef}>0.00s</code>
+        <code ref={eventRef} className={styles.playerEvent}>
+          —
+        </code>
+      </div>
+
+      <h3>
+        Scrubber fallback (no <code>peaks-src</code>)
+      </h3>
+      <daw-player
+        ref={scrubberRef}
+        src={`${BASE}/sonnet.mp3`}
+        wave-height="64"
+        class={styles.playerAlt}
+      />
+      <div className={styles.playerControls}>
+        <button type="button" onClick={() => scrubberRef.current?.play()}>
+          Play
+        </button>
+        <button type="button" onClick={() => scrubberRef.current?.pause()}>
+          Pause
+        </button>
+        <button type="button" onClick={() => scrubberRef.current?.stop()}>
+          Stop
+        </button>
+      </div>
+    </>
+  );
+}

--- a/website/src/components/examples/wc-example.module.css
+++ b/website/src/components/examples/wc-example.module.css
@@ -88,3 +88,56 @@
   color: var(--ifm-color-emphasis-600);
   padding: 0 0.5rem;
 }
+
+/* <daw-player> — same locked dark palette as the editor (see the design
+   decision at the top of this file). Two accents so the peaks-src player
+   and the scrubber fallback read as distinct instruments. */
+.player,
+.playerAlt {
+  display: block;
+  --daw-background: #0a0a0f;
+  --daw-ruler-background: #0a0a0f;
+  --daw-ruler-color: #c49a6c;
+  margin-bottom: 0.75rem;
+}
+
+.player {
+  --daw-wave-color: #c49a6c;
+  --daw-playhead-color: #d08070;
+}
+
+.playerAlt {
+  --daw-wave-color: #63c75f;
+  --daw-playhead-color: #d08070;
+}
+
+.playerControls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.playerControls button,
+.playerControls select {
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  padding: 4px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.playerControls button:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.playerControls code {
+  font-size: 0.85rem;
+  padding: 0 0.5rem;
+}
+
+.playerEvent {
+  color: var(--ifm-color-emphasis-600);
+}

--- a/website/src/pages/examples/wc-player.tsx
+++ b/website/src/pages/examples/wc-player.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import { createLazyExample } from '../../components/BrowserOnlyWrapper';
+
+const LazyWcPlayer = createLazyExample(() =>
+  import('../../components/examples/WcPlayerExample').then((m) => ({ default: m.default }))
+);
+
+export default function WcPlayerPage(): React.ReactElement {
+  return (
+    <Layout
+      title="Web Components — Player"
+      description="Lightweight <daw-player> single-track player. HTMLMediaElement streaming, pre-computed peaks, no Tone.js."
+    >
+      <main className="container margin-vert--lg">
+        <h1>Web Components — Player</h1>
+        <p>
+          <code>&lt;daw-player&gt;</code> is a lightweight single-track player from{' '}
+          <code>@dawcore/components</code>: it wraps an <code>HTMLMediaElement</code>, so audio
+          streams instead of decoding into memory — no Tone.js, no engine, no AudioContext to
+          manage. Click the waveform to seek.
+        </p>
+        <LazyWcPlayer />
+        <div style={{ marginTop: '2rem' }}>
+          <h2>What's in it</h2>
+          <ul>
+            <li>
+              <code>src</code> streams through an <code>HTMLMediaElement</code> — instant start, no
+              full decode
+            </li>
+            <li>
+              <code>peaks-src</code> renders a waveform from pre-computed BBC{' '}
+              <code>audiowaveform</code> peaks (<code>.dat</code>/<code>.json</code>); without it
+              the player falls back to a scrubber bar
+            </li>
+            <li>
+              <code>timescale</code> adds the time ruler; <code>wave-height</code>,{' '}
+              <code>bar-width</code>/<code>bar-gap</code>, <code>mono</code> and the{' '}
+              <code>--daw-*</code> CSS custom properties handle presentation
+            </li>
+            <li>
+              Methods: <code>play()</code>, <code>pause()</code>, <code>stop()</code>,{' '}
+              <code>seekTo(s)</code>, <code>setPlaybackRate(r)</code>, <code>setVolume(v)</code>
+            </li>
+            <li>
+              Events: <code>daw-ready</code>, <code>daw-play</code>, <code>daw-pause</code>,{' '}
+              <code>daw-stop</code>, <code>daw-timeupdate</code> (<code>{'{ time }'}</code>),{' '}
+              <code>daw-ended</code>, <code>daw-error</code> — the readout above is driven by them
+            </li>
+          </ul>
+          <h2>Run it locally</h2>
+          <p>
+            The same example as a standalone Vite app: <code>pnpm example:dawcore-native</code> →
+            opens <code>examples/dawcore-native/player.html</code>.
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Public demo for `<daw-player>` — its first npm release just shipped in `@dawcore/components@0.0.28`, but the element had no website presence (only `examples/dawcore-native/player.html` locally).

New page at `/examples/wc-player`, following the sibling WC-example pattern (`createLazyExample`, dist-based `@dawcore/components` import, locked dark palette in `wc-example.module.css`):

- **Waveform player** — `peaks-src` (pre-computed BBC `.dat`), `timescale`, play/pause/stop, playback-rate select, live time + last-event readouts (DOM-written via refs — no 60fps setState)
- **Scrubber fallback** — same element without `peaks-src`
- Linked from the Web Components getting-started doc's "Try it on this site" list alongside Basic/Multiclip
- Typed `IntrinsicElements` entry + `DawPlayerElement` interface instead of the siblings' `any` (new code held to the lint bar: direct `npx eslint` clean, no new warnings)

Verified in a real browser (Playwright): both players reach `daw-ready` (16.28s / 53.27s), waveform canvases painted (non-blank pixel check through the nested shadow root), playback advances, `setPlaybackRate(1.5)` speeds it up, Stop rewinds to 0 with the readout syncing on lifecycle events, `.dat` served 200, zero console errors. `pnpm --filter website build` passes.