### PR TITLE
fix: React spectrogram canvas-registration race + abort noise in pool fan-out (#562)

### DIFF
--- a/packages/dawcore-spectrogram/__tests__/pool-hardening.test.ts
+++ b/packages/dawcore-spectrogram/__tests__/pool-hardening.test.ts
@@ -4,6 +4,7 @@ import {
   trackingWorkerFactory,
   postedMessages,
   ackComputeFFTs,
+  respondToWorker,
 } from './helpers/poolTestUtils';
 
 const stereoParams = {
@@ -153,5 +154,44 @@ describe('worker pool — hardening (review of #559)', () => {
 
     for (const w of workers) ackComputeFFTs(w);
     await promise;
+  });
+});
+
+describe('worker pool — abort handling in multi-channel fan-out (#562)', () => {
+  it('does not warn when additional channel failures are aborts (normal control flow)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { factory, workers } = trackingWorkerFactory();
+    const pool = createSpectrogramWorkerPool(factory, 2);
+
+    const promise = pool.computeFFT(stereoParams, 1);
+    for (const w of workers) {
+      for (const msg of postedMessages(w)) {
+        if (msg.type === 'compute-fft') {
+          respondToWorker(w, { id: msg.id, type: 'aborted' });
+        }
+      }
+    }
+    await expect(promise).rejects.toThrow(/aborted/);
+
+    const abortNoise = warnSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('additional channel FFT failure')
+    );
+    expect(abortNoise).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
+  it('prefers throwing a real error over an abort when channel failures are mixed', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { factory, workers } = trackingWorkerFactory();
+    const pool = createSpectrogramWorkerPool(factory, 2);
+
+    const promise = pool.computeFFT(stereoParams, 1);
+    const w0fft = postedMessages(workers[0]).find((m) => m.type === 'compute-fft');
+    const w1fft = postedMessages(workers[1]).find((m) => m.type === 'compute-fft');
+    respondToWorker(workers[0], { id: w0fft!.id, type: 'aborted' });
+    respondToWorker(workers[1], { id: w1fft!.id, type: 'error', error: 'boom' });
+
+    await expect(promise).rejects.toThrow(/boom/);
+    warnSpy.mockRestore();
   });
 });

--- a/packages/dawcore-spectrogram/src/worker/createSpectrogramWorkerPool.ts
+++ b/packages/dawcore-spectrogram/src/worker/createSpectrogramWorkerPool.ts
@@ -1,5 +1,6 @@
 import {
   createSpectrogramWorker,
+  SpectrogramAbortError,
   type SpectrogramWorkerApi,
   type SpectrogramWorkerFFTParams,
   type SpectrogramWorkerRenderChunksParams,
@@ -192,21 +193,23 @@ export function createSpectrogramWorkerPool(
         ensureWorkerForChannel(i).computeFFT({ ...params, channelFilter: i }, generation)
       );
       // Use allSettled so one channel's failure doesn't drop surviving channel results.
-      // Throw the first failure; log additional ones so they're not silently swallowed.
       const settled = await Promise.allSettled(promises);
       const failures = settled.filter((s): s is PromiseRejectedResult => s.status === 'rejected');
       if (failures.length > 0) {
-        for (let i = 1; i < failures.length; i++) {
+        // Aborts are normal control flow (generation superseded) — never
+        // warned, and never allowed to mask a real error when mixed (#562).
+        const realErrors = failures.filter((f) => !(f.reason instanceof SpectrogramAbortError));
+        for (let i = 1; i < realErrors.length; i++) {
           console.warn(
             '[dawcore-spectrogram] additional channel FFT failure (' +
               i +
               '): ' +
-              (failures[i].reason instanceof Error
-                ? failures[i].reason.message
-                : String(failures[i].reason))
+              (realErrors[i].reason instanceof Error
+                ? realErrors[i].reason.message
+                : String(realErrors[i].reason))
           );
         }
-        throw failures[0].reason;
+        throw (realErrors[0] ?? failures[0]).reason;
       }
       return (settled[0] as PromiseFulfilledResult<{ cacheKey: string }>).value;
     },

--- a/packages/spectrogram/src/SpectrogramProvider.tsx
+++ b/packages/spectrogram/src/SpectrogramProvider.tsx
@@ -16,6 +16,7 @@ import {
 import {
   extractChunkNumber,
   parseCanvasId,
+  presentChunkIndices,
   groupContiguousIndices,
   classifyChunkTiers,
   computeChunkSampleRange,
@@ -310,11 +311,15 @@ export const SpectrogramProvider: React.FC<SpectrogramProviderProps> = ({
       api: SpectrogramWorkerApi,
       cacheKey: string,
       channelInfo: { canvasIds: string[]; canvasWidths: number[] },
-      indices: number[],
+      requestedIndices: number[],
       item: { config: SpectrogramConfig; colorMap: ColorMapValue },
       channelIndex: number,
       gen: number
     ) => {
+      // Indices are derived from channel 0's registry; this channel may have
+      // registered fewer canvases so far (#562). Skipped chunks render on the
+      // next pass — registration bumps spectrogramCanvasVersion.
+      const indices = presentChunkIndices(channelInfo, requestedIndices);
       if (indices.length === 0) return;
 
       const canvasIds = indices.map((i) => channelInfo.canvasIds[i]);

--- a/packages/spectrogram/src/__tests__/spectrogram-helpers.test.ts
+++ b/packages/spectrogram/src/__tests__/spectrogram-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   extractChunkNumber,
+  presentChunkIndices,
   parseCanvasId,
   groupContiguousIndices,
   classifyChunkTiers,
@@ -272,4 +273,20 @@ describe('mapsDiffer', () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('presentChunkIndices (#562)', () => {
+  it('keeps only indices whose canvas is registered for this channel', () => {
+    // Channel 0 has chunks 0..3 registered; this channel only 0..1 so far —
+    // reusing channel-0 indices must not index past the registry.
+    const channelInfo = { canvasIds: ['clip-ch1-chunk0', 'clip-ch1-chunk1'] };
+    expect(presentChunkIndices(channelInfo, [0, 1, 2, 3])).toEqual([0, 1]);
+  });
+
+  it('returns all indices when the channel registry is complete', () => {
+    const channelInfo = {
+      canvasIds: ['clip-ch0-chunk0', 'clip-ch0-chunk1', 'clip-ch0-chunk2'],
+    };
+    expect(presentChunkIndices(channelInfo, [0, 1, 2])).toEqual([0, 1, 2]);
+  });
 });

--- a/packages/spectrogram/src/spectrogram-helpers.ts
+++ b/packages/spectrogram/src/spectrogram-helpers.ts
@@ -50,6 +50,22 @@ export function extractChunkNumber(canvasId: string): number {
 }
 
 /**
+ * Keep only indices whose canvas is registered for THIS channel.
+ *
+ * Chunk indices are derived once from channel 0's registry and reused across
+ * channels, but canvases register progressively per channel — a later channel
+ * can briefly hold fewer entries, and indexing past its registry threw
+ * `Cannot read properties of undefined (reading 'match')` (#562). Skipped
+ * chunks render on the next pass: registration bumps `spectrogramCanvasVersion`.
+ */
+export function presentChunkIndices(
+  channelInfo: { canvasIds: string[] },
+  indices: number[]
+): number[] {
+  return indices.filter((i) => channelInfo.canvasIds[i] !== undefined);
+}
+
+/**
  * Parse a canvas ID of the form `${clipId}-ch${channelIndex}-chunk${n}` into its
  * clip ID and channel index. Returns `null` when the ID doesn't match.
  */


### PR DESCRIPTION
## Summary

Fixes #562 — the two console errors observed on the React spectrogram path after #559/#561 (both root causes are pre-existing; the audit work made them visible).

### `Cannot read properties of undefined (reading 'match')`

`renderChunkSubset` reuses chunk indices computed from **channel 0's** canvas registry against every channel's registry. Canvas registration is progressive and per-channel, so during initial mount or recorded-clip creation a later channel can briefly hold fewer registered canvases — `channelInfo.canvasIds[idx]` is `undefined` and `extractChunkNumber(undefined)` throws, aborting the whole clip's render pass (chunks stay black until an unrelated re-render).

Fix: new pure helper `presentChunkIndices` filters the requested indices to canvases actually registered for *this* channel. Skipped chunks are rendered on the next pass — registration bumps `spectrogramCanvasVersion`, which re-triggers the render effect.

### `[dawcore-spectrogram] additional channel FFT failure (1): aborted`

The pool's multi-channel `Promise.allSettled` aggregation warned about every rejection beyond the first — but `SpectrogramAbortError` is normal control flow (a generation bump cancelling in-flight channel computes). When both channels abort, the second was noisily warned; worse, a mixed abort+real-error could throw the *abort* (silently caught upstream) and mask the real error.

Fix: aborts are exempt from the additional-failure warning, and when failures are mixed the first **non-abort** error is thrown.

## Test plan

- [x] TDD: 4 new tests observed RED first — `presentChunkIndices` unit tests (spectrogram-helpers), pool abort-noise test (no warn when extra failures are aborts), mixed-failure precedence test (real error thrown over abort)
- [x] `packages/dawcore-spectrogram`: 226/226; `packages/spectrogram`: 38/38; `packages/dawcore`: 710/710
- [x] `pnpm --filter @dawcore/spectrogram build`, `pnpm --filter @waveform-playlist/spectrogram typecheck`, root `pnpm lint` 0 errors
