### PR TITLE
docs: refresh llms.txt for web components + relocate LLM API reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ pnpm publish --filter @waveform-playlist/NEW-PACKAGE --no-git-checks --access pu
 **LLM-Readable Docs:**
 
 - `website/static/llms.txt` — Library discovery page, served at `/llms.txt`. Update when packages, architecture, or key APIs change.
-- `website/docs/api/llm-reference.md` — All TypeScript interfaces from source, no prose. Update when any context type, hook signature, or component prop changes.
+- `website/docs/llm-reference.md` — All TypeScript interfaces from source, no prose. Update when any context type, hook signature, or component prop changes.
 - **Keep all doc surfaces in sync** — When adding new context fields, hook returns, or component props, update: (1) `llm-reference.md` (interfaces), (2) `llms.txt` (descriptions), (3) `docs/api/hooks.md` (context value interfaces), (4) `docs/examples.md` (code snippets), (5) example page files in `src/pages/examples/` (keyboard shortcuts sections, feature lists), (6) provider API docs (`docs/react/api/providers/*.md`) AND guide hook tables (e.g. `media-element-playout.md`), (7) the root README demo table. For dawcore element attributes also: `packages/dawcore/COMPONENTS.md`, the element's entry in `packages/dawcore/CLAUDE.md`, and the attribute tables in `docs/specs/web-components-migration.md`.
 
 ---

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -51,5 +51,5 @@ For any framework or vanilla HTML. Custom elements; no React required.
 
 Both integration paths share the same headless engine (`@waveform-playlist/engine`) and a pluggable `PlayoutAdapter` for audio backends. React wraps the engine in providers + hooks; Web Components wrap it in Lit-based custom elements (`@dawcore/components`).
 
-- [Type reference](/docs/framework-agnostic/llm-reference) — full TypeScript surface
+- [Type reference](/docs/llm-reference) — full TypeScript surface
 - [Examples](/examples) — runnable demos

--- a/website/docs/llm-reference.md
+++ b/website/docs/llm-reference.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: LLM API Reference
 description: Machine-readable API reference for LLMs and coding agents. All TypeScript interfaces from source.
 ---

--- a/website/docs/react/guides/beats-and-bars.md
+++ b/website/docs/react/guides/beats-and-bars.md
@@ -62,7 +62,7 @@ When `snap` is enabled, the provider reads from `BeatsAndBarsProvider` context:
 
 :::info Advanced: Manual DragDropProvider Setup
 
-For full control over drag sensors, modifiers, and handlers, you can bypass `ClipInteractionProvider` and configure `DragDropProvider` directly with `useClipDragHandlers`, `useDragSensors`, `ClipCollisionModifier`, and `SnapToGridModifier`. See the [LLM API Reference](/docs/framework-agnostic/llm-reference) for the complete hook and modifier signatures.
+For full control over drag sensors, modifiers, and handlers, you can bypass `ClipInteractionProvider` and configure `DragDropProvider` directly with `useClipDragHandlers`, `useDragSensors`, `ClipCollisionModifier`, and `SnapToGridModifier`. See the [LLM API Reference](/docs/llm-reference) for the complete hook and modifier signatures.
 
 :::
 

--- a/website/docs/react/guides/custom-drag-setup.md
+++ b/website/docs/react/guides/custom-drag-setup.md
@@ -352,4 +352,4 @@ This uses delay-based activation for touch events (distinguishes drag from scrol
 
 - [Beats & Bars](/docs/react/guides/beats-and-bars) — Musical timescale with `ClipInteractionProvider`
 - [Annotations Example](/examples/annotations) — Combined clip + annotation dragging
-- [LLM API Reference](/docs/framework-agnostic/llm-reference) — Complete TypeScript interfaces
+- [LLM API Reference](/docs/llm-reference) — Complete TypeScript interfaces

--- a/website/docs/react/guides/media-element-playout.md
+++ b/website/docs/react/guides/media-element-playout.md
@@ -80,7 +80,7 @@ import { PlayheadWithMarker } from '@waveform-playlist/ui-components';
 <MediaElementWaveform renderPlayhead={PlayheadWithMarker} />
 ```
 
-`PlayheadWithMarker` adds a triangle marker above the playhead line. You can also write your own — the render function receives `PlayheadProps` (see [API reference](/docs/framework-agnostic/llm-reference)). In the MediaElement context, use `currentTimeRef` for animation; `playbackStartTimeRef` and `audioStartPositionRef` are not applicable.
+`PlayheadWithMarker` adds a triangle marker above the playhead line. You can also write your own — the render function receives `PlayheadProps` (see [API reference](/docs/llm-reference)). In the MediaElement context, use `currentTimeRef` for animation; `playbackStartTimeRef` and `audioStartPositionRef` are not applicable.
 
 ## Web Audio Routing
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,10 +1,10 @@
 # waveform-playlist
 
-> Multitrack Web Audio editor and player with canvas waveform visualization, built with React and Tone.js.
+> Multitrack Web Audio editor and player with canvas waveform visualization. Two UI surfaces over a shared framework-agnostic engine: a React component library (`@waveform-playlist/browser`, Tone.js backend) and framework-agnostic Web Components (`@dawcore/components`, native Web Audio backend).
 
 ## What It Does
 
-waveform-playlist is a React component library for building browser-based audio editing applications. It provides:
+waveform-playlist builds browser-based audio editing applications. Use the React surface (`@waveform-playlist/browser`) or the framework-agnostic Web Components surface (`@dawcore/components`, `<daw-editor>` — works in any framework or vanilla HTML). Both provide:
 
 - Multitrack audio playback, mixing, and editing
 - Canvas-based waveform and spectrogram rendering with zoom
@@ -31,7 +31,7 @@ waveform-playlist is a React component library for building browser-based audio 
 - `@waveform-playlist/webaudio-peaks` — Peak extraction from AudioBuffer
 - `@waveform-playlist/media-element-playout` — HTMLAudioElement playback with pitch-preserving speed control, optional Web Audio routing for fades and Tone.js effect bridging
 - `@waveform-playlist/midi` — React layer for MIDI: `useMidiTracks` hook converts .mid files to ClipTrack[] with midiNotes for piano roll visualization and SoundFont/PolySynth playback. As of v13+ the parser is re-exported from `@dawcore/midi`; React API surface is unchanged. The SoundFont can be provided or swapped after setup via `adapter.setSoundFontCache()` on the adapter returned by `createToneAdapter()` (the React provider forwards late `soundFontCache` prop changes automatically; construct caches with `SoundFontCache.fromUrl(url)`).
-- `@dawcore/components` — Web Components for multi-track audio editing (Lit-based): `<daw-editor>`, `<daw-track>`, `<daw-clip>`, `<daw-waveform>`, `<daw-playhead>`, `<daw-ruler>`, transport buttons. Framework-agnostic — works in any framework or vanilla HTML. No Tone.js dependency; uses native Web Audio via `@dawcore/transport`. Consumer supplies a `PlayoutAdapter` (no default). Unified effects chains: `addEffect`/`removeEffect`/`setEffectParams`/`setEffectBypassed`/`moveEffect`/`effects` on `<daw-track>` (per-track chain) and `<daw-editor>` (master chain), with built-in `native-*` effects (gain, lowpass filter, compressor, stereo panner, delay), custom registration via `registerEffect`, and `daw-effect-add/remove/change/bypass/reorder` events. WAM 2.0 plugins join the same chains via `addWamPlugin(url)` (optional `@dawcore/wam` peer); Faust DSP source compiles in the browser into the same chains via `addFaustEffect(dspCode, {name?})` (optional `@dawcore/faust` peer — entries persist as `{kind:'wam', faustDsp, faustName, state}` and recompile on restore/export; compile errors keep Faust's line/column diagnostics and leave the chain untouched). Effect GUIs: `openEffectGui(effectId, container)`/`closeEffectGui(effectId)` on both elements mount a WAM plugin's own GUI (or a generic parameter panel for GUI-less plugins and `native-*` effects) into a consumer-provided container — close hides without interrupting audio, the element is cached for reopen, and the GUI is destroyed only when the effect is removed. Persistence: `getEffectsState()`/`setEffectsState(entries)` on both elements serialize/restore chains (WAM entries carry the plugin's getState snapshot; an unreachable saved URL becomes a bypassed passthrough placeholder + `daw-effect-error`, restore continues). Offline export: `editor.exportAudio({sampleRate?, startTime?, duration?, channels?})` renders the session through all chains on an OfflineAudioContext (WAM plugins re-instantiated offline with saved state) and resolves to an AudioBuffer. Runnable WAM demo: `examples/dawcore-wam/` (`pnpm example:dawcore-wam`).
+- `@dawcore/components` — Web Components for multi-track audio editing (Lit-based). Elements: `<daw-editor>`, `<daw-track>`, `<daw-clip>`, `<daw-waveform>`, `<daw-playhead>`, `<daw-ruler>`, `<daw-selection>`, `<daw-track-controls>`, `<daw-grid>` (beats/bars grid), `<daw-piano-roll>` (MIDI), `<daw-spectrogram>` (per-track FFT via `render-mode="spectrogram"`), `<daw-transport>` + transport buttons (`<daw-play-button>`, `<daw-pause-button>`, `<daw-stop-button>`, `<daw-record-button>`), `<daw-time-display>`, `<daw-time-format>`, `<daw-keyboard-shortcuts>`, and `<daw-player>` (lightweight single-track HTMLMediaElement player on `@waveform-playlist/media-element-playout` — no engine/adapter/AudioContext required). Framework-agnostic — works in any framework or vanilla HTML. No Tone.js dependency; uses native Web Audio via `@dawcore/transport`. Consumer supplies a `PlayoutAdapter` (no default). Unified effects chains: `addEffect`/`removeEffect`/`setEffectParams`/`setEffectBypassed`/`moveEffect`/`effects` on `<daw-track>` (per-track chain) and `<daw-editor>` (master chain), with built-in `native-*` effects (gain, lowpass filter, compressor, stereo panner, delay), custom registration via `registerEffect`, and `daw-effect-add/remove/change/bypass/reorder` events. WAM 2.0 plugins join the same chains via `addWamPlugin(url)` (optional `@dawcore/wam` peer); Faust DSP source compiles in the browser into the same chains via `addFaustEffect(dspCode, {name?})` (optional `@dawcore/faust` peer — entries persist as `{kind:'wam', faustDsp, faustName, state}` and recompile on restore/export; compile errors keep Faust's line/column diagnostics and leave the chain untouched). Effect GUIs: `openEffectGui(effectId, container)`/`closeEffectGui(effectId)` on both elements mount a WAM plugin's own GUI (or a generic parameter panel for GUI-less plugins and `native-*` effects) into a consumer-provided container — close hides without interrupting audio, the element is cached for reopen, and the GUI is destroyed only when the effect is removed. Persistence: `getEffectsState()`/`setEffectsState(entries)` on both elements serialize/restore chains (WAM entries carry the plugin's getState snapshot; an unreachable saved URL becomes a bypassed passthrough placeholder + `daw-effect-error`, restore continues). Offline export: `editor.exportAudio({sampleRate?, startTime?, duration?, channels?})` renders the session through all chains on an OfflineAudioContext (WAM plugins re-instantiated offline with saved state) and resolves to an AudioBuffer. Runnable WAM demo: `examples/dawcore-wam/` (`pnpm example:dawcore-wam`).
 - `@dawcore/midi` — Framework-agnostic MIDI parser (`parseMidiFile`, `parseMidiUrl` — pure functions, no React). Used by `@dawcore/components` via dynamic import inside `editor.loadMidi()`, and re-exported by `@waveform-playlist/midi`.
 - `@waveform-playlist/spectrogram` — Optional spectrogram package (v13+): React `SpectrogramProvider` + UI (menu items, settings modal) integrating via `SpectrogramIntegrationContext`. Computation/worker/orchestrator are imported from `@dawcore/spectrogram`.
 - `@dawcore/spectrogram` — Framework-agnostic FFT computation, Web Worker, and `SpectrogramOrchestrator` class (viewport classification, 3-tier render, generation-based abort, contiguous chunk grouping, color LUT cache). Shared between the React Provider and the dawcore Lit element layer.
@@ -61,6 +61,33 @@ function App() {
   );
 }
 ```
+
+## Web Components Quick Start
+
+No React and no build step — drop `<daw-editor>` into any HTML page and assign a `PlayoutAdapter`:
+
+```html
+<script type="module">
+  import '@dawcore/components';
+  import { NativePlayoutAdapter } from '@dawcore/transport';
+
+  const editor = document.querySelector('daw-editor');
+  editor.adapter = new NativePlayoutAdapter(new AudioContext());
+</script>
+
+<daw-editor id="editor" samples-per-pixel="1024" wave-height="100" timescale>
+  <daw-track src="/audio/drums.opus" name="Drums"></daw-track>
+  <daw-track src="/audio/bass.opus" name="Bass"></daw-track>
+</daw-editor>
+
+<daw-transport for="editor">
+  <daw-play-button></daw-play-button>
+  <daw-pause-button></daw-pause-button>
+  <daw-stop-button></daw-stop-button>
+</daw-transport>
+```
+
+`<daw-editor>` does not create an `AudioContext` — you own it and assign a `PlayoutAdapter`: `NativePlayoutAdapter` (from `@dawcore/transport`) for native Web Audio, or a Tone.js adapter (from `@waveform-playlist/playout`) when you need MIDI playback.
 
 ## Architecture
 
@@ -147,10 +174,11 @@ Both providers use React Context with 4 split contexts for performance.
 
 ## Documentation
 
-- Full docs: https://naomiaro.github.io/waveform-playlist/docs/
-- LLM API reference: https://naomiaro.github.io/waveform-playlist/docs/api/llm-reference
-- Engine guide (framework-agnostic): https://naomiaro.github.io/waveform-playlist/docs/guides/engine
-- Examples: https://naomiaro.github.io/waveform-playlist/docs/examples
+- Full docs: https://naomiaro.github.io/waveform-playlist/
+- LLM API reference: https://naomiaro.github.io/waveform-playlist/docs/llm-reference
+- Web Components getting started: https://naomiaro.github.io/waveform-playlist/docs/web-components/getting-started
+- Engine guide (framework-agnostic): https://naomiaro.github.io/waveform-playlist/docs/framework-agnostic/engine
+- Examples: https://naomiaro.github.io/waveform-playlist/docs/react/examples
 - WAM Plugins guide: https://naomiaro.github.io/waveform-playlist/docs/wam-plugins
 - WAM example ("WAM! Kick It Up a Notch"): https://naomiaro.github.io/waveform-playlist/examples/wam-effects
 - GitHub: https://github.com/naomiaro/waveform-playlist


### PR DESCRIPTION
Two related docs-discoverability improvements.

## llms.txt refresh (make Web Components first-class)

`website/static/llms.txt` is the LLM discovery page. The `@dawcore/*` packages were listed but the Web Components surface was under-represented:
- Broadened the intro / "What It Does" to present **both** surfaces (React `@waveform-playlist/browser` + framework-agnostic Web Components `@dawcore/components`) over the shared engine.
- Completed the `<daw-*>` **element inventory** (was missing `<daw-player>`, `<daw-spectrogram>`, `<daw-piano-roll>`, `<daw-grid>`, `<daw-selection>`, `<daw-track-controls>`, `<daw-record-button>`, `<daw-time-display>`, `<daw-time-format>`, `<daw-keyboard-shortcuts>`) — verified against the `@customElement` registrations in source.
- Added a **Web Components quick-start** (grounded in `web-components/getting-started.md`).
- Fixed **stale Documentation links** broken by the docs IA restructure: `docs/api/llm-reference` → `docs/llm-reference`, `docs/guides/engine` → `docs/framework-agnostic/engine`, `docs/examples` → `docs/react/examples`; added the Web Components getting-started link.

## Relocate the LLM API reference

It sat at the odd `/docs/framework-agnostic/llm-reference` — but it's a general TypeScript-interface reference across every package, not framework-agnostic-specific. Moved to a flat top-level route:
- `website/docs/framework-agnostic/llm-reference.md` → `website/docs/llm-reference.md` (`/docs/llm-reference`, `sidebar_position: 6`)
- Updated the 4 internal links (intro + 3 React guides) and the `CLAUDE.md` source-path reference
- `engine.md` stays under `framework-agnostic/` (it genuinely is)

**Verified:** `pnpm --filter website build` succeeds with **no broken links or anchors** (policy is `warn`, checked explicitly).

> Stacked on #566 → #565; base retargets to `main` as those merge.
