### PR TITLE
docs: full pass on package READMEs, PROJECT_STRUCTURE.md, and TODO.md

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -22,10 +22,10 @@ waveform-playlist/
 │   ├── engine/            # Framework-agnostic timeline engine
 │   ├── loaders/           # Audio file loaders
 │   ├── media-element-playout/  # Audio playback (HTMLAudioElement, no Tone.js)
-│   ├── midi/              # 📦 OPTIONAL: MIDI file parsing, piano roll, SoundFont playback
+│   ├── midi/              # 📦 OPTIONAL: MIDI file parsing + useMidiTracks hook (parser now in @dawcore/midi)
 │   ├── playout/           # Audio playback (Tone.js wrapper)
 │   ├── recording/         # 📦 OPTIONAL: Audio recording hooks (no UI components)
-│   ├── spectrogram/       # 📦 OPTIONAL: FFT computation, worker rendering, color maps
+│   ├── spectrogram/       # 📦 OPTIONAL: React Provider + UI for spectrograms (computation/worker in @dawcore/spectrogram)
 │   ├── transport/         # @dawcore/transport — native Web Audio transport (clock, scheduler, clip player)
 │   ├── ui-components/     # Reusable React UI components (incl. SegmentedVUMeter)
 │   ├── webaudio-peaks/    # Waveform peak generation
@@ -34,7 +34,8 @@ waveform-playlist/
 ├── examples/              # Standalone Vite example apps (decoupled from package builds)
 │   ├── dawcore-native/    # Web Components + NativePlayoutAdapter (basic, multiclip, effects, record, …)
 │   ├── dawcore-tone/      # Web Components + TonePlayoutAdapter (Tone.js backend, MIDI, SoundFont)
-│   └── dawcore-wam/       # WAM 2.0 plugins end-to-end (library picker, GUIs, Faust compilation, export)
+│   ├── dawcore-wam/       # WAM 2.0 plugins end-to-end (library picker, GUIs, Faust compilation, export)
+│   └── media-element-player/  # React MediaElementPlaylistProvider starter (no Tone.js/playout deps)
 │
 ├── debug/                 # Standalone reproductions and debug apps
 │   ├── tonejs/            # HTML reproductions of upstream Tone.js bugs
@@ -93,6 +94,7 @@ waveform-playlist/
   - `dBUtils.ts` — `dBToNormalized`, `normalizedToDb`, `gainToNormalized` (dB ↔ 0-1 conversions for VU meters)
   - `beatsAndBars.ts` — `PPQN` (192), `ticksPerBeat`, `ticksPerBar`, `ticksToSamples`, `samplesToTicks`, `snapToGrid`, `ticksToBarBeatLabel`
   - `keyboard.ts` — `KeyboardShortcut` type, `handleKeyboardEvent()` (matches event to shortcut array), `getShortcutLabel()` (human-readable label from shortcut definition)
+  - `spectrogramCanvasId.ts` — `buildSpectrogramCanvasId()`/`parseSpectrogramCanvasId()`: the canonical `${clipId}-ch${channelIndex}-chunk${chunkIndex}` canvas-ID contract, single-sourced here (zero-dependency, already a dependency of every producer/consumer) so `@waveform-playlist/spectrogram`, `@dawcore/spectrogram`, and the `<daw-spectrogram>` element can't drift on the format (#560)
 
 **Important Architectural Decision: Sample-Based Representation**
 
@@ -340,15 +342,21 @@ const clip = createClipFromSeconds({
   │   └── SnapToGridModifier.ts         # Snap-to-grid (beats or timescale mode)
   ├── plugins/                          # @dnd-kit plugins
   │   └── noDropAnimationPlugins.ts     # Disables Feedback plugin drop animation
+  ├── playout/                           # Optional-engine resolution (#510)
+  │   ├── resolvePlayoutAdapter.ts       # Dynamic-imports @waveform-playlist/playout + tone
+  │   └── resolveMediaElementPlayout.ts  # Dynamic-imports @waveform-playlist/media-element-playout
   ├── effects/                          # Audio effects system
   │   ├── effectDefinitions.ts          # 20 Tone.js effect definitions
   │   ├── effectFactory.ts              # Effect instance creation
   │   └── index.ts
   ├── workers/                          # Web workers
   │   └── peaksWorker.ts                # Inline Blob worker for peak generation
-  └── waveformDataLoader.ts            # BBC waveform-data.js support
+  ├── waveformDataLoader.ts            # BBC waveform-data.js support
+  └── tone.ts                          # `/tone` subpath entry (Tone-coupled exports)
   ```
-- **Build:** Vite + tsup
+- **Build:** tsup, two entry points (`src/index.tsx`, `src/tone.ts`) → core bundle + `/tone` subpath bundle. (Migrated off Vite; tsup auto-externalizes `dependencies`/`peerDependencies`, see root CLAUDE.md pattern 5.)
+- **Optional playout engines (#510):** `@waveform-playlist/playout`, `@waveform-playlist/media-element-playout`, and `tone` are optional `peerDependencies`, not static imports. `WaveformPlaylistProvider`/`MediaElementPlaylistProvider` resolve the default engine via dynamic `import()` (`src/playout/resolvePlayoutAdapter.ts` / `resolveMediaElementPlayout.ts`, factory-or-dynamic with install-hint rethrow) or accept a consumer-supplied `createAdapter?`/`createPlayout?` factory that skips the import entirely.
+- **`/tone` subpath is the Tone-coupled surface:** the core `@waveform-playlist/browser` entry is structurally free of any static `tone`/`playout` import (enforced by `coreBarrelEngineFree.test.ts`). Tone-dependent exports — `useAudioTracks`, `useDynamicTracks`, the effects hooks/factory/definitions, `useExportWav` + `ExportWavButton`, `useOutputMeter`, `useMasterAnalyser`, WAM effect GUI helpers — live at `@waveform-playlist/browser/tone` only. A MediaElement-only or custom-adapter consumer never resolves `tone`/`playout` under any bundler.
 
 ### 🔊 Audio Layer
 
@@ -369,32 +377,38 @@ const clip = createClipFromSeconds({
   - Timed segment playback
   - Track mixing
 - **Dependencies:** Tone.js, Core
+- **Optional peer of `@waveform-playlist/browser`:** resolved via dynamic `import()` (not a static dependency of the core browser bundle) — see the browser package's "Optional playout engines" note above.
 - **Location:** `packages/playout/src/audioContext.ts`
 
 #### `@waveform-playlist/media-element-playout`
 
-- **Purpose:** Lightweight audio playback using HTMLAudioElement (no Tone.js dependency)
-- **Key class:** `MediaElementPlayout`
+- **Purpose:** Lightweight single-track audio playback using HTMLAudioElement (no Tone.js dependency)
+- **Key classes:** `MediaElementPlayout` (engine, single track — warns + disposes on a second `addTrack`) wraps `MediaElementTrack` (one `<audio>` element)
 - **Use Cases:**
   - Large audio files - streams without downloading entire file
   - Pre-computed peaks - use [audiowaveform](https://github.com/bbc/audiowaveform) server-side
-  - Playback rate control - 0.5x to 2.0x with pitch preservation
+  - Playback rate control - 0.25x to 4.0x with pitch preservation
   - Single-track playback - simpler API, smaller bundle
+  - Lightweight single-track players — backs `<daw-player>` in `@dawcore/components`
 - **Features:**
-  - Play/pause/stop control
+  - Play/pause/stop control, plus player-mode `resume()` (continue from current position, vs. `play()`'s timeline-reset-to-0 semantics)
   - Seeking
   - Playback rate adjustment with pitch preservation
   - currentTime tracking via animation frame
+  - `setSource()`/`load()` for in-place source swap (reuses the element, so the once-per-element `MediaElementAudioSourceNode` and any effects routing survive)
+  - Typed event emitter (`on`/`off` over `loadedmetadata`/`play`/`pause`/`error`/`ended`/`timeupdate`), with legacy callback setters retained for back-compat
 - **When to Use:**
   - Choose `MediaElementPlaylistProvider` for streaming large files with pre-computed peaks
   - Choose `WaveformPlaylistProvider` (Tone.js) for multi-track mixing, effects, recording
-- **Dependencies:** None (pure HTMLAudioElement)
+- **Dependencies:** `@waveform-playlist/core` only (pure HTMLAudioElement, no Tone.js)
+- **Optional peer of `@waveform-playlist/browser`:** resolved via dynamic `import()`, same pattern as `playout`.
 - **Location:** `packages/media-element-playout/src/`
 - **Browser Integration:**
   - `MediaElementPlaylistProvider` - Context provider for media element playback
   - `MediaElementWaveform` - Single-track waveform component
   - Hooks: `useMediaElementAnimation`, `useMediaElementControls`, `useMediaElementState`, `useMediaElementData`
-- **Example:** `website/src/pages/examples/media-element.tsx`
+- **Web Components Integration:** `<daw-player>` in `@dawcore/components` wraps `MediaElementPlayout` directly — no `PlaylistEngine`, no adapter, no AudioContext
+- **Example:** `website/src/pages/examples/media-element.tsx`, `examples/media-element-player/`
 
 #### `@waveform-playlist/loaders`
 
@@ -571,7 +585,8 @@ audiowaveform -i audio.mp3 -o peaks-stereo.dat -z 256 --split-channels
   ├── styled.d.ts
   └── index.ts
   ```
-- **Companion package:** `@dawcore/spectrogram` (framework-agnostic) ships the FFT computation, Web Worker, `SpectrogramOrchestrator` class, and pure helpers (`classifyViewport`, `groupContiguousChunks`, `ColorLUTCache`). Used by this package's Provider AND by the dawcore Lit element layer.
+- **Companion package:** `@dawcore/spectrogram` (framework-agnostic, full description under "🧱 Web Components" below) ships the FFT computation, Web Worker, `SpectrogramOrchestrator` class, and pure helpers (`classifyViewport`, `groupContiguousChunks`, `ColorLUTCache`, `computePaddedFftRange`). Used by this package's Provider AND by the dawcore Lit element layer.
+- **Canvas-ID contract:** the `${clipId}-ch${channelIndex}-chunk${chunkIndex}` format is single-sourced in `@waveform-playlist/core` (`buildSpectrogramCanvasId`/`parseSpectrogramCanvasId`, #560/#556) — this package's `extractChunkNumber`/`parseCanvasId`/`computeChunkSampleRange` are thin adapters over core's parser + `@dawcore/spectrogram`'s `computePaddedFftRange`, not independent implementations.
 - **Integration Pattern:**
   - Browser package defines `SpectrogramIntegrationContext` (nullable)
   - Spectrogram package provides `SpectrogramProvider` that fills this context
@@ -592,6 +607,21 @@ audiowaveform -i audio.mp3 -o peaks-stereo.dat -z 256 --split-channels
 - **Peer Dependencies:** React, @waveform-playlist/browser
 - **Example:** `website/src/components/examples/MirSpectrogramExample.tsx`
 
+#### `@waveform-playlist/midi`
+
+- **Type:** Optional package (install separately)
+- **Purpose:** MIDI file loading, parsing, and React hook integration. Separates `@tonejs/midi` into an opt-in package so audio-only users don't pay the bundle cost.
+- **Install:** `npm install @waveform-playlist/midi`
+- **Architecture (two-layer):**
+  - `parseMidiFile()`/`parseMidiUrl()` — pure functions, re-exported from `@dawcore/midi` as of v13.0.0 (moved during the dawcore framework-split; no React-side API change). Convert a `.mid` ArrayBuffer/URL to `ParsedMidi`.
+  - `useMidiTracks()` — the one original symbol still defined in this package. React hook mirroring `useAudioTracks`, producing `ClipTrack[]` with `clip.midiNotes` for `<WaveformPlaylistProvider tracks={...}>`.
+- **Data pipeline only:** MIDI synthesis (PolySynth, Transport scheduling) lives in `@waveform-playlist/playout` via `MidiToneTrack`.
+- **Multi-track expansion:** One MIDI config can produce multiple `ClipTrack`s (one per MIDI track in the file); `flatten: true` merges them into one, preserving per-note channel identity via `MidiNoteData.channel` (so percussion notes stay routable after flattening).
+- **No native sample rate:** MIDI is event-based — `sampleRate` is required on `useMidiTracks()`'s options (pass `getGlobalAudioContext().sampleRate` from playout) for sample-based timeline positioning.
+- **Dependencies:** `@dawcore/midi`, `@tonejs/midi`, `@waveform-playlist/core`
+- **Peer Dependencies:** React ^18.0.0
+- **Location:** `packages/midi/`
+
 ### 🧱 Web Components
 
 #### `@dawcore/components`
@@ -610,6 +640,9 @@ audiowaveform -i audio.mp3 -o peaks-stereo.dat -z 256 --split-channels
   - `<daw-transport>`, `<daw-play-button>`, `<daw-pause-button>`, `<daw-stop-button>`, `<daw-record-button>` — Transport controls (find target via `for` attribute)
   - `<daw-track-controls>` — Mute/solo/volume/pan per track. Height-responsive via CSS container queries: on short rows the Pan slider drops first, then Vol (name + M/S always visible). Requires an explicit height (the editor sets one per track row).
   - `<daw-keyboard-shortcuts>` — Render-less element. Boolean attribute presets: `playback`, `splitting`, `undo`. JS properties for remapping (`playbackShortcuts`, `splittingShortcuts`, `undoShortcuts`) and custom shortcuts (`customShortcuts`). Listener on `document`. Uses `handleKeyboardEvent` from `@waveform-playlist/core`.
+  - `<daw-piano-roll>`, `<daw-spectrogram>`, `<daw-grid>` — Render-mode-specific visual elements (MIDI notes, spectrogram FFT via `@dawcore/spectrogram`, beats/bars grid), same chunked-canvas (1000px) pattern as `<daw-waveform>`. Selected via `<daw-track render-mode="piano-roll" | "spectrogram">`.
+  - `<daw-time-display>`, `<daw-time-format>` — Transport-adjacent readouts/controls (target resolution like the transport buttons); target owns the state, controls sync via bubbled events.
+  - `<daw-player>` — Lightweight single-track player, independent of `<daw-editor>`. Wraps `MediaElementPlayout` from `@waveform-playlist/media-element-playout` directly — no `PlaylistEngine`, no `PlayoutAdapter`, no AudioContext. Attributes: `src`, `peaks-src` (pre-computed BBC `.dat`/`.json` peaks), `wave-height`, `timescale`, `mono`, `bar-width`, `bar-gap`, `rounded-bars`, `playback-rate`. Composes `<daw-ruler>`/`<daw-waveform>`/`<daw-playhead>` internally; scrubber fallback when `peaks-src` is omitted.
 - **Clip Interactions:**
   - `ClipPointerHandler` (`interactions/clip-pointer-handler.ts`) — Move (header drag) and trim (boundary drag) with engine delegation
   - `splitAtPlayhead` (`interactions/split-handler.ts`) — Split clip at current playhead position (S key)
@@ -634,6 +667,23 @@ audiowaveform -i audio.mp3 -o peaks-stereo.dat -z 256 --split-channels
 - **Events:** `seek(time)` emits a `seek` event (`{ seconds }`) — consumed by the WAM transport bridge among others
 - **Dependencies:** None (zero runtime deps; `@waveform-playlist/core`/`engine` are type-only devDeps)
 - **Location:** `packages/transport/`
+
+#### `@dawcore/spectrogram`
+
+- **Purpose:** Framework-agnostic spectrogram computation, Web Worker, and viewport-aware rendering orchestrator. A **regular dependency** of `@dawcore/components` (always loaded, unlike the optional `@dawcore/wam`/`@dawcore/faust` peers) and also consumed by `@waveform-playlist/spectrogram`'s React Provider for the FFT/worker primitives.
+- **Subpath exports:** root (computation + worker + orchestrator class), `./worker/spectrogram.worker` (Worker URL target), `./orchestrator` (ESM-only — orchestrator + pure helpers without the computation/worker graph)
+- **`SpectrogramOrchestrator`:** Owns the worker pool, per-clip/per-canvas registries, viewport state, and a three-tier render dispatch (viewport → buffer/overscan → remaining via `requestIdleCallback`). Extends `EventTarget`, dispatches `viewport-ready` once per `(generation, trackId)`. Used by `<daw-spectrogram>` + `SpectrogramController` in `@dawcore/components`; the React `SpectrogramProvider` uses the lower-level worker pool directly and keeps its own tier pipeline (candidate for future consolidation).
+- **Worker pool (`createSpectrogramWorkerPool`):** one-channel-per-worker invariant (the FFT cache key is channel-agnostic per worker); grows lazily when audio has more channels than pre-spawned workers. Canvases are routed by channel parsed from the canvas ID (`clipId-ch{N}-chunk{M}`) via `@waveform-playlist/core`'s `parseSpectrogramCanvasId`.
+- **Shared FFT-range math (#560):** `computePaddedFftRange` (`computation/fftSampleRange.ts`) is the padded-by-`fftSize` sample range for a chunk group, single-sourced and shared with the React Provider's `computeChunkSampleRange` so the two spectrogram pipelines can't drift on FFT window sizing.
+- **Dependencies:** `@waveform-playlist/core`, `fft.js`
+- **Location:** `packages/dawcore-spectrogram/`
+
+#### `@dawcore/midi`
+
+- **Purpose:** Framework-agnostic MIDI file loading and parsing — no React, no DOM, no Lit. Houses `parseMidiFile()`/`parseMidiUrl()` and the `MidiLoadOptions`/`MidiLoadResult` types.
+- **Consumers:** `@dawcore/components` (optional peer — `editor.loadMidi()` dynamic-imports this package on first call) and `@waveform-playlist/midi` (regular dependency — re-exports the parser and adds the `useMidiTracks` React hook on top).
+- **Dependencies:** `@waveform-playlist/core` (for the `MidiNoteData` type), `@tonejs/midi`. No peer dependencies — truly framework-agnostic.
+- **Location:** `packages/dawcore-midi/`
 
 #### `@dawcore/wam`
 
@@ -968,17 +1018,12 @@ Output per package:
 - `dist/index.mjs` (ESM)
 - `dist/index.d.ts` (Types)
 
-### 2. Vite Bundles (browser package)
+### 2. Multi-Entry Packages
 
-```bash
-# Auto-runs during pnpm build
-vite build
-```
+All packages build with tsup — no Vite in the package build pipeline (the `browser` package migrated off Vite per #317; tsup auto-externalizes `dependencies`/`peerDependencies` so no manual `external` list drifts). Two packages emit more than a single `index` bundle:
 
-Outputs:
-
-- `packages/browser/dist/index.js` (CJS)
-- `packages/browser/dist/index.mjs` (ESM)
+- **`@waveform-playlist/browser`** — `tsup.config.ts` lists two entries, `src/index.tsx` and `src/tone.ts`, producing the engine-free core bundle plus the `@waveform-playlist/browser/tone` subpath (Tone-coupled hooks/effects/export).
+- **`@dawcore/spectrogram`** — three tsup entry blocks: main (CJS+ESM+DTS), `worker/spectrogram.worker` (ESM-only, no DTS), and `orchestrator/index` (ESM+DTS) under the `./orchestrator` subpath.
 
 ### 3. Docusaurus Website
 
@@ -1011,6 +1056,25 @@ Animation loop (requestAnimationFrame)
 Update currentTime state
     ↓
 Re-render Playhead position
+```
+
+### Optional Engine Resolution (`@waveform-playlist/browser`)
+
+`WaveformPlaylistProvider`/`MediaElementPlaylistProvider` never statically import an audio engine — `playout`, `media-element-playout`, and `tone` are optional peer dependencies resolved at runtime:
+
+```
+Provider mounts
+    ↓
+createAdapter / createPlayout prop supplied?
+    ├─ Yes → call factory directly (no import of playout/tone/media-element-playout)
+    └─ No  → dynamic import() of the default engine
+              (src/playout/resolvePlayoutAdapter.ts | resolveMediaElementPlayout.ts)
+              ├─ Success → engine constructed, provider proceeds
+              └─ Failure → install-hint error rethrown (peer not installed)
+    ↓
+Tone-coupled hooks/effects/export (useAudioTracks, useDynamicEffects, useExportWav, …)
+    are only reachable via the `@waveform-playlist/browser/tone` subpath —
+    the core entry's static import graph stays engine-free under every bundler
 ```
 
 ### Clip Mutation Flow (Move/Trim/Split)

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 Multi-track audio editor roadmap for waveform-playlist.
 
-**Branch:** `main` | **Last Updated:** 2026-03-10
+**Branch:** `main` | **Last Updated:** 2026-07-03
 
 ---
 
@@ -12,8 +12,6 @@ Multi-track audio editor roadmap for waveform-playlist.
 
 ### Playback UX
 
-- [ ] **Eager AudioContext resume** — Resume AudioContext on first user interaction (click/keydown) within playlist, before play is pressed. Eliminates ~200-500ms delay on first space bar press. Use `resumeGlobalAudioContext()` (raw context resume), NOT `Tone.start()` which adds ~2s latency on Safari if called redundantly.
-- [ ] **Undo/redo** — Command pattern for reversible operations (clip move, trim, split, delete, volume/pan changes). Expose via `useUndoRedo()` hook with `undo()`, `redo()`, and `canUndo`/`canRedo` state. Consider [`undo-manager`](https://www.npmjs.com/package/undo-manager) as a lightweight foundation.
 - [ ] **Keyboard shortcuts help overlay** — Modal or panel showing all available keyboard shortcuts, triggered by `?` key.
 - [ ] **Accessibility** — ARIA roles and labels for tracks, clips, and transport controls. Focus management for keyboard navigation between tracks and clips.
 - [ ] **Context menus** — Right-click menus on tracks (mute, solo, remove, duplicate) and clips (split, trim, delete, copy).
@@ -81,67 +79,8 @@ Multi-track audio editor roadmap for waveform-playlist.
 
 ### Timeline
 
-- [ ] **Tempo automation / tempo maps** — Support multiple BPMs across the timeline for projects with tempo changes.
-  - Current v1: `BeatsAndBarsProvider` accepts a single global `bpm` and `timeSignature`. `<daw-tempo>` and `<daw-time-signature>` web components reflect/edit these values. PPQN-based integer math in the ruler and snap grid is correct and carries forward.
-  - v2 (tempo map): Engine owns a `TempoMap` (sorted `TempoEvent[]` with sample position, BPM, time signature, curve type). Exposes `getBpmAt(sample)`, `sampleToMusicalTime(sample)`, `musicalTimeToSample(bar, beat, tick)`. Provider subscribes via `statechange`. `<daw-tempo>` / `<daw-time-signature>` show/edit the value at the current playhead position.
-  - Key change: sample ↔ musical time conversion becomes non-linear (must integrate across tempo segments). Affects ruler tick spacing, snap grid, time format display, and Tone.js Transport automation (`bpm.setValueAtTime()`).
-- [ ] **Time signature changes** — Allow time signature to change mid-timeline (e.g., 4/4 → 3/4 → 6/8). Folded into `TempoEvent` so tempo and time signature share the same position-indexed map.
 - [ ] **Sub-beat snap granularities** — Snap to 1/8, 1/16, triplets, and other subdivisions when editing clips.
-- [ ] **Metronome / click track** — Built-in click track that follows tempo and time signature settings. Use `Transport.scheduleRepeat` with musical time subdivisions — scheduling auto-follows BPM changes.
-- [ ] **Musical time formats** — Add `bar:beat` and `bar:beat:tick` options to `<daw-time-format>` / `setTimeFormat()`. Requires tempo map and time signature data. Follows Audacity's approach where the time format selector offers both absolute (hh:mm:ss) and musical (bar:beat) formats.
-
-### WAM Plugin Support
-
-WAM 2.0 is an open plugin standard for the Web Audio API — the browser equivalent of VST/AU. Plugins are loaded at runtime, expose AudioNodes for graph insertion, and provide their own UIs. Supporting WAM opens the door to a growing ecosystem of third-party effects, instruments, and DSP tools without bundling them.
-
-- [x] **WAM host initialization** — Done (#433, `@dawcore/wam` `ensureWamHost`). Original notes: Initialize the WAM host environment on the shared AudioContext so plugins can be instantiated. This is a one-time setup that creates a plugin group for event routing between plugins on the same context.
-  - Call `initializeWamHost(audioContext)` once during playlist initialization (or lazily on first plugin load). Store the returned `hostGroupId` for plugin instantiation.
-  - Expose via a `useWamHost()` hook that returns `{ hostGroupId, isReady }`. The hook should be idempotent — multiple consumers calling it shouldn't re-initialize.
-  - Guard against AudioContext state — host init requires a running context, so defer until after first user gesture (same timing as `resumeGlobalAudioContext()`).
-  - Example: a user opens the effects panel for the first time; the host initializes in the background before any plugin loads.
-
-- [x] **Per-track WAM plugin slot** — Done (#436 + #422): landed as unified-chain entries via `track.addWamPlugin(url)` rather than a separate slot. Original notes: Allow each track to load a single WAM plugin inserted into its audio chain. The plugin's `audioNode` sits between the track's source and its gain/pan stage, processing audio in real time.
-  - Add a `plugin` field to track state: `{ url: string; state?: any } | null`.
-  - On load: dynamically import the plugin's `index.js`, call `PluginFactory.createInstance(hostGroupId, audioContext, savedState)`, and wire `source → plugin.audioNode → gainNode`.
-  - On removal: call `plugin.audioNode.destroy()`, disconnect, and restore direct routing.
-  - Handle hot-swap — replacing one plugin with another should cleanly tear down the old instance before connecting the new one, with no audio glitches (brief mute during swap is acceptable).
-  - Example: a user applies a WAM reverb plugin to a vocal track, then swaps it for a delay — the old reverb is destroyed and the delay takes its place in the chain.
-
-- [x] **Plugin chain (multi-plugin per track)** — Done (#422): WAM plugins are ordered entries in the unified effects chain (move/remove/bypass shared with native effects). Event routing between plugins still future. Original notes: Extend the single-slot model to support an ordered chain of WAM plugins per track, similar to an effects rack. Audio flows through each plugin in sequence.
-  - Track state becomes `plugins: Array<{ url: string; state?: any }>`.
-  - Chain management: insert at position, remove, reorder (drag-and-drop in UI). Reconnect the audio graph on every topology change.
-  - Use WAM event routing (`connectEvents`) between adjacent plugins so automation and MIDI flow through the chain.
-  - Example: a guitar track with a tuner → compressor → amp sim → reverb chain, where the user can reorder or bypass individual plugins.
-
-- [x] **Plugin discovery and loading** — Done (#427 + #421, `@dawcore/wam`): `createWamInstance(url, ...)` for direct URL loading with post-instantiation descriptor validation (apiVersion 2.x, audio in/out required) and per-URL factory caching; `fetchWamLibrary(manifestUrl, { baseUrl? })` parses `library.json` manifests (webaudiomodules.com community registry + pedalboard2/wam-studio shapes) into `{ entries, warnings }`. Runnable picker UI in `examples/dawcore-wam/`. Original notes: Provide a mechanism for users to discover and load WAM plugins from URLs or a curated registry. Plugins are ES modules loaded via dynamic `import()`.
-  - Accept plugin URLs directly (paste a URL to a WAM `index.js`).
-  - Support WAM library manifests (`library.json`) — a JSON file listing available plugins with metadata (name, description, thumbnail, URL). Parse and display as a browsable list.
-  - Validate `WamDescriptor` after loading — check `apiVersion` compatibility, `hasAudioInput`/`hasAudioOutput` flags, and reject incompatible plugins with a clear error message.
-  - Cache loaded plugin factories in a `Map<url, PluginFactory>` so re-instantiating the same plugin on another track doesn't re-fetch.
-  - Example: a user pastes a URL to a community-built WAM compressor; the host fetches it, validates the descriptor, and makes it available in the plugin selector.
-
-- [x] **Plugin GUI embedding** — Done (#423): `openEffectGui(effectId, container)` / `closeEffectGui(effectId)` on `<daw-editor>` and `<daw-track>` mount a plugin's own `createGui()` element into a consumer-provided container; close hides without interrupting audio (element cached for reopen), destroy only on effect removal. GUI-less plugins and `native-*` effects get the generic parameter panel from `@dawcore/wam` (`createWamParameterPanel`). Original notes: Mount WAM plugin GUIs in a panel or floating window. WAM plugins create their own DOM elements via `createGui()`, which can be appended to any container.
-  - Call `await plugin.createGui()` to get an `HTMLElement`. Mount it in a designated panel (e.g., a drawer below the track, or a floating window).
-  - GUIs use ShadowDOM for style isolation — no CSS conflicts with the playlist UI.
-  - Show/hide GUI without destroying the plugin instance (toggling visibility, not mount/unmount).
-  - Provide a fallback for plugins without a GUI — render a generic parameter list using `getParameterInfo()` with sliders for each parameter.
-  - Example: a user clicks the plugin name on a track to open its GUI in a floating panel; closing the panel hides the GUI but the effect keeps processing audio.
-
-- [x] **Plugin state persistence** — Done (#424): `getEffectsState()` / `setEffectsState(entries)` on both elements serialize chains (WAM entries carry the plugin's `getState()` snapshot, reapplied on restore). An unreachable saved URL becomes a bypassed passthrough placeholder at its position (`daw-effect-error` fires, restore continues, saved state round-trips for retry). localStorage reload demo in `examples/dawcore-wam/`. Original notes: Save and restore plugin state so projects can be reopened with the same plugin configurations. WAM plugins support `getState()` and `setState()` for serializable snapshots.
-  - On project save: iterate all tracks, call `await plugin.getState()` for each loaded plugin, and include the state alongside the plugin URL in the project data.
-  - On project load: after instantiating each plugin, call `await plugin.setState(savedState)` to restore parameters, presets, and internal state.
-  - Handle missing plugins gracefully — if a saved plugin URL is unreachable, show a placeholder with the plugin name and skip it rather than failing the entire project load.
-  - Example: a user saves a project with a reverb and delay on two tracks; reopening the project restores both plugins with their exact parameter settings.
-
-- [x] **WAM transport events** — Done (#425, `createWamTransportBridge` in `@dawcore/wam`): broadcasts `wam-transport` events ({playing, tempo, timeSig, currentBar, currentBarStarted}) to all live plugin nodes on play/pause/stop/seek/tempochange/meterchange, plus a rAF watcher for variable-tempo boundary crossings. dawcore's `EffectsManager` wires it automatically on first `addWamPlugin`. Original notes: Broadcast transport state (playhead position, tempo, time signature, playing/stopped) to all loaded WAM plugins via `wam-transport` events. This lets tempo-synced effects (delays, LFOs, arpeggiators) lock to the playlist's timeline.
-  - On play/stop/seek: dispatch `wam-transport` events to all active plugin nodes with current `tempo`, `timeSigNumerator`, `timeSigDenominator`, `currentBar`, and `playing` state.
-  - On tempo or time signature change: re-broadcast updated transport data.
-  - Example: a tempo-synced delay plugin automatically adjusts its delay time when the user changes the project BPM from 120 to 140.
-
-- [x] **Faust DSP integration** — Done (epic #414). Static mode (#429): pre-compiled faust2wam bundles load via plain `addWamPlugin(url)` with zero special handling; three fixtures under `website/static/faust-wams/`. Dynamic mode (#430, `@dawcore/faust`): `addFaustEffect(dspCode, {name?})` on `<daw-editor>`/`<daw-track>` compiles Faust source in the browser via `@shren/faust2wam` `generate()` (optional peer, compiler lazy-loaded on first call), instantiates through `@dawcore/wam`'s `createWamInstanceFromFactory`, and lands in the chain as `kind:'wam'` with `source:{faust}`. Persistence stores `faustDsp`/`faustName` and recompiles on restore and offline export. Compile errors keep Faust's line/column diagnostics; chain untouched on failure. Textarea demo in `examples/dawcore-wam/` ("Faust (compile in browser)" section). Original notes: Support loading Faust DSP code as WAM plugins via `faust2wam`. Faust is a functional DSP language that compiles to WebAssembly — users can write custom effects in a few lines of code and hear them instantly.
-  - Provide a code editor UI (e.g., textarea with syntax highlighting) where users can write or paste Faust code, click "Compile", and apply the resulting effect to a track. (Rich editing is consumer territory — the example uses a plain textarea.)
-  - Auto-extract parameters from Faust's `hslider`/`vslider`/`checkbox` declarations — the compiled plugin's GUI renders controls automatically.
-  - Example: a user writes `process = fi.lowpass(2, hslider("cutoff", 1000, 20, 20000, 1));` in the editor, compiles it, and applies a custom 2nd-order lowpass filter to a track with a cutoff knob.
+- [ ] **Musical time formats** — Add `bar:beat` and `bar:beat:tick` options to `<daw-time-format>` / `setTimeFormat()` (today it offers only `hh:mm:ss.sss` / `hh:mm:ss` / `seconds`). Requires tempo map and time signature data. Follows Audacity's approach where the time format selector offers both absolute (hh:mm:ss) and musical (bar:beat) formats.
 
 ### Project
 
@@ -152,5 +91,3 @@ WAM 2.0 is an open plugin standard for the Web Audio API — the browser equival
 - [ ] **Sticky clip header text** — Keep track/clip name visible when scrolling horizontally using Intersection Observer.
 - [ ] **Contributing guidelines** — Document contribution workflow, code standards, and PR process.
 - [ ] **Revamp GitHub Sponsors tiers** — Update sponsorship tiers and perks via GitHub UI.
-- [ ] **Web Components UI layer** — Build a vanilla TypeScript + native Web Components layer on top of `@waveform-playlist/engine` as the primary UI implementation. Custom elements (`<waveform-playlist>`, `<waveform-track>`, `<waveform-transport>`) with Shadow DOM, attribute/property configuration, and custom events. React 19+ has native Web Components interop, so React users could consume these directly — eliminating the need for a separate React-specific UI layer.
-

--- a/packages/annotations/README.md
+++ b/packages/annotations/README.md
@@ -1,0 +1,97 @@
+# @waveform-playlist/annotations
+
+Time-synchronized text annotations for waveform-playlist — mark up an audio timeline with draggable, editable regions for transcripts, podcast chapters, cue points, or music markers.
+
+Used with [`@waveform-playlist/browser`](https://www.npmjs.com/package/@waveform-playlist/browser): wrap your playlist in `AnnotationProvider` and pass `annotationList` to `WaveformPlaylistProvider` — `<Waveform />` then renders annotation boxes and text automatically.
+
+## Features
+
+- **Timeline annotation boxes** — draggable regions overlaid on the waveform, with boundary resize handles
+- **Editable text list** — a scrollable, auto-scrolling list of annotation text synced to playback
+- **Drag-to-edit boundaries** — resize annotation start/end by dragging, with optional linked endpoints so adjacent segments stay contiguous
+- **Continuous play mode** — automatically advance to the next annotation during playback
+- **Aeneas import/export** — `parseAeneas` / `serializeAeneas` for the Aeneas forced-alignment JSON format
+- **Prebuilt controls** — checkboxes for continuous play, linked endpoints, editable mode, and a JSON download button
+- **Composable building blocks** — use `AnnotationsTrack`, `AnnotationBox`, `AnnotationBoxesWrapper`, and `AnnotationText` directly for custom annotation UIs
+
+## Installation
+
+```bash
+npm install @waveform-playlist/annotations
+```
+
+Peer dependencies: `react` (^18.0.0), `styled-components` (^6.0.0), `@dnd-kit/react` (^0.3.0), and `@waveform-playlist/browser` (matching major version).
+
+## Usage
+
+```tsx
+import { useState } from 'react';
+import { WaveformPlaylistProvider, Waveform, useAudioTracks } from '@waveform-playlist/browser';
+import { AnnotationProvider } from '@waveform-playlist/annotations';
+
+function AnnotatedPlaylist() {
+  const { tracks, loading } = useAudioTracks([{ src: '/audio/podcast.mp3', name: 'Podcast' }]);
+
+  const [annotations, setAnnotations] = useState([
+    { id: '1', start: 0, end: 5, lines: ['Introduction'] },
+    { id: '2', start: 5, end: 15, lines: ['Topic Overview'] },
+    { id: '3', start: 15, end: 30, lines: ['Main Discussion'] },
+  ]);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <WaveformPlaylistProvider
+      tracks={tracks}
+      timescale
+      annotationList={{
+        annotations,
+        editable: true,
+        linkEndpoints: false,
+      }}
+      onAnnotationsChange={setAnnotations} // required for edits to persist
+    >
+      <AnnotationProvider>
+        <Waveform />
+      </AnnotationProvider>
+    </WaveformPlaylistProvider>
+  );
+}
+```
+
+Each annotation is a plain object:
+
+```typescript
+interface AnnotationData {
+  id: string; // Unique identifier
+  start: number; // Start time in seconds
+  end: number; // End time in seconds
+  lines: string[]; // Text content as array of lines
+  language?: string; // Optional language code (e.g., 'en', 'es')
+}
+```
+
+For building a custom UI outside the integrated `<Waveform />` pattern, use `useAnnotationControls` plus the standalone components directly:
+
+```tsx
+import {
+  useAnnotationControls,
+  ContinuousPlayCheckbox,
+  LinkEndpointsCheckbox,
+  EditableCheckbox,
+  DownloadAnnotationsButton,
+} from '@waveform-playlist/annotations';
+
+const { continuousPlay, linkEndpoints, setContinuousPlay, setLinkEndpoints } =
+  useAnnotationControls();
+```
+
+## Examples & Documentation
+
+- [Annotations guide](https://naomiaro.github.io/waveform-playlist/docs/react/guides/annotations) — full provider configuration, keyboard controls, styling, and Aeneas import/export
+- [Live Annotations example](https://naomiaro.github.io/waveform-playlist/examples/annotations)
+- [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/) — full documentation
+
+## License
+
+MIT

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,0 +1,104 @@
+# @waveform-playlist/browser
+
+React components, hooks, and context providers for building a multitrack Web Audio editor and player — canvas waveform rendering, clip-based editing, and playback controls on top of Tone.js or a native `HTMLAudioElement`.
+
+## Features
+
+- **Multitrack editor** — `<Waveform />` renders canvas waveforms, per-track controls (mute/solo/volume/pan), a time ruler, and a playhead for any number of tracks
+- **Clip-based editing** — drag-to-move, boundary trimming with collision detection, splitting at the playhead, snap-to-grid (beats/bars or timescale), undo/redo
+- **Split context providers** — `WaveformPlaylistProvider` (multitrack, Tone.js-backed) and `MediaElementPlaylistProvider` (single-track, `<audio>`-backed with pitch-preserving playback rate)
+- **Four focused context hooks** — `usePlaybackAnimation`, `usePlaylistState`, `usePlaylistControls`, `usePlaylistData` isolate 60fps playhead updates from low-frequency state so unrelated components don't re-render on every animation frame
+- **Audio effects** — 20 Tone.js effects (reverb, delay, modulation, filter, distortion, dynamics, spatial) with runtime parameter control, master and per-track chains, plus WAM 2.0 plugin hosting
+- **Recording** — pairs with `@waveform-playlist/recording` for mic input, overdubbing, and live waveform preview
+- **Annotations & spectrogram** — optional integration contexts for `@waveform-playlist/annotations` and `@waveform-playlist/spectrogram`
+- **WAV export** — render the full mix (including effects) offline to a downloadable WAV file
+- **MediaElement player mode** — a lightweight single-track player with pitch-preserving speed control, for podcast/audiobook-style use cases that don't need multitrack mixing
+
+## Installation
+
+```bash
+npm install @waveform-playlist/browser tone @dnd-kit/react
+```
+
+`@waveform-playlist/browser` requires these peer dependencies:
+
+| Package | Purpose |
+|---------|---------|
+| `react` / `react-dom` | ^18.0.0 or ^19.0.0 |
+| `styled-components` | ^6.0.0 — CSS-in-JS styling |
+| `tone` | ^15.0.0 — Web Audio engine (optional if you supply your own `PlayoutAdapter`) |
+| `@dnd-kit/react` | ^0.3.0 — drag-and-drop (includes `@dnd-kit/dom` and `@dnd-kit/abstract`) |
+| `@waveform-playlist/playout` | Tone.js playout engine (optional peer, dynamically imported by default) |
+| `@waveform-playlist/media-element-playout` | engine for `MediaElementPlaylistProvider` (optional peer) |
+| `@waveform-playlist/annotations` / `@waveform-playlist/recording` / `@dawcore/wam` | optional, install only if you use those features |
+
+**Engine-free core:** the package's main entry has no static dependency on `tone` or `@waveform-playlist/playout` — a `MediaElementPlaylistProvider`-only consumer, or one supplying a custom `createAdapter`, never resolves either. Tone-coupled exports (`useAudioTracks`, `useDynamicTracks`, effects hooks, `useExportWav`, `useOutputMeter`, `useMasterAnalyser`) live at the **`@waveform-playlist/browser/tone`** subpath:
+
+```typescript
+import { useAudioTracks, useDynamicEffects, useExportWav } from '@waveform-playlist/browser/tone';
+```
+
+## Quick Start
+
+```tsx
+import {
+  WaveformPlaylistProvider,
+  Waveform,
+  PlayButton,
+  PauseButton,
+  StopButton,
+} from '@waveform-playlist/browser';
+import { useAudioTracks } from '@waveform-playlist/browser/tone';
+
+function MyPlaylist() {
+  const { tracks, loading, error } = useAudioTracks([
+    { src: '/audio/vocals.mp3', name: 'Vocals' },
+    { src: '/audio/guitar.mp3', name: 'Guitar' },
+  ]);
+
+  if (loading) return <div>Loading audio...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <WaveformPlaylistProvider
+      tracks={tracks}
+      samplesPerPixel={1024}
+      waveHeight={128}
+      timescale
+      controls={{ show: true, width: 200 }}
+    >
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <PlayButton />
+        <PauseButton />
+        <StopButton />
+      </div>
+      <Waveform />
+    </WaveformPlaylistProvider>
+  );
+}
+```
+
+Prefer a lightweight single-track player instead? Use `MediaElementPlaylistProvider` with `@waveform-playlist/media-element-playout` — no Tone.js, no AudioBuffer decoding, and pitch-preserving playback rate out of the box.
+
+## Context Hooks
+
+`WaveformPlaylistProvider` splits its context into four hooks so components only re-render for the data they actually read:
+
+| Hook | Exposes |
+|------|---------|
+| `usePlaybackAnimation` | `isPlaying`, `currentTime`, animation refs, `getPlaybackTime()`, `registerFrameCallback()` for 60fps-driven UI (playhead, progress bars) |
+| `usePlaylistState` | Low-frequency state — selection, loop region, annotations, `selectedTrackId`, `canUndo`/`canRedo` |
+| `usePlaylistControls` | Actions — `play`, `pause`, `stop`, `seekTo`, track mute/solo/volume/pan, zoom, undo/redo |
+| `usePlaylistData` | Derived/config data — `tracks`, `duration`, `sampleRate`, `peaksDataArray`, `trackStates`, `isReady` |
+
+`usePlaylistDataOptional` is the same as `usePlaylistData` but returns `null` outside a provider (for components that render both inside and outside one). `MediaElementPlaylistProvider` has the equivalent `useMediaElementAnimation`, `useMediaElementState`, `useMediaElementControls`, `useMediaElementData`.
+
+## Examples & Documentation
+
+- [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/) — guides, API reference, and live examples
+- [Basic Usage guide](https://naomiaro.github.io/waveform-playlist/docs/react/getting-started/basic-usage) — walkthrough of the provider pattern
+- [`examples/media-element-player`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/media-element-player) — `MediaElementPlaylistProvider` starter (`pnpm example:media-element`)
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,83 @@
+# @waveform-playlist/core
+
+Core types, interfaces and utilities for waveform-playlist — pure functions and TypeScript types with zero runtime dependencies.
+
+Used by nearly every `@waveform-playlist/*` and `@dawcore/*` package (`engine`, `playout`, `media-element-playout`, `browser`, `ui-components`, `recording`, `annotations`, `spectrogram`, `midi`, `transport`, `dawcore`, `dawcore-spectrogram`, `dawcore-midi`, `webaudio-peaks`, `loaders`, and more). Most consumers get it transitively — install it directly only if you're building on the clip model, timeline math, or fade curves yourself.
+
+## Features
+
+- **Clip & track types** — `AudioClip`, `ClipTrack`, `Timeline`, `Fade`/`FadeType`, `Peaks`/`Bits`/`PeakData`, `WaveformDataObject`
+- **Sample-based timeline math** — `createClip`/`createClipFromSeconds`/`createClipFromTicks`, clip queries (`getClipsInRange`, `clipsOverlap`, `findGaps`), and second-conversion helpers (`clipStartTime`, `clipEndTime`, `clipPixelWidth`)
+- **Fade curves** — linear, exponential, logarithmic, and S-curve generators for native Web Audio `AudioParam` (no Tone.js dependency)
+- **Decibel utilities** — gain ↔ dB ↔ normalized-0-1 conversions for meters and volume controls
+- **Peaks generation** — real-time min/max peak extraction during recording
+- **Musical time** — PPQN tick math, bar/beat conversion, time-signature meter detection, grid snapping
+- **Keyboard shortcuts** — a framework-agnostic shortcut matcher shared by the React and Web Components layers
+- **Spectrogram canvas-ID contract** — canonical build/parse helpers for the `${clipId}-ch${n}-chunk${m}` canvas ID format shared by the worker pool and rendering layers
+- **HTTP range support probing** — detect whether an audio host supports byte-range seeking
+
+## Installation
+
+```bash
+npm install @waveform-playlist/core
+```
+
+Zero dependencies — safe to install anywhere without pulling in Web Audio, React, or Tone.js.
+
+## Usage
+
+```typescript
+import { createClipFromSeconds, clipStartTime, clipEndTime, gainToDb } from '@waveform-playlist/core';
+
+// Build a clip from a decoded AudioBuffer, positioned at 2.5s on the timeline
+const clip = createClipFromSeconds({
+  audioBuffer,
+  startTime: 2.5,
+  offset: 0,
+  fadeIn: { duration: 0.5, type: 'linear' },
+});
+
+clipStartTime(clip); // 2.5
+clipEndTime(clip); // 2.5 + audioBuffer.duration
+
+// Convert a linear gain value to dB for a Tone.js Volume node
+gainToDb(0.5); // ≈ -6.02
+```
+
+```typescript
+import { buildSpectrogramCanvasId, parseSpectrogramCanvasId } from '@waveform-playlist/core';
+
+const id = buildSpectrogramCanvasId({ clipId: 'clip-1', channelIndex: 0, chunkIndex: 3 });
+// "clip-1-ch0-chunk3"
+
+parseSpectrogramCanvasId(id);
+// { clipId: 'clip-1', channelIndex: 0, chunkIndex: 3 }
+```
+
+## API
+
+| Module | Key exports |
+|---|---|
+| `types/` | `AudioClip`, `ClipTrack`, `Timeline`, `Track`, `Fade`, `FadeType`, `Peaks`, `Bits`, `PeakData`, `WaveformDataObject`, `SpectrogramConfig`, `RenderMode`, `ColorMapValue` |
+| `clipTimeHelpers` | `clipStartTime`, `clipEndTime`, `clipOffsetTime`, `clipDurationTime`, `clipPixelWidth`, `trackChannelCount` |
+| clip constructors (`types/clip`) | `createClip`, `createClipFromSeconds`, `createClipFromTicks`, `createTrack`, `createTimeline`, `getClipsInRange`, `getClipsAtSample`, `clipsOverlap`, `sortClipsByTime`, `findGaps` |
+| `fades` | `applyFadeIn`, `applyFadeOut`, `generateCurve`, `linearCurve`, `exponentialCurve`, `logarithmicCurve`, `sCurveCurve` |
+| `utils/dBUtils` | `gainToDb`, `dBToNormalized`, `normalizedToDb`, `gainToNormalized` |
+| `utils/conversions` | `samplesToSeconds`, `secondsToSamples`, `samplesToPixels`, `pixelsToSamples`, `pixelsToSeconds`, `secondsToPixels` |
+| `utils/beatsAndBars` | `PPQN`, `ticksPerBeat`, `ticksPerBar`, `ticksToSamples`, `samplesToTicks`, `snapToGrid` |
+| `utils/musicalTicks` | `computeMusicalTicks`, `snapToTicks`, `snapTickToGrid`, `SnapTo`, `MusicalTick` |
+| `utils/meterDetection` | `MeterEntry`, `detectMeterChanges` |
+| `utils/peaksGenerator` | `generatePeaks`, `appendPeaks` |
+| `utils/audioBufferUtils` | `concatenateAudioData`, `createAudioBuffer`, `appendToAudioBuffer`, `calculateDuration` |
+| `keyboard` | `KeyboardShortcut`, `handleKeyboardEvent`, `getShortcutLabel` |
+| `spectrogramCanvasId` | `buildSpectrogramCanvasId`, `parseSpectrogramCanvasId`, `SpectrogramCanvasIdParts` |
+| `probeRangeSupport` | `probeRangeSupport`, `RangeSupport` |
+| `constants` | `MAX_CANVAS_WIDTH` |
+
+## Examples & Documentation
+
+- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/dawcore-faust/README.md
+++ b/packages/dawcore-faust/README.md
@@ -70,6 +70,7 @@ const plugin = await createWamInstanceFromFactory(compiled.factory, audioContext
 
 Notes:
 
+- The `name` option (and the `{ name }` passed to `addFaustEffect`) sets the descriptor name **unless the DSP itself declares one** — `declare name "My Lowpass";` in the source wins over the option.
 - The generated plugin is a standard WAM 2.0 effect — everything in [`@dawcore/wam`'s README](https://www.npmjs.com/package/@dawcore/wam) about Faust-generated plugins (flat parameter-map state, auto-generated GUI, descriptor shape) applies.
 - Factory-created instances have no `url` and cannot be cloned with `cloneInstanceInto` — recompile the DSP on the target context instead (this is what dawcore's offline export does).
 - Effects only — Faust polyphonic instruments are out of scope.

--- a/packages/dawcore-midi/README.md
+++ b/packages/dawcore-midi/README.md
@@ -42,8 +42,8 @@ Note timings are in seconds, already tempo-adjusted by `@tonejs/midi`. Tracks wi
 
 ## Examples & Documentation
 
-- [`examples/dawcore-tone/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-tone) — MIDI piano-roll rendering and playback (`pnpm example:dawcore-tone`)
-- Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)
+- [`examples/dawcore-tone/midi-load.html`](https://github.com/naomiaro/waveform-playlist/blob/main/examples/dawcore-tone/midi-load.html) — loading a `.mid` file (URL or file input) into `<daw-editor>` via `editor.loadMidi()`, with cancellation (`pnpm example:dawcore-tone`)
+- [MIDI guide](https://naomiaro.github.io/waveform-playlist/docs/react/guides/midi) — covers both the React (`@waveform-playlist/midi`) and Web Components (`@dawcore/components`) paths, which share this package's parser underneath
 
 ## License
 

--- a/packages/dawcore-spectrogram/README.md
+++ b/packages/dawcore-spectrogram/README.md
@@ -45,7 +45,7 @@ The orchestrator renders in three tiers (visible viewport first, then a 25% over
 
 ## Entry Points
 
-- `@dawcore/spectrogram` — `computeSpectrogram`, `computeSpectrogramMono`, `getColorMap`, `getFrequencyScale`, worker factories (`createSpectrogramWorker`, `createSpectrogramWorkerPool`, `SpectrogramAbortError`), and the orchestrator re-exports
+- `@dawcore/spectrogram` — `computeSpectrogram`, `computeSpectrogramMono`, `getColorMap`, `getFrequencyScale`, `computePaddedFftRange` (pure window-padded, clip-clamped FFT sample-range math — shared with the React provider's chunk-range computation so both pipelines can't drift), worker factories (`createSpectrogramWorker`, `createSpectrogramWorkerPool`, `SpectrogramAbortError`), and the orchestrator re-exports
 - `@dawcore/spectrogram/worker/spectrogram.worker` — the Worker module URL target (resolve with `new URL(..., import.meta.url)`)
 - `@dawcore/spectrogram/orchestrator` — `SpectrogramOrchestrator` and helpers (`classifyViewport`, `groupContiguousChunks`, `ColorLUTCache`) without the computation/worker graph, for consumers with their own FFT pipeline
 

--- a/packages/dawcore-wam/README.md
+++ b/packages/dawcore-wam/README.md
@@ -136,7 +136,7 @@ const { entries, warnings } = await fetchWamLibrary(
   'https://www.webaudiomodules.com/community/plugins.json',
   { baseUrl: 'https://www.webaudiomodules.com/community/plugins/' }
 );
-// entries: [{ name, url, description?, vendor?, thumbnail?, keywords? }, ...]
+// entries: [{ name, url, description?, vendor?, thumbnail?, keywords?, category? }, ...]
 // warnings: per-entry messages for invalid entries that were skipped
 ```
 
@@ -164,12 +164,29 @@ The resulting instance has no `url`, so it cannot be cloned via `cloneInstanceIn
 
 Each entry is either:
 
-- an **object** — `name` (required) plus a plugin URL in `url` or `path` (required). Optional fields are passed through when well-formed: `description` (string), `vendor` (string), `thumbnail` (string URL), `keywords` (string array). Unknown fields are ignored.
+- an **object** — `name` (required) plus a plugin URL in `url` or `path` (required). Optional fields are passed through when well-formed: `description` (string), `vendor` (string), `thumbnail` (string URL), `keywords` (string array), `category` (string or string array — normalized to a non-empty array of trimmed strings, e.g. `["Effect"]`). Unknown fields are ignored.
 - a **bare URL string** — the plugin URL; a display name is derived from the URL path (generic segments like `index.js`, `dist`, `src` are skipped, so `…/quadrafuzz/dist/index.js` becomes `quadrafuzz`).
 
 Relative plugin and thumbnail URLs are resolved against the manifest URL — or against `options.baseUrl` for registries (like webaudiomodules.com) that keep paths relative to a directory next to the manifest.
 
 Invalid entries (missing name, missing/unresolvable URL) are skipped with a per-entry message collected into `warnings` — one bad entry never fails the manifest. An unreachable manifest, invalid JSON, an unrecognized shape, or zero valid entries rejects with a `[waveform-playlist]`-prefixed error.
+
+`category` (e.g. `Effect`/`Modulation`/`Instrument`/`MIDI`/`Video`, as tagged by the webaudiomodules.com registry) is a cheap fallback for filtering non-effect entries out of a picker UI before ever loading them — see descriptor probing below for a more reliable, per-entry check.
+
+#### Descriptor probing
+
+`category` is manifest-supplied and can be wrong or absent. `fetchWamDescriptor` reads the static `descriptor.json` that WAM SDK builds ship next to the plugin module, for a more reliable audio-I/O and WAM-version check before committing to `createWamInstance`:
+
+```typescript
+import { fetchWamDescriptor } from '@dawcore/wam';
+
+const info = await fetchWamDescriptor(
+  'https://www.webaudiomodules.com/community/plugins/burns-audio/delay/index.js'
+);
+// info: { apiVersion?, hasAudioInput?, hasAudioOutput?, hasMidiInput?, hasMidiOutput?, isInstrument? } | null
+```
+
+Best-effort and read-only — returns `null` when the plugin ships no readable descriptor (unreachable, non-OK response, invalid JSON, wrong shape); absence is expected for many registries, not an error. A descriptor with no boolean flags resolves to `{}` (distinct from `null`): the SDK defaults `hasAudioInput`/`hasAudioOutput` to `true` at runtime, so treat a **missing** flag as capable and gate only on an explicit `false` — never require `=== true`. `apiVersion` is asymmetric the same way: the SDK only stamps it reliably on the *runtime* instance descriptor, so a static probe can positively identify WAM 1.0 (a declared value starting with `"1"`) but an absent field usually just means a WAM 2.0 build that omitted it. `createWamInstance` remains authoritative at load time regardless of what this probe reports.
 
 ### Plugin GUIs
 

--- a/packages/dawcore/README.md
+++ b/packages/dawcore/README.md
@@ -21,6 +21,8 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 - **Effect GUIs and persistence** — Mount plugin GUIs into your own panels; snapshot and restore whole chains. See [Effect GUIs](#effect-guis) and [Effects Persistence](#effects-persistence).
 - **Offline export** — `editor.exportAudio()` renders the session (clips, mix, all effect chains) to an `AudioBuffer`. See [Offline Export](#offline-export).
 - **Transport access** — Tempo, metronome, count-in, meter, effects via `@dawcore/transport`
+- **Lightweight single-track player** — `<daw-player>` wraps `@waveform-playlist/media-element-playout` (`HTMLMediaElement`, no adapter/AudioContext/PlaylistEngine) for podcast/audiobook-style playback with pitch-preserving rate control (0.25×–4×). See [Single-Track Player](#single-track-player).
+- **Time display & format** — `<daw-time-display>` / `<daw-time-format>` show and switch the playback clock (`hh:mm:ss.sss`, `hh:mm:ss`, `seconds`) for any transport target.
 - **CSS theming** — Dark mode by default, fully customizable via CSS custom properties
 - **Native Web Audio** — Uses `@dawcore/transport` for playback scheduling. No Tone.js dependency.
 
@@ -351,6 +353,33 @@ const result = await editor.loadFiles(fileList);
 </script>
 ```
 
+## Single-Track Player
+
+`<daw-player>` is a standalone element for single-track playback (podcasts, audiobooks, previewing one file) — it wraps `@waveform-playlist/media-element-playout` and needs no `adapter`, `AudioContext`, or `PlaylistEngine`. `@waveform-playlist/media-element-playout` ships as a direct dependency of `@dawcore/components`, so there's nothing extra to install:
+
+```html
+<daw-player
+  id="player"
+  src="/audio/episode.mp3"
+  peaks-src="/audio/episode.dat"
+  wave-height="96"
+  timescale
+></daw-player>
+
+<script type="module">
+  import '@dawcore/components';
+
+  const player = document.getElementById('player');
+  player.addEventListener('daw-ready', () => console.log('duration:', player.duration));
+  player.addEventListener('daw-timeupdate', (e) => console.log(e.detail.time));
+
+  player.play();
+  player.setPlaybackRate(1.5); // pitch-preserving, 0.25x-4x
+</script>
+```
+
+Click the waveform to seek. Omit `peaks-src` for a scrubber-only fallback (no waveform, still playable). See `examples/dawcore-native/player.html` for a runnable demo with both modes.
+
 ## Keyboard Shortcuts
 
 Add `<daw-keyboard-shortcuts>` as a child of `<daw-editor>`:
@@ -412,11 +441,13 @@ Core orchestrator. Attributes:
 | `file-drop` | boolean | `false` | Accept audio files dropped onto the editor |
 | `mono` | boolean | `false` | Merge stereo to mono display |
 | `bar-width` / `bar-gap` | number | `1` / `0` | Waveform bar rendering style |
+| `rounded-bars` | boolean | `false` | Pill-shaped bar caps (radius `bar-width / 2`) |
 | `indefinite-playback` | boolean | `false` | Keep ruler/timeline filling the viewport with no clips |
 | `scale-mode` | string | `'temporal'` | `'temporal'` (seconds) or `'beats'` (tick-linear grid) |
 | `ticks-per-pixel` | number | `24` | Zoom level in beats mode |
 | `snap-to` | string | `'off'` | Grid snapping in beats mode (`'bar'`, `'beat'`, `'1/2'`…`'1/16'`, `'off'`) |
 | `eager-resume` | string | — | Resume AudioContext on first gesture; bare attribute targets the editor, or pass `"document"` / a CSS selector |
+| `time-format` | string | `'hh:mm:ss.sss'` | Clock format read by `<daw-time-display>` / `<daw-time-format>`: `'hh:mm:ss.sss'`, `'hh:mm:ss'`, or `'seconds'` |
 
 JS properties: `adapter` (required `PlayoutAdapter`), `recordingStream`, `bpm`, `ppqn`, `timeSignature`, `meterEntries`, `secondsToTicks` / `ticksToSeconds` (variable-tempo callbacks), `spectrogramConfig`, `spectrogramColorMap`. Read-only: `engine`, `audioContext` (from the adapter), `tracks`, `selection`, `selectedTrackId`, `currentTime`, `canUndo` / `canRedo`, `isRecording`.
 
@@ -424,6 +455,7 @@ Methods:
 
 - Playback: `play(startTime?)`, `pause()`, `stop()`, `togglePlayPause()`, `seekTo(time)`
 - Loading: `loadFiles(files)`, `loadMidi(urlOrFile, options?)`, `ready()`
+- Display: `setTimeFormat(format)` — sugar over the `timeFormat` property, fires `daw-time-format-change`
 - Tracks & clips: `addTrack(config)`, `removeTrack(id)`, `updateTrack(id, partial)`, `addClip(trackId, config)`, `removeClip(trackId, clipId)`, `updateClip(trackId, clipId, partial)`
 - Editing: `splitAtPlayhead()`, `undo()`, `redo()`, `setSelection(start, end)`
 - Recording: `startRecording(stream?, options?)`, `stopRecording()`, `pauseRecording()`, `resumeRecording()`, `togglePauseRecording()`
@@ -443,7 +475,7 @@ Visual element for MIDI note rendering. Mounted automatically when the parent tr
 
 ### `<daw-transport for="editor-id">`
 
-Container that resolves target editor. Children: `<daw-play-button>`, `<daw-pause-button>`, `<daw-stop-button>`, `<daw-record-button>`.
+Container that resolves target editor. Children: `<daw-play-button>`, `<daw-pause-button>`, `<daw-stop-button>`, `<daw-record-button>`, `<daw-time-display>`, `<daw-time-format>`.
 
 ### `<daw-track-controls>`
 
@@ -452,6 +484,26 @@ Per-track UI for volume, pan, mute, solo. Receives state from editor, dispatches
 ### `<daw-keyboard-shortcuts>`
 
 Render-less child of `<daw-editor>`. Boolean attributes: `playback`, `splitting`, `undo`.
+
+### `<daw-time-display>`
+
+Formatted playback-time readout. Must be inside a `<daw-transport for="editor-id">` (resolves its target the same way the transport buttons do). Reads the target's `currentTime` / `timeFormat` and stays in sync via bubbled `daw-timeupdate` / `daw-time-format-change` events. `role="status"`, `aria-live="off"`.
+
+### `<daw-time-format>`
+
+`<select>` that sets the time format on the transport target (`target.setTimeFormat(...)`) — the target owns the state, every display/select syncs via `daw-time-format-change`. Renders disabled when the target doesn't implement `setTimeFormat`.
+
+### `<daw-player>`
+
+Standalone single-track player — see [Single-Track Player](#single-track-player). No `adapter`/`AudioContext`/`PlaylistEngine`; wraps `@waveform-playlist/media-element-playout`.
+
+Attributes: `src`, `peaks-src`, `wave-height` (default `128`), `timescale`, `mono`, `bar-width` (default `1`), `bar-gap` (default `0`), `rounded-bars`, `playback-rate` (default `1`, clamped `0.25`–`4`).
+
+Properties: `isPlaying`, `duration`, `currentTime` (get/set), `volume` (get/set), `audioElement` (underlying `HTMLAudioElement | null`).
+
+Methods: `play()`, `pause()`, `stop()`, `seekTo(time)`, `setPlaybackRate(rate)`, `setVolume(volume)`.
+
+Events: `daw-ready`, `daw-play`, `daw-pause`, `daw-stop`, `daw-timeupdate` (`{ time }`), `daw-ended`, `daw-error` (`{ operation, error }`).
 
 ## Events
 
@@ -508,7 +560,7 @@ Set the adapter before tracks load. The provided context is used for decoding, p
 
 ## Examples & Documentation
 
-- [`examples/dawcore-native/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-native) — native transport: basics, multi-clip, metronome, beats grid, beat maps, effects, spectrogram, recording (`pnpm example:dawcore-native`)
+- [`examples/dawcore-native/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-native) — native transport: basics, multi-clip, metronome, beats grid, beat maps, effects, spectrogram, recording, `<daw-player>` (`pnpm example:dawcore-native`)
 - [`examples/dawcore-tone/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-tone) — Tone.js adapter: MIDI, SoundFont playback (`pnpm example:dawcore-tone`)
 - [`examples/dawcore-wam/`](https://github.com/naomiaro/waveform-playlist/tree/main/examples/dawcore-wam) — WAM plugins end-to-end + in-browser Faust compilation (`pnpm example:dawcore-wam`)
 - Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started)

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,188 @@
+# @waveform-playlist/engine
+
+Framework-agnostic multitrack timeline engine for waveform-playlist — pure clip/track operations plus a stateful `PlaylistEngine` that manages tracks, selection, loop, zoom, and undo/redo, decoupled from any audio backend via a pluggable `PlayoutAdapter`.
+
+Used by `@waveform-playlist/browser` (the React provider) and `@dawcore/components` (the Lit web-components layer). Pair it with a `PlayoutAdapter` implementation such as `@waveform-playlist/playout` (Tone.js) or `@dawcore/transport` (native Web Audio) to actually produce sound — the engine itself never touches the audio graph directly.
+
+## Features
+
+- **Clip-based timeline model** — tracks hold multiple clips; move, trim, and split with automatic collision constraints
+- **Sample + tick timeline math** — integer samples for precision, ticks for tempo-independent positioning
+- **Undo/redo** — snapshot-based history for all structural mutations, with transaction grouping for drag gestures
+- **Selection, loop, and zoom state** — engine owns selection range, loop region, zoom level, and master volume
+- **`statechange` events** — subscribe once and mirror a single `EngineState` snapshot into any UI framework
+- **Adapter-pluggable playback** — bring your own `PlayoutAdapter` (Tone.js, native Web Audio, or a custom backend); the engine runs headless without one
+
+## Installation
+
+```bash
+npm install @waveform-playlist/engine @waveform-playlist/core
+```
+
+`@waveform-playlist/core` is a required peer dependency (`>=7.0.0`) — it provides the `ClipTrack`/`AudioClip` types and clip-construction helpers used below.
+
+## Quick Start
+
+```typescript
+import { PlaylistEngine } from '@waveform-playlist/engine';
+import { createClipFromSeconds, type ClipTrack } from '@waveform-playlist/core';
+import { TonePlayout } from '@waveform-playlist/playout'; // any PlayoutAdapter implementation
+
+const adapter = new TonePlayout();
+const engine = new PlaylistEngine({ adapter, sampleRate: 48000 });
+await engine.init();
+
+const track: ClipTrack = {
+  id: 'track-1',
+  name: 'Guitar',
+  clips: [
+    createClipFromSeconds({
+      audioBuffer, // decoded AudioBuffer
+      startTime: 0,
+    }),
+  ],
+  muted: false,
+  soloed: false,
+  volume: 1.0,
+  pan: 0,
+};
+
+engine.setTracks([track]);
+
+// Subscribe once; mirror EngineState into your framework's state
+engine.on('statechange', (state) => {
+  console.log('duration:', state.duration, 'currentTime:', state.currentTime);
+});
+
+// Transport
+engine.play(); // resumes from current position
+engine.seek(5); // seek to 5 seconds
+engine.pause();
+engine.stop(); // returns to the position playback started from
+
+// Clip editing (all undoable, all emit statechange)
+engine.moveClip('track-1', track.clips[0].id, 48000); // shift 1s right (in samples)
+engine.trimClip('track-1', track.clips[0].id, 'left', 24000);
+engine.splitClip('track-1', track.clips[0].id, 96000);
+
+engine.undo();
+engine.redo();
+```
+
+## API
+
+### PlaylistEngine
+
+Key methods (see `src/types.ts` for the full `EngineState` shape):
+
+```typescript
+class PlaylistEngine {
+  constructor(options?: PlaylistEngineOptions);
+
+  // Tracks
+  setTracks(tracks: ClipTrack[]): void;
+  addTrack(track: ClipTrack): void;
+  removeTrack(trackId: string): void;
+  updateTrack(trackId: string, track?: ClipTrack): void;
+  selectTrack(trackId: string | null): void;
+
+  // Clip editing (undoable)
+  moveClip(trackId: string, clipId: string, deltaSamples: number, skipAdapter?: boolean): number;
+  trimClip(trackId: string, clipId: string, boundary: 'left' | 'right', deltaSamples: number, skipAdapter?: boolean): void;
+  splitClip(trackId: string, clipId: string, atSample: number): void;
+  constrainTrimDelta(trackId: string, clipId: string, boundary: 'left' | 'right', deltaSamples: number): number;
+
+  // Playback (no-ops without an adapter)
+  init(): Promise<void>;
+  play(startTime?: number, endTime?: number): void;
+  pause(): void;
+  stop(): void;
+  seek(time: number): void;
+  getCurrentTime(): number;
+  getAudibleTime(): number; // latency-compensated position for playheads/UI
+
+  // Selection, loop, zoom, volume
+  setSelection(start: number, end: number): void;
+  setLoopRegion(start: number, end: number): void;
+  setLoopEnabled(enabled: boolean): void;
+  setMasterVolume(volume: number): void;
+  setTrackVolume(trackId: string, volume: number): void;
+  setTrackMute(trackId: string, muted: boolean): void;
+  setTrackSolo(trackId: string, soloed: boolean): void;
+  setTrackPan(trackId: string, pan: number): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  setZoomLevel(samplesPerPixel: number): void;
+  setTempo(bpm: number, atTick?: number): void;
+
+  // Undo/redo
+  undo(): void;
+  redo(): void;
+  clearHistory(): void;
+  beginTransaction(): void;
+  commitTransaction(): void;
+  abortTransaction(): void;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+
+  // State & events
+  getState(): EngineState;
+  on<K extends keyof EngineEvents>(event: K, listener: EngineEvents[K]): void;
+  off<K extends keyof EngineEvents>(event: K, listener: EngineEvents[K]): void; // 'statechange' | 'play' | 'pause' | 'stop'
+
+  dispose(): void;
+}
+```
+
+### PlayoutAdapter
+
+The interface an audio backend implements to plug into the engine:
+
+```typescript
+interface PlayoutAdapter {
+  readonly audioContext: AudioContext;
+  readonly ppqn: number;
+  setPpqn?(ppqn: number): void;
+
+  init(): Promise<void>;
+  setTracks(tracks: ClipTrack[]): void;
+  addTrack?(track: ClipTrack): void;
+  removeTrack?(trackId: string): void;
+  updateTrack?(trackId: string, track: ClipTrack): void;
+
+  play(startTime: number, endTime?: number): void;
+  pause(): void;
+  stop(): void;
+  seek(time: number): void;
+  getCurrentTime(): number;
+  isPlaying(): boolean;
+
+  setMasterVolume(volume: number): void;
+  setTrackVolume(trackId: string, volume: number): void;
+  setTrackMute(trackId: string, muted: boolean): void;
+  setTrackSolo(trackId: string, soloed: boolean): void;
+  setTrackPan(trackId: string, pan: number): void;
+  setLoop(enabled: boolean, start: number, end: number): void;
+
+  setTempo?(bpm: number, atTick?: number): boolean | void;
+  setMeter?(numerator: number, denominator: number, atTick?: number): void;
+  ticksToSeconds?(tick: number): number;
+  secondsToTicks?(seconds: number): number;
+
+  dispose(): void;
+}
+```
+
+Implement this against your own audio backend to use the engine outside Tone.js or native Web Audio — everything else (undo/redo, clip constraints, timeline state) works the same headless or adapted.
+
+### Pure operations
+
+`src/operations` exports framework-free helper functions the engine itself is built on — `constrainClipDrag`, `constrainBoundaryTrim`, `splitClip`, `canSplitAt`, `calculateDuration`, `findClosestZoomIndex`, `calculateViewportBounds`, `getVisibleChunkIndices`, and more — useful if you need the raw math without the stateful class.
+
+## Examples & Documentation
+
+- [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/loaders/README.md
+++ b/packages/loaders/README.md
@@ -1,0 +1,116 @@
+# @waveform-playlist/loaders
+
+Audio loaders for waveform-playlist — fetch or read a URL, `Blob`, or `File` and decode it into a Web Audio `AudioBuffer`, with progress and state-change events along the way.
+
+## Installation
+
+```bash
+npm install @waveform-playlist/loaders
+```
+
+## Usage
+
+```typescript
+import { LoaderFactory } from '@waveform-playlist/loaders';
+
+const audioContext = new AudioContext();
+
+// Works with a URL string (uses XHRLoader) or a Blob/File (uses BlobLoader)
+const loader = LoaderFactory.createLoader('/audio/track.mp3', audioContext);
+
+loader.on('loadprogress', (percentComplete) => {
+  console.log(`Loading: ${percentComplete.toFixed(0)}%`);
+});
+
+loader.on('audiorequeststatechange', (state) => {
+  console.log('State:', state); // 'loading' | 'decoding' | 'finished' | 'error'
+});
+
+loader.on('error', (error) => {
+  console.error('Failed to load audio:', error.message);
+});
+
+const audioBuffer = await loader.load();
+console.log(audioBuffer.duration, audioBuffer.numberOfChannels);
+```
+
+Loading from a file input (`File` extends `Blob`, so the same factory call routes to `BlobLoader`):
+
+```typescript
+const file = fileInput.files[0];
+const fileLoader = LoaderFactory.createLoader(file, audioContext);
+const buffer = await fileLoader.load();
+```
+
+## API
+
+### `LoaderFactory`
+
+```typescript
+class LoaderFactory {
+  // Returns an XHRLoader for a URL string, a BlobLoader for a Blob/File.
+  // Throws if src is neither.
+  static createLoader(src: string | Blob, audioContext: BaseAudioContext): Loader;
+}
+```
+
+### `Loader` (abstract base class)
+
+Both `XHRLoader` and `BlobLoader` extend `Loader`, which extends `EventEmitter` (from `eventemitter3`) and handles the shared `decodeAudioData` step and state tracking.
+
+```typescript
+enum LoaderState {
+  UNINITIALIZED = 'uninitialized',
+  LOADING = 'loading',
+  DECODING = 'decoding',
+  FINISHED = 'finished',
+  ERROR = 'error',
+}
+
+interface LoaderEvents {
+  loadprogress: (percentComplete: number, src: string | Blob) => void;
+  audiorequeststatechange: (state: LoaderState, src: string | Blob) => void;
+  error: (error: Error) => void;
+}
+
+abstract class Loader {
+  constructor(src: Blob | string, audioContext: BaseAudioContext);
+
+  abstract load(): Promise<AudioBuffer>;
+
+  getState(): LoaderState;
+  getAudioBuffer(): AudioBuffer | undefined;
+
+  // EventEmitter methods (on/off/once/emit, etc.) over LoaderEvents
+}
+```
+
+### `XHRLoader`
+
+Loads a URL via `XMLHttpRequest` (`responseType: 'arraybuffer'`), emitting `loadprogress` on the XHR `progress` event and rejecting with a descriptive `Error` on non-2xx status, network error, or abort.
+
+```typescript
+class XHRLoader extends Loader {
+  constructor(src: string, audioContext: BaseAudioContext);
+  load(): Promise<AudioBuffer>;
+}
+```
+
+### `BlobLoader`
+
+Loads a `Blob` or `File` via `FileReader.readAsArrayBuffer`, emitting `loadprogress` on the reader's `progress` event. Rejects if the blob's MIME type doesn't match `audio/*` (or `video/ogg`, accepted for Firefox's Ogg mistagging).
+
+```typescript
+class BlobLoader extends Loader {
+  constructor(src: Blob, audioContext: BaseAudioContext);
+  load(): Promise<AudioBuffer>;
+}
+```
+
+## Examples & Documentation
+
+Guides: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/media-element-playout/README.md
+++ b/packages/media-element-playout/README.md
@@ -4,7 +4,7 @@ A lightweight, HTMLMediaElement-based playout engine for waveform-playlist with 
 
 ## Features
 
-- **Pitch-preserving playback rate** (0.5x - 2.0x) - uses browser's built-in time-stretching
+- **Pitch-preserving playback rate** (0.25x - 4.0x) - uses browser's built-in time-stretching
 - **Pre-computed peaks** - no AudioBuffer decoding required, instant visualization
 - **Lightweight** - no Tone.js dependency
 - **Simple API** - designed for single-track playback use cases
@@ -69,7 +69,7 @@ playout.dispose();
 ```typescript
 interface MediaElementPlayoutOptions {
   masterVolume?: number;  // 0.0 to 1.0 (default: 1.0)
-  playbackRate?: number;  // 0.5 to 2.0 (default: 1.0)
+  playbackRate?: number;  // 0.25 to 4.0 (default: 1.0)
 }
 
 class MediaElementPlayout {
@@ -97,7 +97,7 @@ class MediaElementPlayout {
 
   // Volume & Rate
   setMasterVolume(volume: number): void;
-  setPlaybackRate(rate: number): void;  // 0.5 to 2.0, pitch preserved
+  setPlaybackRate(rate: number): void;  // 0.25 to 4.0, pitch preserved
 
   // State
   readonly isPlaying: boolean;

--- a/packages/midi/README.md
+++ b/packages/midi/README.md
@@ -1,0 +1,128 @@
+# @waveform-playlist/midi
+
+MIDI file loading and parsing for waveform-playlist — fetch a `.mid` file (or use pre-parsed notes) and get back `ClipTrack[]` ready to hand to `WaveformPlaylistProvider`.
+
+This package is the React wrapper over [`@dawcore/midi`](https://www.npmjs.com/package/@dawcore/midi) (the framework-agnostic parser, re-exported here) plus a `useMidiTracks` hook that produces waveform-playlist's clip/track shape. It only handles the data pipeline — `.mid` → notes → `ClipTrack`. Pair it with `@waveform-playlist/browser` for the playlist UI and `@waveform-playlist/playout` (piano-roll rendering + SoundFont/PolySynth playback via Tone.js) for actual MIDI sound.
+
+## Features
+
+- Parse `.mid` files from an `ArrayBuffer` or fetch by URL (`parseMidiFile`, `parseMidiUrl`)
+- `useMidiTracks` React hook — loads one or more MIDI configs into `ClipTrack[]` with loading/error state
+- Accepts pre-parsed `midiNotes` to skip fetch+parse entirely
+- Multi-track MIDI files expand to one `ClipTrack` per track by default, or merge into one with `flatten: true`
+- GM instrument naming (percussion detection, program-number lookup) and per-note channel preserved for multi-timbral playback
+
+## Installation
+
+```bash
+npm install @waveform-playlist/midi @waveform-playlist/browser
+```
+
+`react` is a peer dependency. `@dawcore/midi`, `@tonejs/midi`, and `@waveform-playlist/core` are regular dependencies — installed automatically.
+
+## Usage
+
+```tsx
+import { useMidiTracks } from '@waveform-playlist/midi';
+import { WaveformPlaylistProvider } from '@waveform-playlist/browser';
+
+function MidiPlaylist() {
+  const audioContext = new AudioContext();
+
+  const { tracks, loading, error } = useMidiTracks(
+    [{ src: '/music/song.mid', name: 'Piano' }],
+    { sampleRate: audioContext.sampleRate }
+  );
+
+  if (loading) return <p>Loading MIDI…</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  return <WaveformPlaylistProvider tracks={tracks}>{/* your UI */}</WaveformPlaylistProvider>;
+}
+```
+
+Parsing without React (e.g. a Node script or a custom loader):
+
+```typescript
+import { parseMidiFile, parseMidiUrl } from '@waveform-playlist/midi';
+
+const parsed = await parseMidiUrl('/music/song.mid');
+console.log(parsed.tracks.map((t) => t.name)); // ['Piano', 'Drums', ...]
+```
+
+## API
+
+### `useMidiTracks(configs, options)`
+
+```typescript
+function useMidiTracks(
+  configs: MidiTrackConfig[],
+  options: UseMidiTracksOptions
+): UseMidiTracksReturn;
+
+interface MidiTrackConfig {
+  src?: string; // URL to a .mid file (fetched + parsed)
+  midiNotes?: MidiNoteData[]; // pre-parsed notes — skips fetch+parse
+  name?: string;
+  muted?: boolean;
+  soloed?: boolean;
+  volume?: number; // default 1.0
+  pan?: number; // default 0
+  color?: string;
+  startTime?: number; // clip position on timeline, in seconds (default 0)
+  duration?: number; // override clip duration in seconds
+  flatten?: boolean; // merge all tracks in the file into one ClipTrack (default false)
+}
+
+interface UseMidiTracksOptions {
+  sampleRate: number; // pass AudioContext.sampleRate — MIDI has no native sample rate
+}
+
+interface UseMidiTracksReturn {
+  tracks: ClipTrack[];
+  loading: boolean;
+  error: string | null;
+  loadedCount: number;
+  totalCount: number;
+}
+```
+
+### `parseMidiFile(data, options?)` / `parseMidiUrl(url, options?, signal?)`
+
+Re-exported from `@dawcore/midi`.
+
+```typescript
+function parseMidiFile(data: ArrayBuffer, options?: ParseMidiOptions): ParsedMidi;
+function parseMidiUrl(url: string, options?: ParseMidiOptions, signal?: AbortSignal): Promise<ParsedMidi>;
+
+interface ParseMidiOptions {
+  flatten?: boolean; // merge all tracks into one ParsedMidiTrack
+}
+
+interface ParsedMidi {
+  tracks: ParsedMidiTrack[];
+  duration: number; // seconds
+  name: string; // song name from MIDI header
+  bpm: number; // first tempo in the file (default 120)
+  timeSignature: [number, number]; // default [4, 4]
+}
+
+interface ParsedMidiTrack {
+  name: string;
+  notes: MidiNoteData[]; // { midi, name, time, duration, velocity, channel }
+  duration: number; // seconds
+  channel: number; // 9 = GM percussion
+  instrument: string;
+  programNumber: number; // GM program number (0-127)
+}
+```
+
+## Examples & Documentation
+
+- [MIDI guide](https://naomiaro.github.io/waveform-playlist/docs/react/guides/midi) — piano-roll rendering, SoundFont playback, and full walkthrough
+- [MIDI example](https://naomiaro.github.io/waveform-playlist/examples/midi)
+- [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/playout/README.md
+++ b/packages/playout/README.md
@@ -1,6 +1,29 @@
 # @waveform-playlist/playout
 
-Tone.js-based `PlayoutAdapter` for [`@waveform-playlist/engine`](https://www.npmjs.com/package/@waveform-playlist/engine) — drives playback, recording, and effects on a shared global audio context. Used by `@waveform-playlist/browser` (the React surface). For native Web Audio (no Tone.js), see `@dawcore/transport`.
+Tone.js-based `PlayoutAdapter` for [`@waveform-playlist/engine`](https://www.npmjs.com/package/@waveform-playlist/engine) — drives playback, recording, and effects on a shared global Tone.js audio context. Used by `@waveform-playlist/browser` (the React surface). For native Web Audio (no Tone.js), see `@dawcore/transport`.
+
+## Installation
+
+```bash
+npm install @waveform-playlist/playout
+```
+
+Requires `tone` (`^15.0.0`) as a peer dependency — this package doesn't bundle Tone.js, so the version in your app is the one that runs. `@waveform-playlist/engine` is an optional peer; most consumers pull in both automatically via `@waveform-playlist/browser` rather than installing this package directly.
+
+## Usage
+
+```typescript
+import { createToneAdapter } from '@waveform-playlist/playout';
+import { PlaylistEngine } from '@waveform-playlist/engine';
+
+const adapter = createToneAdapter();
+const engine = new PlaylistEngine({ adapter });
+
+engine.setTracks(tracks); // ClipTrack[]
+engine.play(0);
+```
+
+`createToneAdapter()` eagerly creates the shared global Tone.js context before building its audio graph, so `adapter.audioContext` is guaranteed to be the same context the playout's nodes are on.
 
 ## Audio context is a standardized-audio-context ponyfill
 
@@ -19,3 +42,7 @@ await addRecordingWorkletModule((url) => ctx.audioWorklet.addModule(url));
 ```
 
 If you genuinely need a native `AudioContext`, own it yourself via the web-components adapter surface (`@dawcore/*`), which uses native Web Audio rather than Tone.
+
+## License
+
+MIT

--- a/packages/recording/README.md
+++ b/packages/recording/README.md
@@ -1,14 +1,17 @@
 # @waveform-playlist/recording
 
-Audio recording support for waveform-playlist using AudioWorklet.
+Audio recording support for waveform-playlist using AudioWorklet — mic capture, live waveform preview, VU metering, and overdub, as a set of React hooks.
 
 ## Features
 
-- ✅ **AudioWorklet-based recording** - Low latency, direct PCM access
-- ✅ **Real-time waveform visualization** - See the waveform as you record
-- ✅ **React hooks** - Easy integration with React apps
-- ✅ **Device selection** - Choose from available microphone inputs
-- ✅ **Optional package** - Only include if you need recording
+- **AudioWorklet-based capture** — direct PCM access on the audio thread, no `ScriptProcessorNode`
+- **Live waveform preview** — incremental per-channel peaks as you record, before the final `AudioBuffer` exists
+- **Sample-accurate VU metering** — a dedicated meter worklet measures peak/RMS on every sample, not just once per animation frame
+- **Multi-channel recording** — auto-detects the microphone's actual channel count from the `MediaStream`
+- **Overdub with latency compensation** — record against existing playback; the finalized clip's timeline position accounts for output latency and Tone.js scheduling lookahead, with an optional manual override
+- **Device selection & hot-plug** — enumerate microphones, switch devices mid-session, auto-fallback if the active device disconnects
+- **Pause/resume** — pauses the worklet itself, not just the UI
+- **Hooks only** — no bundled UI components; wire the state into your own controls or `@waveform-playlist/ui-components`'s `SegmentedVUMeter`
 
 ## Installation
 
@@ -16,113 +19,120 @@ Audio recording support for waveform-playlist using AudioWorklet.
 npm install @waveform-playlist/recording
 ```
 
+`@waveform-playlist/recording` requires these peer dependencies:
+
+| Package | Purpose |
+|---------|---------|
+| `react` | ^18.0.0 |
+| `styled-components` | ^6.0.0 — required transitively by `@waveform-playlist/ui-components` |
+| `tone` | ^15.0.0 — recording shares the global AudioContext with `@waveform-playlist/playout` |
+
+Pairs with `@waveform-playlist/browser` — see the [Recording guide](https://naomiaro.github.io/waveform-playlist/docs/react/guides/recording) for a full `WaveformPlaylistProvider` integration.
+
 ## Usage
 
 ### Basic Recording
 
-```typescript
-import { useRecording, useMicrophoneAccess, RecordButton } from '@waveform-playlist/recording';
+```tsx
+import { useMicrophoneAccess, useRecording } from '@waveform-playlist/recording';
 
-function RecordingApp() {
-  const { stream, requestAccess } = useMicrophoneAccess();
-  const { isRecording, startRecording, stopRecording, peaks, duration } = useRecording(stream);
+function RecordButton() {
+  const { stream, hasPermission, requestAccess } = useMicrophoneAccess();
+  const { isRecording, duration, peaks, startRecording, stopRecording } = useRecording(stream);
 
   const handleRecord = async () => {
-    if (!stream) {
+    if (!hasPermission) {
       await requestAccess();
+      return;
     }
 
     if (isRecording) {
       const audioBuffer = await stopRecording();
-      // Use the recorded audio buffer
+      // audioBuffer is the finalized AudioBuffer — add it to a track, upload it, etc.
     } else {
       await startRecording();
     }
   };
 
   return (
-    <div>
-      <RecordButton isRecording={isRecording} onClick={handleRecord} />
-      <p>Duration: {duration.toFixed(1)}s</p>
-      {/* Display waveform using peaks */}
-    </div>
+    <button onClick={handleRecord}>
+      {isRecording ? `Stop (${duration.toFixed(1)}s)` : 'Record'}
+    </button>
   );
 }
 ```
 
-### With Microphone Selection
+### VU Meter
 
-```typescript
-import {
-  useMicrophoneAccess,
-  useRecording,
-  MicrophoneSelector,
-  RecordButton,
-  RecordingIndicator,
-} from '@waveform-playlist/recording';
+`useMicrophoneLevel` drives level monitoring independently of recording — useful for an input-check screen before the user hits record.
 
-function RecordingApp() {
-  const { stream, devices, requestAccess } = useMicrophoneAccess();
-  const { isRecording, duration, startRecording, stopRecording } = useRecording(stream);
-  const [selectedDevice, setSelectedDevice] = useState<string>();
+```tsx
+import { useMicrophoneAccess, useMicrophoneLevel } from '@waveform-playlist/recording';
+import { SegmentedVUMeter } from '@waveform-playlist/ui-components';
 
-  const handleDeviceChange = async (deviceId: string) => {
-    setSelectedDevice(deviceId);
-    await requestAccess(deviceId);
-  };
-
-  return (
-    <div>
-      <MicrophoneSelector
-        devices={devices}
-        selectedDeviceId={selectedDevice}
-        onDeviceChange={handleDeviceChange}
-      />
-      <RecordButton
-        isRecording={isRecording}
-        onClick={isRecording ? stopRecording : startRecording}
-      />
-      <RecordingIndicator isRecording={isRecording} duration={duration} />
-    </div>
-  );
-}
-```
-
-### Integration with WaveformPlaylist
-
-```typescript
-import { WaveformPlaylistProvider, Waveform } from '@waveform-playlist/browser';
-import { useRecording, useMicrophoneAccess } from '@waveform-playlist/recording';
-
-function RecordingPlaylist() {
+function MicMonitor() {
   const { stream, requestAccess } = useMicrophoneAccess();
-  const { peaks, audioBuffer, startRecording, stopRecording } = useRecording(stream);
-  const [tracks, setTracks] = useState([]);
-
-  const handleStopRecording = async () => {
-    const buffer = await stopRecording();
-    if (buffer) {
-      // Add recorded track to playlist
-      setTracks([
-        ...tracks,
-        {
-          src: buffer,
-          name: 'Recording',
-        },
-      ]);
-    }
-  };
+  const { levels, peakLevels } = useMicrophoneLevel(stream, { channelCount: 2 });
 
   return (
-    <WaveformPlaylistProvider tracks={tracks}>
-      <button onClick={requestAccess}>Request Microphone</button>
-      <button onClick={startRecording}>Record</button>
-      <button onClick={handleStopRecording}>Stop</button>
-      <Waveform />
-    </WaveformPlaylistProvider>
+    <>
+      <button onClick={() => requestAccess()}>Enable Microphone</button>
+      <SegmentedVUMeter levels={levels} peakLevels={peakLevels} />
+    </>
   );
 }
 ```
+
+### Integrated Recording (with a track list)
+
+`useIntegratedRecording` combines microphone access, metering, and recording into one hook that appends the finalized clip directly to a `ClipTrack[]` — the same array shape used by `@waveform-playlist/browser`'s `WaveformPlaylistProvider`.
+
+```tsx
+import { useIntegratedRecording } from '@waveform-playlist/recording';
+import type { ClipTrack } from '@waveform-playlist/core';
+
+function Recorder({
+  tracks,
+  setTracks,
+  selectedTrackId,
+  currentTime,
+}: {
+  tracks: ClipTrack[];
+  setTracks: (tracks: ClipTrack[]) => void;
+  selectedTrackId: string | null;
+  currentTime: number;
+}) {
+  const {
+    isRecording,
+    duration,
+    levels,
+    peakLevels,
+    devices,
+    selectedDevice,
+    requestMicAccess,
+    changeDevice,
+    startRecording,
+    stopRecording,
+    recordingPeaks, // live per-channel peaks — feed straight into your waveform preview
+    error,
+  } = useIntegratedRecording(tracks, setTracks, selectedTrackId, {
+    currentTime,
+    channelCount: 2,
+  });
+
+  return (
+    <div>
+      <button onClick={() => requestMicAccess()}>Enable Microphone</button>
+      <button onClick={isRecording ? stopRecording : startRecording} disabled={!selectedTrackId}>
+        {isRecording ? `Stop (${duration.toFixed(1)}s)` : 'Record'}
+      </button>
+      {error && <p>{error.message}</p>}
+    </div>
+  );
+}
+```
+
+Stopping adds a new `AudioClip` to `selectedTrackId` at `max(currentTime at record-start, end of last clip on that track)` — safe for overdubbing onto a track that already has clips.
 
 ## API Reference
 
@@ -130,93 +140,95 @@ function RecordingPlaylist() {
 
 #### `useMicrophoneAccess()`
 
-Manages microphone access and device enumeration.
+Manages microphone permission, device enumeration, and hot-plug detection.
 
-**Returns:**
-- `stream: MediaStream | null` - Active microphone stream
-- `devices: MicrophoneDevice[]` - Available microphone devices
-- `hasPermission: boolean` - Whether microphone permission is granted
-- `isLoading: boolean` - Loading state during access request
-- `requestAccess: (deviceId?: string) => Promise<void>` - Request microphone access
-- `stopStream: () => void` - Stop the microphone stream
-- `error: Error | null` - Error state
+**Returns (`UseMicrophoneAccessReturn`):**
+- `stream: MediaStream | null`
+- `devices: MicrophoneDevice[]` — `{ deviceId, label, groupId }`
+- `hasPermission: boolean`
+- `isLoading: boolean`
+- `requestAccess: (deviceId?: string, audioConstraints?: MediaTrackConstraints) => Promise<void>`
+- `stopStream: () => void`
+- `error: Error | null`
+
+Requested audio constraints default to `echoCancellation: false`, `noiseSuppression: false`, `autoGainControl: false`, `latency: 0` (raw signal, low latency) — pass `audioConstraints` to override.
 
 #### `useRecording(stream, options?)`
 
-Main recording hook using AudioWorklet.
+The core AudioWorklet-based recording hook.
 
 **Parameters:**
-- `stream: MediaStream | null` - Microphone stream from `useMicrophoneAccess`
+- `stream: MediaStream | null`
 - `options?: RecordingOptions`
-  - `sampleRate?: number` - Sample rate (defaults to AudioContext rate)
-  - `channelCount?: number` - Number of channels (default: 1)
-  - `samplesPerPixel?: number` - Samples per pixel for peaks (default: 1024)
+  - `channelCount?: number` — fallback used only if the stream doesn't report its own channel count (default: `1`)
+  - `samplesPerPixel?: number` — peak resolution for the live preview (default: `1024`)
+  - `bits?: 8 | 16` — peak value bit depth (default: `16`)
 
-**Returns:**
-- `isRecording: boolean` - Whether recording is active
-- `isPaused: boolean` - Whether recording is paused
-- `duration: number` - Recording duration in seconds
-- `peaks: number[]` - Peak data for waveform visualization
-- `audioBuffer: AudioBuffer | null` - Final recorded audio buffer
-- `startRecording: () => Promise<void>` - Start recording
-- `stopRecording: () => Promise<AudioBuffer | null>` - Stop and finalize recording
-- `pauseRecording: () => void` - Pause recording
-- `resumeRecording: () => void` - Resume recording
-- `error: Error | null` - Error state
+**Returns (`UseRecordingReturn`):**
+- `isRecording: boolean`, `isPaused: boolean`, `duration: number` (seconds)
+- `peaks: (Int8Array | Int16Array)[]` — one entry per channel, growing live during recording
+- `audioBuffer: AudioBuffer | null` — set after `stopRecording()` resolves
+- `level: number`, `peakLevel: number` — reserved for backwards compatibility; prefer `useMicrophoneLevel` for metering
+- `startRecording: () => Promise<void>`
+- `stopRecording: () => Promise<AudioBuffer | null>` — awaits the worklet's final flush before resolving, so the last samples are never dropped
+- `pauseRecording: () => void`, `resumeRecording: () => void` — pause/resume the worklet itself, not just the UI
+- `error: Error | null`
 
-### Components
+#### `useMicrophoneLevel(stream, options?)`
 
-#### `<RecordButton />`
+Sample-accurate VU metering via a separate meter AudioWorklet — independent of `useRecording`, so it works before recording starts.
 
-Button for starting/stopping recording.
+**Parameters:**
+- `stream: MediaStream | null`
+- `options?: UseMicrophoneLevelOptions`
+  - `updateRate?: number` — Hz (default: `60`)
+  - `channelCount?: number` (default: `1`)
 
-**Props:**
-- `isRecording: boolean` - Recording state
-- `onClick: () => void` - Click handler
-- `disabled?: boolean` - Disabled state
-- `className?: string` - CSS class name
+**Returns (`UseMicrophoneLevelReturn`):**
+- `levels: number[]`, `peakLevels: number[]`, `rmsLevels: number[]` — per channel, normalized 0–1
+- `level: number`, `peakLevel: number` — scalar convenience values (max across channels when `channelCount > 1`)
+- `resetPeak: () => void` — clears held peak indicators, e.g. on device switch
+- `error: Error | null`
 
-#### `<MicrophoneSelector />`
+#### `useIntegratedRecording(tracks, setTracks, selectedTrackId, options?)`
 
-Dropdown for selecting microphone device.
+Batteries-included hook: wires `useMicrophoneAccess` + `useMicrophoneLevel` + `useRecording` together and appends the finalized recording to `tracks` as a new `AudioClip`.
 
-**Props:**
-- `devices: MicrophoneDevice[]` - Available devices
-- `selectedDeviceId?: string` - Currently selected device
-- `onDeviceChange: (deviceId: string) => void` - Change handler
-- `disabled?: boolean` - Disabled state
-- `className?: string` - CSS class name
+**Parameters:**
+- `tracks: ClipTrack[]`, `setTracks: (tracks: ClipTrack[]) => void`, `selectedTrackId: string | null`
+- `options?: IntegratedRecordingOptions`
+  - `currentTime?: number` — playback/cursor position; the clip is captured at this position at record *start* (not stop), so overdubbing while transport is running lands the clip correctly
+  - `audioConstraints?: MediaTrackConstraints`
+  - `channelCount?: number` (default: `1`)
+  - `samplesPerPixel?: number` (default: `1024`)
+  - `latencyOffset?: number` — seconds; overrides the auto-computed `outputLatency + lookAhead` compensation applied to the clip's start. `0` disables compensation; omit to auto-compute
 
-#### `<RecordingIndicator />`
+**Returns (`UseIntegratedRecordingReturn`):** recording state (`isRecording`, `isPaused`, `duration`, `level`, `peakLevel`, `levels`, `peakLevels`, `rmsLevels`), microphone state (`stream`, `devices`, `hasPermission`, `selectedDevice`), controls (`startRecording`, `stopRecording`, `pauseRecording`, `resumeRecording`, `requestMicAccess`, `changeDevice`), `recordingPeaks` (live per-channel peaks for preview), and a combined `error`.
 
-Visual indicator showing recording status and duration.
+### Types
 
-**Props:**
-- `isRecording: boolean` - Recording state
-- `isPaused?: boolean` - Paused state
-- `duration: number` - Duration in seconds
-- `formatTime?: (seconds: number) => string` - Custom time formatter
-- `className?: string` - CSS class name
+`RecordingState`, `RecordingData`, `MicrophoneDevice`, `RecordingOptions`, `UseRecordingReturn`, `UseMicrophoneAccessReturn` are all exported from the package root for consumers building their own UI around these hooks.
 
 ## Architecture
-
-The recording implementation uses AudioWorklet for low-latency audio capture:
 
 ```
 getUserMedia → MediaStream
                     ↓
-        MediaStreamSource (Web Audio)
+   MediaStreamSource (shared global AudioContext)
                     ↓
-          AudioWorklet Processor
-          (captures raw PCM data)
+    AudioWorklet Processors (from @waveform-playlist/worklets)
+    - recording-processor: captures raw PCM per channel
+    - meter-processor: sample-accurate peak/RMS
                     ↓
-        Main Thread (React Hook)
-          - Accumulates audio data
-          - Generates peaks in real-time
-          - Updates waveform visualization
+        Main Thread (React Hooks)
+          - Accumulates audio data per channel
+          - Generates live peaks incrementally
+          - Updates VU meter state
                     ↓
-         Final AudioBuffer
+   Final AudioBuffer (after stopRecording's stop-handshake)
 ```
+
+Each hook creates its own `MediaStreamSource` from the shared context rather than reusing one across hooks — required for Firefox, which throws if source and destination nodes come from different context instances.
 
 ## Browser Support
 

--- a/packages/spectrogram/README.md
+++ b/packages/spectrogram/README.md
@@ -1,0 +1,58 @@
+# @waveform-playlist/spectrogram
+
+React Provider + UI for rendering waveform-playlist tracks as FFT spectrograms — color-mapped time-frequency plots instead of (or alongside) the time-domain waveform.
+
+Wraps [`@dawcore/spectrogram`](https://www.npmjs.com/package/@dawcore/spectrogram), which owns the FFT computation, Web Worker, and chunked rendering. This package supplies the React layer: mount `<SpectrogramProvider>` inside `<WaveformPlaylistProvider>` from [`@waveform-playlist/browser`](https://www.npmjs.com/package/@waveform-playlist/browser).
+
+## Features
+
+- **Per-track FFT spectrograms** rendered from the real `AudioBuffer` — no separate analysis step
+- **Render-mode switching** per track — `'waveform'`, `'spectrogram'`, or `'both'` (waveform on top, spectrogram below)
+- **Six built-in color maps** (`viridis`, `magma`, `inferno`, `grayscale`, `igray`, `roseus`) plus custom `[r, g, b]` palettes
+- **Five frequency scales** — linear, logarithmic, mel, bark, erb
+- **Drop-in settings UI** — `<SpectrogramSettingsModal>` (FFT size, hop size, window function, gain/range, frequency bounds) and `<SpectrogramMenuItems>` for a track context menu
+- **Viewport-aware rendering** — a Web Worker pool computes the visible chunks first, then a scroll buffer, then the rest in the background, so long timelines stay responsive
+
+## Installation
+
+```bash
+npm install @waveform-playlist/spectrogram
+```
+
+Requires `@waveform-playlist/browser`, `react`, and `styled-components` as peer dependencies (already part of any waveform-playlist React setup). `@dawcore/spectrogram` is a regular dependency and installs automatically.
+
+## Usage
+
+Wrap your editor with `<SpectrogramProvider>` and set a track's `renderMode`:
+
+```tsx
+import { WaveformPlaylistProvider, Waveform } from '@waveform-playlist/browser';
+import { useAudioTracks } from '@waveform-playlist/browser/tone';
+import { SpectrogramProvider } from '@waveform-playlist/spectrogram';
+
+function MyEditor() {
+  const { tracks, loading } = useAudioTracks([
+    { src: '/audio/vocals.opus', name: 'Vocals', renderMode: 'spectrogram' },
+  ]);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <WaveformPlaylistProvider tracks={tracks}>
+      <SpectrogramProvider config={{ fftSize: 2048, frequencyScale: 'mel' }} colorMap="viridis">
+        <Waveform />
+      </SpectrogramProvider>
+    </WaveformPlaylistProvider>
+  );
+}
+```
+
+`<SpectrogramProvider>` exposes one config + one color map at a time; per-track overrides come from that track's own `spectrogramConfig` / `spectrogramColorMap` fields, or via `<SpectrogramSettingsModal>` at runtime.
+
+## Examples & Documentation
+
+Full guide, `SpectrogramConfig` reference, color map / frequency scale tables, and Web Components equivalent: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/).
+
+## License
+
+MIT

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -1,6 +1,6 @@
 # @dawcore/transport
 
-Native Web Audio transport for multi-track audio scheduling, looping, tempo, and metronome. Zero npm dependencies.
+Native Web Audio transport for the dawcore family — multi-track scheduling, looping, tempo automation, time signatures, and metronome. No Tone.js, zero npm dependencies.
 
 ## Features
 
@@ -172,6 +172,8 @@ transport.connectMasterOutput(compressor);
 transport.disconnectMasterOutput();
 ```
 
+**Note:** `ClipTrack.effects` (the Tone.js-oriented per-track effects function used by `@waveform-playlist/playout`) is not read by `NativePlayoutAdapter` — it's silently ignored. Use `connectTrackOutput`/`connectMasterOutput` for effects with the native transport, or use `TonePlayoutAdapter` if a track still relies on `ClipTrack.effects`.
+
 ## API
 
 ### Transport
@@ -269,6 +271,10 @@ Implements `PlayoutAdapter` from `@waveform-playlist/engine`. All methods delega
 - `adapter.masterOutputNode` — Master gain node for parallel taps (analyzers, recorders)
 - `adapter.init()` — Resumes a suspended AudioContext and waits for the hardware pipeline to warm up (Safari needs this before clips scheduled at time 0 play on time)
 - `setTempo(bpm, atTick?)`, `setMeter(numerator, denominator, atTick?)`, `ticksToSeconds(tick)`, `secondsToTicks(seconds)` — tempo/meter surface the engine uses for tick-based timeline math
+
+### Advanced (Low-Level Building Blocks)
+
+For consumers assembling a custom scheduler or embedding transport internals elsewhere, the layers underneath `Transport` are also exported: `Clock`, `Scheduler`, `Timer`, `SampleTimeline`, `TempoMap`, `MeterMap`, `MasterNode`, `TrackNode`, `ClipPlayer`, `MetronomePlayer`. See [`src/index.ts`](https://github.com/naomiaro/waveform-playlist/blob/main/packages/transport/src/index.ts) for the full export list — most consumers only need `Transport` and `NativePlayoutAdapter`.
 
 ## Examples
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,0 +1,71 @@
+# @waveform-playlist/ui-components
+
+React UI components for waveform-playlist — canvas-rendered waveform/spectrogram/piano-roll channels, track controls, VU metering, and the styled-components theming layer.
+
+Used internally by [`@waveform-playlist/browser`](https://www.npmjs.com/package/@waveform-playlist/browser), which composes these components into a full multitrack editor. Most users get this package transitively and never install it directly — reach for it standalone if you're building custom playlist UI (e.g. a bespoke VU meter or a themed control) without the full editor.
+
+## Features
+
+- **Canvas waveform rendering** — `Channel` draws peaks as bars, with an optional `roundedBars` mode
+- **Spectrogram & piano-roll channels** — `SpectrogramChannel` and `PianoRollChannel` render alongside waveform as alternate track visualizations
+- **Track controls** — mute/solo/volume, track menu, and other transport-adjacent controls
+- **Theming** — `ThemeProvider` + `WaveformPlaylistTheme` (with `defaultTheme` and `darkTheme`) drive every styled component from a single theme object
+- **Virtual scrolling** — chunked canvases and viewport tracking so long timelines don't render off-screen content
+- **`SegmentedVUMeter`** — standalone level meter with configurable color stops, orientation, and scale
+- **`PlaylistErrorBoundary`** — catches render errors without depending on `ThemeProvider`
+
+## Installation
+
+```bash
+npm install @waveform-playlist/ui-components
+```
+
+Peer dependencies (install alongside):
+
+```bash
+npm install react react-dom styled-components
+```
+
+`@dnd-kit/react` is an optional peer — only needed if you use the drag/trim-enabled clip components.
+
+## Usage
+
+Most components expect the context providers from `@waveform-playlist/browser`, but standalone pieces like `SegmentedVUMeter` work with just props:
+
+```tsx
+import { SegmentedVUMeter } from '@waveform-playlist/ui-components';
+
+function TrackMeter({ levels }: { levels: number[] }) {
+  return (
+    <SegmentedVUMeter
+      levels={levels}
+      channelLabels={['L', 'R']}
+      orientation="vertical"
+      showScale
+    />
+  );
+}
+```
+
+## Theming
+
+Wrap your tree in styled-components' `ThemeProvider` with a `WaveformPlaylistTheme` object — `defaultTheme` and `darkTheme` are exported as starting points and can be partially overridden:
+
+```tsx
+import { ThemeProvider } from 'styled-components';
+import { defaultTheme } from '@waveform-playlist/ui-components';
+
+<ThemeProvider theme={{ ...defaultTheme, waveOutlineColor: '#ff6600' }}>
+  {/* playlist components */}
+</ThemeProvider>;
+```
+
+`@waveform-playlist/browser`'s `WaveformPlaylistProvider` sets this up for you via its own `theme` prop — you only need `ThemeProvider` directly when using `ui-components` outside that provider.
+
+## Examples & Documentation
+
+Full guides, API reference, and live examples: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/webaudio-peaks/README.md
+++ b/packages/webaudio-peaks/README.md
@@ -1,0 +1,107 @@
+# @waveform-playlist/webaudio-peaks
+
+Small library to extract min/max peaks from an array of audio samples or a Web Audio `AudioBuffer` — the data waveform renderers draw from. Standalone and framework-agnostic; no dependency on the rest of waveform-playlist beyond a shared types package.
+
+## Installation
+
+```bash
+npm install @waveform-playlist/webaudio-peaks
+```
+
+## Usage
+
+```typescript
+import extractPeaksFromBuffer from '@waveform-playlist/webaudio-peaks';
+
+// From a decoded AudioBuffer
+const audioContext = new AudioContext();
+const response = await fetch('/audio/track.mp3');
+const arrayBuffer = await response.arrayBuffer();
+const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+
+const peakData = extractPeaksFromBuffer(
+  audioBuffer,
+  1000, // samplesPerPixel
+  true, // isMono - merge all channels into one
+  0, // cueIn - start sample
+  undefined, // cueOut - end sample (defaults to full length)
+  16 // bits - 8 or 16
+);
+
+console.log(peakData.length); // number of peak pairs
+console.log(peakData.data); // Peaks[] - one entry per channel (or one, if isMono)
+console.log(peakData.bits); // 16
+
+// From a raw Float32Array (e.g. one channel pulled from an AudioBuffer,
+// or samples produced by a worker/AudioWorklet)
+const channelData = audioBuffer.getChannelData(0);
+const monoPeaks = extractPeaksFromBuffer(channelData, 1000);
+```
+
+## API
+
+### `extractPeaksFromBuffer(source, samplesPerPixel?, isMono?, cueIn?, cueOut?, bits?)`
+
+Default export. Extracts peaks from an `AudioBuffer` or a `Float32Array`.
+
+```typescript
+function extractPeaksFromBuffer(
+  source: AudioBuffer | Float32Array,
+  samplesPerPixel?: number, // samples per peak pair (default: 1000)
+  isMono?: boolean, // merge multi-channel input to mono (default: true)
+  cueIn?: number, // start sample index (default: 0)
+  cueOut?: number, // end sample index (default: source.length)
+  bits?: 8 | 16 // peak bit depth (default: 16)
+): PeakData;
+```
+
+- **`source`** — an `AudioBuffer` (all channels are read via `getChannelData`) or a single `Float32Array` of samples.
+- **`samplesPerPixel`** — how many source samples are collapsed into one min/max peak pair. Higher values produce fewer, coarser peaks (typical for zoomed-out views); lower values produce more detail.
+- **`isMono`** — when `true` and the source has multiple channels, all channels are averaged down to a single merged peak channel. When `false`, each channel's peaks are kept separate.
+- **`cueIn` / `cueOut`** — restrict extraction to a sample range within the source, useful for extracting peaks from a trimmed region without decoding a new buffer.
+- **`bits`** — `8` or `16`. Throws if any other value is passed. Peak values are quantized to `Int8Array` or `Int16Array` accordingly, which keeps pre-computed peaks compact to store or transmit.
+
+Throws an `Error` if `bits` is not `8` or `16`.
+
+### Return value: `PeakData`
+
+```typescript
+interface PeakData {
+  length: number; // number of peak pairs (per channel)
+  data: Peaks[]; // one entry per channel; each is an interleaved [min, max, min, max, ...] typed array
+  bits: Bits; // 8 or 16 — the bit depth used to quantize the values
+}
+
+type Peaks = Int8Array | Int16Array;
+type Bits = 8 | 16;
+```
+
+`Peaks`, `Bits`, and `PeakData` are re-exported from `@waveform-playlist/core` for convenience — you don't need to install `core` separately just to reference these types.
+
+### Lower-level helpers
+
+The min/max extraction and quantization primitives that `extractPeaksFromBuffer` is built from are also exported directly, for callers assembling their own pipeline (e.g. inside an `AudioWorklet` or a Web Worker where you already have raw channel data):
+
+```typescript
+import { extractPeaks, makeMono, findMinMax, convert, makeTypedArray } from '@waveform-playlist/webaudio-peaks';
+
+// Extract peaks for a single channel you already have as a Float32Array
+const channelPeaks = extractPeaks(channelData, 1000, 16);
+
+// Merge several per-channel Peaks arrays into one mono Peaks array
+const [mono] = makeMono([leftPeaks, rightPeaks], 16);
+```
+
+- `extractPeaks(channel: Float32Array, samplesPerPixel: number, bits: Bits): Peaks` — extracts interleaved min/max peaks from a single channel.
+- `makeMono(channelPeaks: Peaks[], bits: Bits): Peaks[]` — averages multiple channels' peaks into a single-entry array.
+- `findMinMax(array: Float32Array): { min: number; max: number }` — plain min/max over a typed array segment.
+- `convert(n: number, bits: Bits): number` — quantizes a float peak value (-1..1) to the integer range for the given bit depth.
+- `makeTypedArray(bits: Bits, length: number): Peaks` — allocates an `Int8Array` or `Int16Array`.
+
+## Examples & Documentation
+
+Guides and full API reference: [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT

--- a/packages/worklets/README.md
+++ b/packages/worklets/README.md
@@ -1,0 +1,64 @@
+# @waveform-playlist/worklets
+
+AudioWorklet processors for waveform-playlist — metering (VU) and recording capture.
+
+Used by `@waveform-playlist/recording`, `@waveform-playlist/browser` (output metering), and the dawcore recording controller.
+
+## Features
+
+- **Recording processor** — captures microphone/input audio in the audio rendering thread, with transferable-buffer flushes for low-overhead delivery to the main thread
+- **Metering processor** — computes peak/RMS levels per channel for VU meters
+- **Context-agnostic loading** — a callback-injection loader works with a native `AudioContext` or a Tone.js (standardized-audio-context) context, so you decide how `addModule` is called
+
+## Installation
+
+```bash
+npm install @waveform-playlist/worklets
+```
+
+## Usage
+
+Register the worklet module on your `AudioContext` before creating the corresponding `AudioWorkletNode`. Pass in your own `addModule` call — this works whether the context is a native `AudioContext` or a Tone.js context:
+
+```typescript
+import { addRecordingWorkletModule } from '@waveform-playlist/worklets';
+
+// Native AudioContext
+const ctx = new AudioContext();
+await addRecordingWorkletModule((url) => ctx.audioWorklet.addModule(url));
+
+// Tone.js context (standardized-audio-context)
+const rawCtx = context.rawContext;
+await addRecordingWorkletModule((url) => rawCtx.audioWorklet.addModule(url));
+
+const recorderNode = new AudioWorkletNode(ctx, 'recording-processor');
+```
+
+Metering follows the same pattern:
+
+```typescript
+import { addMeterWorkletModule, type MeterMessage } from '@waveform-playlist/worklets';
+
+await addMeterWorkletModule((url) => ctx.audioWorklet.addModule(url));
+
+const meterNode = new AudioWorkletNode(ctx, 'meter-processor');
+meterNode.port.onmessage = (event: MessageEvent<MeterMessage>) => {
+  const { peak, rms } = event.data; // per-channel arrays
+  updateVuMeter(peak, rms);
+};
+```
+
+## API
+
+- `addRecordingWorkletModule(addModule: (url: string) => Promise<void>): Promise<void>` — registers the `recording-processor` worklet module via your context's `addModule` callback
+- `addMeterWorkletModule(addModule: (url: string) => Promise<void>): Promise<void>` — registers the `meter-processor` worklet module via your context's `addModule` callback
+- `recordingProcessorUrl` / `meterProcessorUrl` — the underlying module URLs, for consumers who want to call `audioWorklet.addModule()` directly instead of using the loaders
+- `MeterMessage` — `{ peak: number[]; rms: number[] }`, the shape posted by the `meter-processor` on its port
+
+## Examples & Documentation
+
+- [naomiaro.github.io/waveform-playlist](https://naomiaro.github.io/waveform-playlist/)
+
+## License
+
+MIT


### PR DESCRIPTION
A full documentation pass across every package README plus the two root docs. **Docs only — no code changes.**

## Package READMEs (19)

README.md is each package's npmjs.com page, so this makes all 19 published packages presentable and accurate.

**Created** (10 packages had no README): `core`, `browser`, `engine`, `ui-components`, `annotations`, `midi`, `spectrogram`, `loaders`, `webaudio-peaks`, `worklets`.

**Refreshed** (9 existing), with real drift fixed:
- `recording` — documented `RecordButton`/`MicrophoneSelector`/`RecordingIndicator`, which no longer exist; rebuilt around the real hook surface (`useRecording`/`useMicrophoneAccess`/`useMicrophoneLevel`/`useIntegratedRecording`) and added the latency/overdub options.
- `media-element-playout` — playback-rate range `0.5x–2.0x` → `0.25x–4.0x` (widened in v12.3.0).
- `@dawcore/components` — added the missing `<daw-player>`, `<daw-time-display>`, `<daw-time-format>` elements + `rounded-bars`/`time-format` attributes.
- `@dawcore/wam` — added the undocumented `fetchWamDescriptor` and manifest `category` field.
- `@dawcore/{midi,faust,spectrogram}`, `transport`, `playout` — link and export/entry-point drift.

All 19 follow one house style (title → tagline → Features → Installation → Usage → API → Examples & Docs → MIT) and were verified against `src/index.ts`/`package.json` — no invented APIs, no reference to the removed `useWaveformPlaylist`, all website doc links resolve to real pages.

## PROJECT_STRUCTURE.md

- Added the entirely-missing packages `@dawcore/spectrogram`, `@dawcore/wam`, `@dawcore/faust`, plus full sections so all 19 packages are described.
- Added `<daw-player>` (+ `<daw-piano-roll>`/`<daw-spectrogram>`/`<daw-grid>`/`<daw-time-*>`), the `@waveform-playlist/browser/tone` optional-engine split (#510), and the #560 spectrogram helpers (`buildSpectrogramCanvasId`/`parseSpectrogramCanvasId`, `computePaddedFftRange`).
- Fixed stale descriptions: `browser` builds with tsup (not Vite, #317); corrected `spectrogram`/`midi` tree comments (FFT/SoundFont live elsewhere); added `examples/media-element-player/` to the tree.
- Structure/data-flow only — no progress notes.

## TODO.md

Removed all completed items (WAM plugin support, tempo automation, time signatures, metronome, undo/redo, eager resume, web-components layer, …), leaving only the forward-looking roadmap (171 → 90 lines).

## Notes

- READMEs are Sonnet-authored from source and spot-verified (exports, links, placeholders checked programmatically; a sample read in full).
- Surfaced separately: **`@waveform-playlist/loaders` has no actual source consumers** (only workspace `package.json` deps, no imports) — possibly vestigial, worth a separate look.
