### PR TITLE
fix(dawcore): <daw-player> ruler frozen at 0:00 — re-render on loadedmetadata

### DIFF
--- a/packages/dawcore/src/__tests__/daw-player.test.ts
+++ b/packages/dawcore/src/__tests__/daw-player.test.ts
@@ -174,6 +174,30 @@ describe('DawPlayerElement — playback wiring', () => {
       expect(ready).toHaveBeenCalledTimes(1);
     });
 
+    it('re-renders the ruler with the real duration once metadata loads', async () => {
+      const el = loadedPlayer();
+      el.timescale = true;
+      await el.updateComplete;
+      const ruler = el.shadowRoot!.querySelector('daw-ruler') as HTMLElement & {
+        duration: number;
+      };
+      expect(ruler).toBeTruthy();
+
+      // Real browsers report duration 0/NaN until metadata arrives — establish
+      // that pre-metadata render state (MockAudio starts at 120, so force it).
+      (el.audioElement as unknown as { duration: number }).duration = 0;
+      el.requestUpdate();
+      await el.updateComplete;
+      expect(ruler.duration).toBe(0);
+
+      // Metadata arrives AFTER the last render (the peaks-first race) — the
+      // ruler must re-bind the real duration, not stay frozen at 0:00.
+      (el.audioElement as unknown as { duration: number }).duration = 120;
+      el.audioElement!.dispatchEvent(new Event('loadedmetadata'));
+      await el.updateComplete;
+      expect(ruler.duration).toBe(120);
+    });
+
     it('dispatches daw-play / daw-pause / daw-ended from native events', async () => {
       const el = loadedPlayer();
       await el.updateComplete;

--- a/packages/dawcore/src/elements/daw-player.ts
+++ b/packages/dawcore/src/elements/daw-player.ts
@@ -291,6 +291,10 @@ export class DawPlayerElement extends LitElement {
 
   private _onLoadedMetadata = (): void => {
     this._metadataLoaded = true;
+    // duration (and the ruler SPP derived from it) is a render input read
+    // straight off the engine — without this, a render that happened before
+    // metadata (peaks usually resolve first) leaves the ruler frozen at 0:00.
+    this.requestUpdate();
     this._maybeDispatchReady();
   };
 


### PR DESCRIPTION
Reported on the new `/examples/wc-player` page (#547): the `timescale` ruler shows only `0:00`.

**Root cause** (reproduced on both the website page and `examples/dawcore-native/player.html`, i.e. an element bug shipped with #473 / `@dawcore/components@0.0.28`): the ruler's render inputs (`duration`, and the SPP derived from it) are read straight off the engine during `render()`, but `_onLoadedMetadata` never triggered a Lit re-render. Peaks (`@state _channelPeaks`) usually resolve before the media element's `loadedmetadata` — the tiny `.dat` beats the audio metadata — so the last render happens with `duration = 0` and the ruler freezes at a single `0:00` tick. Confirmed by hypothesis test before fixing: a manual `requestUpdate()` on the live element made the full tick set appear.

**Fix:** `_onLoadedMetadata` now calls `this.requestUpdate()` (one line + comment).

**TDD:** new test simulates the real browser sequence (render with duration 0 → `loadedmetadata` arrives after the last render) and asserts the ruler re-binds the real duration — RED before the fix, GREEN after. dawcore suite 703/703, per-package typecheck clean, root lint 0 errors.

**Browser-verified** on both surfaces: local `player.html` (source-aliased) and the website `/examples/wc-player` page (rebuilt dist) now render the full `0:00`–`0:16` tick set with no manual nudge.

Note: external consumers need a `@dawcore/components` patch release (0.0.29) to get this — 0.0.28 ships the bug. The deployed website picks it up from the workspace on merge.