### PR TITLE
perf: eliminate per-flush allocations in meter worklet

### DIFF
--- a/packages/browser/src/hooks/useOutputMeter.ts
+++ b/packages/browser/src/hooks/useOutputMeter.ts
@@ -124,17 +124,19 @@ export function useOutputMeter(options: UseOutputMeterOptions = {}): UseOutputMe
       workletNode.port.onmessage = (event: MessageEvent) => {
         if (!isMounted) return;
 
-        const { peak, rms } = event.data as MeterMessage;
+        // MeterMessage layout: [0..N-1] peak, [N..2N-1] rms
+        const data = event.data as MeterMessage;
+        const workletChannels = data.length / 2;
         const smoothed = smoothedPeakRef.current;
 
         const peakValues: number[] = [];
         const rmsValues: number[] = [];
 
-        for (let ch = 0; ch < peak.length; ch++) {
+        for (let ch = 0; ch < workletChannels; ch++) {
           // Smoothed peak: jump up instantly, decay slowly
-          smoothed[ch] = Math.max(peak[ch], (smoothed[ch] ?? 0) * PEAK_DECAY);
+          smoothed[ch] = Math.max(data[ch], (smoothed[ch] ?? 0) * PEAK_DECAY);
           peakValues.push(gainToNormalized(smoothed[ch]));
-          rmsValues.push(gainToNormalized(rms[ch]));
+          rmsValues.push(gainToNormalized(data[workletChannels + ch]));
         }
 
         setLevels(peakValues);

--- a/packages/recording/src/hooks/useMicrophoneLevel.ts
+++ b/packages/recording/src/hooks/useMicrophoneLevel.ts
@@ -165,23 +165,25 @@ export function useMicrophoneLevel(
       workletNode.port.onmessage = (event: MessageEvent) => {
         if (!isMounted) return;
 
-        const { peak, rms } = event.data as MeterMessage;
+        // MeterMessage layout: [0..N-1] peak, [N..2N-1] rms
+        const data = event.data as MeterMessage;
+        const workletChannels = data.length / 2;
         const smoothed = smoothedPeakRef.current;
 
         const peakValues: number[] = [];
         const rmsValues: number[] = [];
 
-        for (let ch = 0; ch < peak.length; ch++) {
-          smoothed[ch] = Math.max(peak[ch], (smoothed[ch] ?? 0) * PEAK_DECAY);
+        for (let ch = 0; ch < workletChannels; ch++) {
+          smoothed[ch] = Math.max(data[ch], (smoothed[ch] ?? 0) * PEAK_DECAY);
           peakValues.push(gainToNormalized(smoothed[ch]));
-          rmsValues.push(gainToNormalized(rms[ch]));
+          rmsValues.push(gainToNormalized(data[workletChannels + ch]));
         }
 
         // Mirror mono to fill requested channelCount
         const mirroredPeaks =
-          peak.length < channelCount ? new Array(channelCount).fill(peakValues[0]) : peakValues;
+          workletChannels < channelCount ? new Array(channelCount).fill(peakValues[0]) : peakValues;
         const mirroredRms =
-          peak.length < channelCount ? new Array(channelCount).fill(rmsValues[0]) : rmsValues;
+          workletChannels < channelCount ? new Array(channelCount).fill(rmsValues[0]) : rmsValues;
 
         setLevels(mirroredPeaks);
         setRmsLevels(mirroredRms);

--- a/packages/worklets/src/__tests__/meter-processor.test.ts
+++ b/packages/worklets/src/__tests__/meter-processor.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-interface MeterMessage {
-  peak: number[];
-  rms: number[];
-}
+/**
+ * Message layout: single reused Float32Array of length 2*N.
+ * Indices [0..N-1] are per-channel peak, [N..2N-1] are per-channel RMS.
+ */
+type MeterMessage = Float32Array;
 
 interface MockProcessor {
   port: {
@@ -90,7 +91,7 @@ describe('MeterProcessor', () => {
     processor.process(makeInput([input]), makeOutput(1), {});
     expect(mockPort.postMessage).toHaveBeenCalledTimes(1);
     const msg = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
-    expect(msg.peak[0]).toBeCloseTo(0.9, 5);
+    expect(msg[0]).toBeCloseTo(0.9, 5);
   });
 
   it('computes correct RMS for known samples', () => {
@@ -98,7 +99,7 @@ describe('MeterProcessor', () => {
     const input = new Float32Array(128).fill(0.5);
     processor.process(makeInput([input]), makeOutput(1), {});
     const msg = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
-    expect(msg.rms[0]).toBeCloseTo(0.5, 5);
+    expect(msg[1]).toBeCloseTo(0.5, 5);
   });
 
   it('accumulates peak across multiple quantums before posting', () => {
@@ -116,19 +117,21 @@ describe('MeterProcessor', () => {
     processor.process(makeInput([silence]), makeOutput(1), {});
     expect(mockPort.postMessage).toHaveBeenCalledTimes(1);
     const msg = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
-    expect(msg.peak[0]).toBeCloseTo(0.8, 5);
+    expect(msg[0]).toBeCloseTo(0.8, 5);
   });
 
-  it('handles multi-channel independently', () => {
+  it('handles multi-channel independently with rms in the upper half', () => {
     const processor = createProcessor({ numberOfChannels: 2, updateRate: 48000 });
     const ch0 = new Float32Array(128).fill(0);
     ch0[0] = 0.3;
-    const ch1 = new Float32Array(128).fill(0);
-    ch1[0] = 0.7;
+    const ch1 = new Float32Array(128).fill(0.5);
     processor.process(makeInput([ch0, ch1]), makeOutput(2), {});
     const msg = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
-    expect(msg.peak[0]).toBeCloseTo(0.3, 5);
-    expect(msg.peak[1]).toBeCloseTo(0.7, 5);
+    expect(msg.length).toBe(4);
+    expect(msg[0]).toBeCloseTo(0.3, 5);
+    expect(msg[1]).toBeCloseTo(0.5, 5);
+    expect(msg[2]).toBeCloseTo(Math.sqrt((0.3 * 0.3) / 128), 5);
+    expect(msg[3]).toBeCloseTo(0.5, 5);
   });
 
   it('resets accumulators after posting', () => {
@@ -140,7 +143,22 @@ describe('MeterProcessor', () => {
     const silence = new Float32Array(128).fill(0);
     processor.process(makeInput([silence]), makeOutput(1), {});
     const msg2 = mockPort.postMessage.mock.calls[1][0] as MeterMessage;
-    expect(msg2.peak[0]).toBe(0);
+    expect(msg2[0]).toBe(0);
+    expect(msg2[1]).toBe(0);
+  });
+
+  it('reuses a single Float32Array across flushes (no per-flush allocation)', () => {
+    const processor = createProcessor({ numberOfChannels: 1, updateRate: 48000 });
+    const input = new Float32Array(128).fill(0.25);
+    processor.process(makeInput([input]), makeOutput(1), {});
+    processor.process(makeInput([input]), makeOutput(1), {});
+
+    expect(mockPort.postMessage).toHaveBeenCalledTimes(2);
+    const first = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
+    const second = mockPort.postMessage.mock.calls[1][0] as MeterMessage;
+    expect(first).toBeInstanceOf(Float32Array);
+    expect(first.length).toBe(2);
+    expect(second).toBe(first);
   });
 
   it('returns true to keep processor alive', () => {

--- a/packages/worklets/src/index.ts
+++ b/packages/worklets/src/index.ts
@@ -36,8 +36,16 @@ export async function addMeterWorkletModule(
   await addModule(meterProcessorUrl);
 }
 
-/** Message shape posted by the meter-processor worklet */
-export interface MeterMessage {
-  peak: number[];
-  rms: number[];
-}
+/**
+ * Message posted by the meter-processor worklet.
+ *
+ * A Float32Array of length 2*N (N = metered channel count):
+ * - indices [0..N-1]: per-channel peak (max absolute sample)
+ * - indices [N..2N-1]: per-channel RMS
+ *
+ * The worklet reuses one buffer across flushes (each postMessage structured-
+ * clones the contents) so the audio thread does no per-flush allocation.
+ * Receivers get a fresh copy per message and derive the channel count as
+ * `data.length / 2`.
+ */
+export type MeterMessage = Float32Array;

--- a/packages/worklets/src/worklet/meter-processor.worklet.ts
+++ b/packages/worklets/src/worklet/meter-processor.worklet.ts
@@ -5,6 +5,12 @@
  * Accumulates peak (max absolute sample) and RMS (root mean square) across all
  * 128-sample quantums, posting results at ~updateRate Hz via postMessage.
  *
+ * Message format: a single reused Float32Array of length 2*N (N = channel
+ * count) — indices [0..N-1] are per-channel peak, [N..2N-1] are per-channel
+ * RMS (see MeterMessage in ../index.ts). All accumulators and the message
+ * buffer are pre-allocated at construction; steady-state process()/flush does
+ * no allocation on the audio thread.
+ *
  * RMS Strategy: Simple interval average (not sliding window).
  * Trade-off: A sliding window (like openDAW's 100ms circular buffer) provides
  * smoother loudness display. Our interval-based approach may appear jumpier
@@ -22,9 +28,12 @@ class MeterProcessor extends AudioWorkletProcessor {
   private numberOfChannels: number;
   private blocksPerUpdate: number;
   private blocksProcessed: number;
-  private maxPeak: number[];
-  private sumSquares: number[];
-  private sampleCount: number[];
+  private maxPeak: Float32Array;
+  /** Float64 to avoid precision drift when summing many squared samples */
+  private sumSquares: Float64Array;
+  private sampleCount: Uint32Array;
+  /** Reused message buffer: [0..N-1] peak, [N..2N-1] rms */
+  private levels: Float32Array;
 
   constructor(options: { processorOptions: MeterProcessorOptions }) {
     super();
@@ -32,9 +41,10 @@ class MeterProcessor extends AudioWorkletProcessor {
     this.numberOfChannels = numberOfChannels;
     this.blocksPerUpdate = Math.max(1, Math.floor(sampleRate / (128 * updateRate)));
     this.blocksProcessed = 0;
-    this.maxPeak = new Array(numberOfChannels).fill(0);
-    this.sumSquares = new Array(numberOfChannels).fill(0);
-    this.sampleCount = new Array(numberOfChannels).fill(0);
+    this.maxPeak = new Float32Array(numberOfChannels);
+    this.sumSquares = new Float64Array(numberOfChannels);
+    this.sampleCount = new Uint32Array(numberOfChannels);
+    this.levels = new Float32Array(2 * numberOfChannels);
   }
 
   process(
@@ -79,16 +89,16 @@ class MeterProcessor extends AudioWorkletProcessor {
     this.blocksProcessed++;
 
     if (this.blocksProcessed >= this.blocksPerUpdate) {
-      const peak: number[] = [];
-      const rms: number[] = [];
-
       for (let ch = 0; ch < this.numberOfChannels; ch++) {
-        peak.push(this.maxPeak[ch]);
+        this.levels[ch] = this.maxPeak[ch];
         const count = this.sampleCount[ch];
-        rms.push(count > 0 ? Math.sqrt(this.sumSquares[ch] / count) : 0);
+        this.levels[this.numberOfChannels + ch] =
+          count > 0 ? Math.sqrt(this.sumSquares[ch] / count) : 0;
       }
 
-      this.port.postMessage({ peak, rms });
+      // Structured clone copies the contents; the worklet keeps its buffer.
+      // Transferring would detach it and force a per-flush reallocation.
+      this.port.postMessage(this.levels);
 
       this.maxPeak.fill(0);
       this.sumSquares.fill(0);


### PR DESCRIPTION
## Summary

Tier-1 deferred item from the PR #386 review: the meter-processor worklet allocated on the audio thread on every flush (~60 Hz) — two fresh `number[]` arrays built with `.push()`, plus an envelope object, posted via structured clone. Its internal accumulators were also plain `Array<number>`.

- **Worklet internals**: accumulators are now pre-allocated typed arrays — `Float32Array` maxPeak, `Float64Array` sumSquares (avoids precision drift when summing many squared samples), `Uint32Array` sampleCount.
- **Wire format**: posts a single **reused** `Float32Array(2*N)` — peaks at `[0..N-1]`, RMS at `[N..2N-1]` — instead of `{ peak: number[], rms: number[] }`. The buffer is deliberately *not* transferred: structured clone copies the contents and the worklet keeps its buffer, so steady-state `process()`/flush does **zero allocation** on the audio thread.
- **`MeterMessage`** (exported from `@waveform-playlist/worklets`) changes from an interface to the documented `Float32Array` layout type.
- **Consumers updated** to read by index: `useMicrophoneLevel` (recording) and `useOutputMeter` (browser) — the only two consumers in the repo (verified by grep; dawcore/website/examples don't touch the meter message).

## Breaking change / release note

The meter wire format and the `MeterMessage` type are breaking for any external consumer of `@waveform-playlist/worklets` that uses the meter processor directly.

No version bumps in this PR (per repo convention, bumps happen at release time). When releasing:
- `@waveform-playlist/worklets` needs a **major** bump.
- `@waveform-playlist/recording` and `@waveform-playlist/browser` both pin `workspace:*` → exact pins at publish, so both must be republished in the same sweep.

## Test plan

- [x] TDD: updated `meter-processor.test.ts` to the new layout first and watched 6 tests fail against the old implementation, then implemented (10/10 pass)
- [x] New test asserts buffer reuse across flushes (same `Float32Array` identity, no per-flush allocation) and the RMS upper-half layout
- [x] `npx tsc --project tsconfig.worklet.json --noEmit` (worklet scope) clean
- [x] Rebuilt worklets dist, then `pnpm --filter @waveform-playlist/recording typecheck` and `--filter @waveform-playlist/browser typecheck` clean
- [x] Full suites: worklets 27/27, recording 32/32, browser 270/270
- [x] `pnpm lint` — 0 errors (warnings are the pre-existing `no-explicit-any` baseline)
- [x] `pnpm --filter ... build` for worklets, recording, browser
