### PR TITLE
fix: worklets CJS entry crash + meter-processor edge behaviors (#574, #581)

### DIFF
--- a/packages/worklets/src/__tests__/meter-processor.test.ts
+++ b/packages/worklets/src/__tests__/meter-processor.test.ts
@@ -161,6 +161,49 @@ describe('MeterProcessor', () => {
     expect(second).toBe(first);
   });
 
+  it('treats empty input as silence so levels fall to zero instead of freezing', () => {
+    const processor = createProcessor({ numberOfChannels: 1, updateRate: 48000 });
+    const loud = new Float32Array(128).fill(0.5);
+    processor.process(makeInput([loud]), makeOutput(1), {});
+    expect(mockPort.postMessage).toHaveBeenCalledTimes(1);
+
+    // Ended/idle source delivering empty input must still advance the flush
+    // cadence with silent samples — a frozen VU meter stuck at the last
+    // level is indistinguishable from live signal.
+    processor.process([[]], makeOutput(1), {});
+    expect(mockPort.postMessage).toHaveBeenCalledTimes(2);
+    const msg = mockPort.postMessage.mock.calls[1][0] as MeterMessage;
+    expect(msg[0]).toBe(0);
+    expect(msg[1]).toBe(0);
+  });
+
+  it('defaults an invalid updateRate instead of never posting', () => {
+    // updateRate 0 would make blocksPerUpdate Infinity — a silent no-op meter.
+    const processor = createProcessor({ numberOfChannels: 1, updateRate: 0 });
+    const input = new Float32Array(128).fill(0.5);
+    // Default 60Hz at 48kHz → blocksPerUpdate 6
+    for (let i = 0; i < 6; i++) {
+      processor.process(makeInput([input]), makeOutput(1), {});
+    }
+    expect(mockPort.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('constructs with missing processorOptions using defaults (no throw)', () => {
+    const Processor = getProcessorClass();
+    expect(() => new Processor({})).not.toThrow();
+
+    mockPort.postMessage.mockClear();
+    const processor = new Processor({}) as MockProcessor;
+    const input = new Float32Array(128).fill(0.5);
+    // Defaults: 1 channel, 60Hz → blocksPerUpdate 6 at 48kHz
+    for (let i = 0; i < 6; i++) {
+      processor.process([[input]], makeOutput(1), {});
+    }
+    expect(mockPort.postMessage).toHaveBeenCalledTimes(1);
+    const msg = mockPort.postMessage.mock.calls[0][0] as MeterMessage;
+    expect(msg.length).toBe(2);
+  });
+
   it('returns true to keep processor alive', () => {
     const processor = createProcessor({ numberOfChannels: 1 });
     const result = processor.process(makeInput([new Float32Array(128)]), makeOutput(1), {});

--- a/packages/worklets/src/worklet/meter-processor.worklet.ts
+++ b/packages/worklets/src/worklet/meter-processor.worklet.ts
@@ -35,16 +35,26 @@ class MeterProcessor extends AudioWorkletProcessor {
   /** Reused message buffer: [0..N-1] peak, [N..2N-1] rms */
   private levels: Float32Array;
 
-  constructor(options: { processorOptions: MeterProcessorOptions }) {
+  constructor(options: { processorOptions?: Partial<MeterProcessorOptions> }) {
     super();
-    const { numberOfChannels, updateRate } = options.processorOptions;
-    this.numberOfChannels = numberOfChannels;
-    this.blocksPerUpdate = Math.max(1, Math.floor(sampleRate / (128 * updateRate)));
+    // Console output from a worklet is invisible — fall back to safe defaults
+    // silently instead of dying in the constructor (missing processorOptions)
+    // or never posting (updateRate <= 0 makes blocksPerUpdate Infinity).
+    const { numberOfChannels, updateRate } = options?.processorOptions ?? {};
+    this.numberOfChannels =
+      typeof numberOfChannels === 'number' && Number.isFinite(numberOfChannels)
+        ? Math.max(1, Math.floor(numberOfChannels))
+        : 1;
+    const rate =
+      typeof updateRate === 'number' && Number.isFinite(updateRate) && updateRate > 0
+        ? updateRate
+        : 60;
+    this.blocksPerUpdate = Math.max(1, Math.floor(sampleRate / (128 * rate)));
     this.blocksProcessed = 0;
-    this.maxPeak = new Float32Array(numberOfChannels);
-    this.sumSquares = new Float64Array(numberOfChannels);
-    this.sampleCount = new Uint32Array(numberOfChannels);
-    this.levels = new Float32Array(2 * numberOfChannels);
+    this.maxPeak = new Float32Array(this.numberOfChannels);
+    this.sumSquares = new Float64Array(this.numberOfChannels);
+    this.sampleCount = new Uint32Array(this.numberOfChannels);
+    this.levels = new Float32Array(2 * this.numberOfChannels);
   }
 
   process(
@@ -56,6 +66,14 @@ class MeterProcessor extends AudioWorkletProcessor {
     const output = outputs[0];
 
     if (!input || input.length === 0) {
+      // No input (ended/idle source): count a silent quantum so the flush
+      // cadence continues and levels fall to zero — an early return here
+      // freezes the meter at its last posted value.
+      for (let ch = 0; ch < this.numberOfChannels; ch++) {
+        this.sampleCount[ch] += 128;
+      }
+      this.blocksProcessed++;
+      this.flushIfDue();
       return true;
     }
 
@@ -87,26 +105,29 @@ class MeterProcessor extends AudioWorkletProcessor {
     }
 
     this.blocksProcessed++;
-
-    if (this.blocksProcessed >= this.blocksPerUpdate) {
-      for (let ch = 0; ch < this.numberOfChannels; ch++) {
-        this.levels[ch] = this.maxPeak[ch];
-        const count = this.sampleCount[ch];
-        this.levels[this.numberOfChannels + ch] =
-          count > 0 ? Math.sqrt(this.sumSquares[ch] / count) : 0;
-      }
-
-      // Structured clone copies the contents; the worklet keeps its buffer.
-      // Transferring would detach it and force a per-flush reallocation.
-      this.port.postMessage(this.levels);
-
-      this.maxPeak.fill(0);
-      this.sumSquares.fill(0);
-      this.sampleCount.fill(0);
-      this.blocksProcessed = 0;
-    }
+    this.flushIfDue();
 
     return true;
+  }
+
+  private flushIfDue(): void {
+    if (this.blocksProcessed < this.blocksPerUpdate) return;
+
+    for (let ch = 0; ch < this.numberOfChannels; ch++) {
+      this.levels[ch] = this.maxPeak[ch];
+      const count = this.sampleCount[ch];
+      this.levels[this.numberOfChannels + ch] =
+        count > 0 ? Math.sqrt(this.sumSquares[ch] / count) : 0;
+    }
+
+    // Structured clone copies the contents; the worklet keeps its buffer.
+    // Transferring would detach it and force a per-flush reallocation.
+    this.port.postMessage(this.levels);
+
+    this.maxPeak.fill(0);
+    this.sumSquares.fill(0);
+    this.sampleCount.fill(0);
+    this.blocksProcessed = 0;
   }
 }
 

--- a/packages/worklets/tsup.config.ts
+++ b/packages/worklets/tsup.config.ts
@@ -10,6 +10,10 @@ export default defineConfig([
     splitting: false,
     sourcemap: true,
     clean: true,
+    // Without shims, the CJS build stubs import.meta as {} and the top-level
+    // `new URL('./worklet/…', import.meta.url)` throws Invalid URL at require
+    // time (#574). shims replaces import.meta.url with pathToFileURL(__filename).
+    shims: true,
   },
   {
     entry: {


### PR DESCRIPTION
## Summary

Two worklets-package findings from the 2026-07-04 recording review.

**#574 — CJS dist threw at require time.** tsup's CJS output stubbed `import.meta` as `{}`, so the top-level `new URL('./worklet/…', import.meta.url)` threw `TypeError: Invalid URL` the moment the module was `require`d — the `require` export condition has been a dead artifact since inception. Fixed with `shims: true` (tsup replaces `import.meta.url` with `pathToFileURL(__filename)` in CJS). Verified: `node -e "require('.../dist/index.js')"` now resolves and `meterProcessorUrl` is a real `file://` URL.

**#581 — meter-processor edges (TDD, 3 new tests).**
- Empty input (ended/idle source) now counts a silent quantum so the flush cadence continues and levels decay to zero instead of freezing at the last posted value.
- `updateRate <= 0` (previously → `blocksPerUpdate = Infinity`, a silent no-op meter) and missing `processorOptions` (previously a constructor throw) fall back to safe defaults — worklet console output is invisible, so silent-safe beats dead.

## Test plan
- [x] 3 new meter tests written first and watched fail (32/32 after)
- [x] `tsc --project tsconfig.worklet.json` clean
- [x] CJS require verified against rebuilt dist (was: Invalid URL)
- [x] `pnpm lint` 0 errors

Fixes #574, fixes #581