### PR TITLE
docs: WAM guide readability — three integration paths, Firefox scoped to Tone backends

### DIFF
--- a/website/docs/wam-plugins.md
+++ b/website/docs/wam-plugins.md
@@ -1,19 +1,33 @@
 ---
 sidebar_position: 5
-description: "Host Web Audio Modules (WAM 2.0) plugins in React or Web Components using native AudioContext mode"
+description: "Host Web Audio Modules (WAM 2.0) plugins in React or Web Components — on the Tone.js backend (native AudioContext mode) or the native Web Audio backend"
 ---
 
 # WAM Plugins
 
-Waveform Playlist can host third-party [Web Audio Modules (WAM 2.0)](https://www.webaudiomodules.com/) plugins — synths and effects built once and pluggable into any compatible host — mixed freely alongside the built-in Tone.js effects. This guide covers both integration paths: React hooks and the Web Components `<daw-editor>` on the Tone.js backend.
+Waveform Playlist can host third-party [Web Audio Modules (WAM 2.0)](https://www.webaudiomodules.com/) plugins — effects built once and pluggable into any compatible host — mixed freely alongside the built-in Tone.js effects.
 
 ## What WAMs are
 
 [WAM 2.0](https://www.webaudiomodules.com/) is a community standard for portable Web Audio plugins. A WAM plugin ships as an ES module URL; any WAM-compatible host (Waveform Playlist, wam-studio, or your own app) can load it, wire it into an audio graph, and mount its GUI. The [webaudiomodules.com community registry](https://www.webaudiomodules.com/community/) lists dozens of ready-to-use effects and instruments you can insert by URL — no bundling or npm install of the plugin itself required.
 
-## Enable native AudioContext mode
+## Choosing an integration path
 
-WAM plugins are `AudioWorkletNode`s that subclass the native Web Audio API. Tone.js normally runs on a `standardized-audio-context` wrapper (for cross-browser worklet support), but WAM worklets cannot join that wrapped graph. To host WAM plugins, opt the shared global context into native mode **before any audio initialization** — before the first track loads or `createToneAdapter()` runs:
+There are three ways to host WAM plugins, and their requirements differ:
+
+| Integration | Audio backend | Native-context setup | Firefox | Plugin transport sync |
+| --- | --- | --- | --- | --- |
+| [React hooks](#react-hooks) | Tone.js | Required | ❌ | ❌ ([#537](https://github.com/naomiaro/waveform-playlist/issues/537)) |
+| [`<daw-editor>` + `createToneAdapter()`](#web-components-daw-editor-on-the-tone-backend) | Tone.js | Required | ❌ | ❌ ([#537](https://github.com/naomiaro/waveform-playlist/issues/537)) |
+| [`<daw-editor>` + `NativePlayoutAdapter`](#web-components-daw-editor-on-the-native-backend) | Native Web Audio | None — already native | ✅ | ✅ |
+
+The **Firefox** and **setup** columns share one root cause: WAM worklets subclass the native `AudioWorkletNode` and can only live on a native `AudioContext`. The Tone.js backends normally run on a `standardized-audio-context` wrapper and must be switched into native mode (next section) — a mode Firefox can't run because of a Tone.js limitation. The native `@dawcore/transport` backend has no Tone.js in it at all, so none of that applies — including in Firefox.
+
+## Enable native AudioContext mode (Tone backends)
+
+This section applies to the two **Tone.js** paths only — the native `NativePlayoutAdapter` path needs no setup and can [skip ahead](#web-components-daw-editor-on-the-native-backend).
+
+Tone.js normally runs on a `standardized-audio-context` wrapper (for cross-browser worklet support), but WAM worklets cannot join that wrapped graph. To host WAM plugins, opt the shared global context into native mode **before any audio initialization** — before the first track loads or `createToneAdapter()` runs:
 
 ```ts
 import { configureGlobalContext } from '@waveform-playlist/playout';
@@ -23,15 +37,17 @@ configureGlobalContext({ nativeAudioContext: true });
 
 `configureGlobalContext` must run before `getGlobalContext()` is called by anything else (any `useAudioTracks`/`WaveformPlaylistProvider` render, or `createToneAdapter()`) — once the context exists, native mode can no longer be applied and a console warning is logged instead.
 
-### Browser support
+### Browser support (Tone backends)
 
-| Browser | Native context mode |
+| Browser | Native context mode on Tone.js |
 |---|---|
 | Chrome / Edge | ✅ |
 | Safari | ✅ |
 | Firefox | ❌ — falls back automatically |
 
-Firefox does not implement the `AudioListener` position `AudioParam`s (`positionX`/`positionY`/`positionZ`, etc.) that Tone.js's `Listener` wraps eagerly at context initialization. `configureGlobalContext` feature-detects this (via `supportsNativeContextMode()`) and falls back to the default `standardized-audio-context` path with a `[playout]` console warning — built-in Tone.js effects keep working. Any subsequent WAM call (`addWamEffect`, `addWamEffectToTrack`, `editor.addWamPlugin`) throws with the same "requires a native AudioContext" instruction.
+The Firefox limitation is **Tone.js's, not WAM's**: Firefox does not implement the `AudioListener` position `AudioParam`s (`positionX`/`positionY`/`positionZ`, etc.) that Tone.js's `Listener` wraps eagerly at context initialization. `configureGlobalContext` feature-detects this (via `supportsNativeContextMode()`) and falls back to the default `standardized-audio-context` path with a `[playout]` console warning — built-in Tone.js effects keep working. Any subsequent WAM call (`addWamEffect`, `addWamEffectToTrack`, `editor.addWamPlugin`) throws with the same "requires a native AudioContext" instruction.
+
+Firefox users are only excluded from the Tone paths: WAM hosting on the [native backend](#web-components-daw-editor-on-the-native-backend) works in Firefox, since no Tone.js is involved.
 
 Check support yourself, and read back whether native mode actually activated:
 
@@ -80,7 +96,7 @@ function MasterRack() {
 }
 ```
 
-`addWamEffect(url, initialState?)` (master) and `addWamEffectToTrack(trackId, url, initialState?)` (per-track) dynamically import the optional `@dawcore/wam` peer, host the plugin on the global native context, and append it to the chain. Both resolve with the new entry's `instanceId`, and both throw if native-context mode isn't active (see [above](#enable-native-audiocontext-mode)). `initialState`, when provided, is passed to the plugin as its initial `setState()` snapshot.
+`addWamEffect(url, initialState?)` (master) and `addWamEffectToTrack(trackId, url, initialState?)` (per-track) dynamically import the optional `@dawcore/wam` peer, host the plugin on the global native context, and append it to the chain. Both resolve with the new entry's `instanceId`, and both throw if native-context mode isn't active (see [above](#enable-native-audiocontext-mode-tone-backends)). `initialState`, when provided, is passed to the plugin as its initial `setState()` snapshot.
 
 ### Bypass semantics
 
@@ -151,10 +167,30 @@ Once wired up, the full dawcore effects surface works unchanged — `editor.addW
 
 Runnable demo: `examples/dawcore-tone/wam.html` (`pnpm example:dawcore-tone`).
 
+## Web Components (`<daw-editor>`) on the native backend
+
+`<daw-editor>` with `NativePlayoutAdapter` (`@dawcore/transport`) is the zero-setup path: the adapter's `AudioContext` is already native, so there is no `configureGlobalContext` step and no mode to fall back from.
+
+```ts
+import { NativePlayoutAdapter } from '@dawcore/transport';
+
+editor.adapter = new NativePlayoutAdapter(new AudioContext());
+await editor.addWamPlugin(url); // just works — no native-context setup
+```
+
+Compared to the Tone paths, this backend also:
+
+- **works in Firefox** — verified with a community plugin hosting and processing audio on Firefox 150;
+- **broadcasts transport/tempo events to plugins** — the `wam-transport` bridge (play/stop state, tempo, time signature, bar position) is active here, which the Tone adapter doesn't support yet ([#537](https://github.com/naomiaro/waveform-playlist/issues/537)).
+
+The trade-off: no built-in Tone.js effects — chains here mix WAM plugins with the registry's native Web Audio effects instead.
+
+Runnable demo: `pnpm example:dawcore-wam` — community-library picker, GUIs, persistence, WAV export, and in-browser Faust compilation, all on the native adapter.
+
 ## Limitations
 
 - **Don't mutate effect chains or add tracks while a WAV export is in flight** — the offline render swaps Tone's global context during the graph build, so nodes created in that window land on the offline context. See [Exporting with WAM plugins](#exporting-with-wam-plugins).
-- **No tempo/transport broadcast on the Tone adapter** ([#537](https://github.com/naomiaro/waveform-playlist/issues/537)). `@dawcore/wam`'s transport bridge (tempo-synced delays, LFOs, arpeggiators) needs a query surface the Tone adapter's `transport` doesn't implement yet. WAM plugins on the Tone backend receive audio but no transport/tempo events (a one-time console warning notes the skip). **If you need transport sync today, host WAM plugins through dawcore's `<daw-editor>` on `NativePlayoutAdapter` (`@dawcore/transport`), where the bridge is active.** In practice no insertable community-registry effect currently consumes transport events — the plugins that do sync (sequencers, modulators) lack effect audio I/O and are rejected at insert — so with registry plugins this gap has no audible impact.
+- **No tempo/transport broadcast on the Tone adapter** ([#537](https://github.com/naomiaro/waveform-playlist/issues/537)). `@dawcore/wam`'s transport bridge (tempo-synced delays, LFOs, arpeggiators) needs a query surface the Tone adapter's `transport` doesn't implement yet. WAM plugins on the Tone backend receive audio but no transport/tempo events (a one-time console warning notes the skip). **If you need transport sync today, use the [native backend](#web-components-daw-editor-on-the-native-backend), where the bridge is active — and which also works in Firefox.** In practice no insertable community-registry effect currently consumes transport events — the plugins that do sync (sequencers, modulators) lack effect audio I/O and are rejected at insert — so with registry plugins this gap has no audible impact.
 - **Web Components (`<daw-editor>`) on the Tone adapter:** per-track effect chains use the adapter's `transport.connectTrackOutput(trackId, node)` hook, which supports audio tracks only — adding a per-track chain to a MIDI-only track throws. Master chains work for all track types.
 - **React hooks** are unaffected by this limitation: `useTrackDynamicEffects` wires chains through the track-effects closure, which applies to audio, MIDI, and SoundFont playout tracks alike.
 


### PR DESCRIPTION
Two problems with the WAM guide:

1. It framed everything through the Tone.js lens — the native `@dawcore/transport` backend appeared only as an aside in a Limitations bullet, so the reader had no map of the integration options.
2. **It implied Firefox can't host WAM at all.** The "Browser support" table said "Firefox ❌" under a generic "Native context mode" heading, while the transport-sync workaround recommended the native backend without saying whether that works in Firefox. The limitation is actually Tone.js's (its `Listener` eagerly wraps `AudioListener` position AudioParams Firefox lacks) — **verified in Firefox 150** before writing this: on a plain native `AudioContext` (no Tone), `ensureWamHost` + `createWamInstance` host burns-audio Simple Delay and an offline render through the plugin produces RMS 0.455. WAM on the native backend works in Firefox.

Changes:

- New **"Choosing an integration path"** table up front: React hooks / `<daw-editor>`+Tone / `<daw-editor>`+`NativePlayoutAdapter`, with native-context setup, Firefox support, and plugin transport sync per path — plus one paragraph explaining the shared root cause.
- "Enable native AudioContext mode" and "Browser support" retitled and scoped to the **Tone backends**; explicit "the Firefox limitation is Tone.js's, not WAM's" sentence with a pointer to the native path.
- New short **"Web Components on the native backend"** section: zero-setup snippet, works-in-Firefox (with the verification), transport bridge active, Tone-effects trade-off, `pnpm example:dawcore-wam` demo.
- Limitations transport bullet now points at that section ("also works in Firefox") instead of an inline workaround sentence.
- Frontmatter description updated to cover both backends.

`pnpm --filter website build` passes (no broken links/anchors — explicit `{#id}` heading syntax turned out to be unsupported by this MDX config; internal links use the auto slugs, with the one pre-existing `#enable-native-audiocontext-mode` reference updated to the renamed heading's slug).