### PR TITLE
fix: recording package cleanup — device-switch guard, tracks snapshot, meter hygiene (#571, #572, #580)

### DIFF
--- a/packages/recording/src/__tests__/useIntegratedRecording.test.tsx
+++ b/packages/recording/src/__tests__/useIntegratedRecording.test.tsx
@@ -1,0 +1,235 @@
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ClipTrack } from '@waveform-playlist/core';
+
+interface MockNode {
+  port: {
+    postMessage: ReturnType<typeof vi.fn>;
+    onmessage: ((event: MessageEvent) => void) | null;
+    close: ReturnType<typeof vi.fn>;
+  };
+  onprocessorerror: ((event: Event) => void) | null;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function createMockNode(autoAckStop = true): MockNode {
+  const node: MockNode = {
+    port: {
+      postMessage: vi.fn((msg: { command?: string }) => {
+        if (autoAckStop && msg?.command === 'stop' && node.port.onmessage) {
+          node.port.onmessage({
+            data: { channels: [], channelCount: 1, done: true },
+          } as MessageEvent);
+        }
+      }),
+      onmessage: null,
+      close: vi.fn(),
+    },
+    onprocessorerror: null,
+    disconnect: vi.fn(),
+  };
+  return node;
+}
+
+let recNode: MockNode;
+let meterNode: MockNode;
+let mockContext: {
+  state: string;
+  sampleRate: number;
+  lookAhead: number;
+  resume: ReturnType<typeof vi.fn>;
+  createMediaStreamSource: ReturnType<typeof vi.fn>;
+  createAudioWorkletNode: ReturnType<typeof vi.fn>;
+  rawContext: { sampleRate: number; audioWorklet: { addModule: ReturnType<typeof vi.fn> } };
+};
+let mockRawAudioContext: { outputLatency: number; sampleRate: number };
+
+vi.mock('@waveform-playlist/playout', () => ({
+  getGlobalContext: () => mockContext,
+  getGlobalAudioContext: () => mockRawAudioContext,
+  resumeGlobalAudioContext: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@waveform-playlist/worklets', () => ({
+  addRecordingWorkletModule: vi.fn(() => Promise.resolve()),
+  addMeterWorkletModule: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@waveform-playlist/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@waveform-playlist/core')>();
+  return {
+    ...actual,
+    appendPeaks: vi.fn((existing: Int8Array | Int16Array) => existing),
+    concatenateAudioData: vi.fn((chunks: Float32Array[]) => {
+      const total = chunks.reduce((sum, c) => sum + c.length, 0);
+      return new Float32Array(total);
+    }),
+    createAudioBuffer: vi.fn((_ctx: unknown, channelData: Float32Array[]) => ({
+      length: channelData[0]?.length ?? 0,
+      sampleRate: 48000,
+      numberOfChannels: channelData.length || 1,
+      duration: (channelData[0]?.length ?? 0) / 48000,
+    })),
+  };
+});
+
+const { useIntegratedRecording } = await import('../hooks/useIntegratedRecording');
+
+function createMockStream(id: string): MediaStream {
+  const track = {
+    stop: vi.fn(),
+    kind: 'audio',
+    getSettings: () => ({ channelCount: 1 }),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  return {
+    id,
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+}
+
+let getUserMediaMock: ReturnType<typeof vi.fn>;
+
+function makeTrack(id: string, clips: ClipTrack['clips'] = []): ClipTrack {
+  return { id, name: id, clips } as ClipTrack;
+}
+
+beforeEach(() => {
+  recNode = createMockNode();
+  meterNode = createMockNode();
+  mockContext = {
+    state: 'running',
+    sampleRate: 48000,
+    lookAhead: 0,
+    resume: vi.fn(() => Promise.resolve()),
+    createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+    createAudioWorkletNode: vi.fn((name: string) =>
+      name === 'recording-processor' ? recNode : meterNode
+    ),
+    rawContext: {
+      sampleRate: 48000,
+      audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
+    },
+  };
+  mockRawAudioContext = { outputLatency: 0, sampleRate: 48000 };
+  getUserMediaMock = vi.fn();
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia: getUserMediaMock,
+      enumerateDevices: vi.fn(async () => [
+        { kind: 'audioinput', deviceId: 'dev-a', label: 'Mic A', groupId: 'g1' },
+      ]),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+  });
+});
+
+afterEach(async () => {
+  await act(async () => {
+    cleanup();
+  });
+  vi.clearAllMocks();
+});
+
+describe('useIntegratedRecording', () => {
+  async function setupRecording(initialTracks: ClipTrack[], setTracks: (t: ClipTrack[]) => void) {
+    const stream = createMockStream('mic');
+    getUserMediaMock.mockResolvedValue(stream);
+
+    const rendered = renderHook(
+      ({ tracks }: { tracks: ClipTrack[] }) => useIntegratedRecording(tracks, setTracks, 'track-1'),
+      { initialProps: { tracks: initialTracks } }
+    );
+
+    await act(async () => {
+      await rendered.result.current.requestMicAccess();
+    });
+    await act(async () => {
+      await rendered.result.current.startRecording();
+    });
+    expect(rendered.result.current.isRecording).toBe(true);
+    return rendered;
+  }
+
+  it('rejects changeDevice while recording (stream untouched, error surfaced)', async () => {
+    const setTracks = vi.fn();
+    const { result } = await setupRecording([makeTrack('track-1')], setTracks);
+
+    const streamBefore = result.current.stream;
+    getUserMediaMock.mockClear();
+
+    await act(async () => {
+      await result.current.changeDevice('dev-b');
+    });
+
+    // Switching devices mid-recording stops the old stream's tracks without
+    // firing 'ended' — the rest of the take silently records silence. The
+    // guard must refuse instead.
+    expect(getUserMediaMock).not.toHaveBeenCalled();
+    expect(result.current.stream).toBe(streamBefore);
+    expect(result.current.isRecording).toBe(true);
+    expect(result.current.error?.message).toMatch(/recording/i);
+  });
+
+  it('rejects requestMicAccess while recording', async () => {
+    const setTracks = vi.fn();
+    const { result } = await setupRecording([makeTrack('track-1')], setTracks);
+
+    getUserMediaMock.mockClear();
+    await act(async () => {
+      await result.current.requestMicAccess();
+    });
+
+    expect(getUserMediaMock).not.toHaveBeenCalled();
+    expect(result.current.isRecording).toBe(true);
+  });
+
+  it('finalizes the clip against the latest tracks (concurrent edits survive the stop handshake)', async () => {
+    const setTracks = vi.fn();
+    const trackOne = makeTrack('track-1');
+    const rendered = await setupRecording([trackOne], setTracks);
+
+    // Push one chunk so the finalized buffer is non-empty
+    act(() => {
+      recNode.port.onmessage!({
+        data: { channels: [new Float32Array(1024).fill(0.2)], channelCount: 1 },
+      } as MessageEvent);
+    });
+
+    // Defer the stop ack so the handshake stays in flight while tracks change
+    recNode.port.postMessage = vi.fn((msg: { command?: string }) => {
+      if (msg?.command === 'stop') {
+        setTimeout(() => {
+          recNode.port.onmessage?.({
+            data: { channels: [], channelCount: 1, done: true },
+          } as MessageEvent);
+        }, 20);
+      }
+    });
+
+    let stopPromise!: Promise<void>;
+    act(() => {
+      stopPromise = rendered.result.current.stopRecording() as unknown as Promise<void>;
+    });
+
+    // A concurrent edit lands while the stop handshake is in flight
+    const trackTwo = makeTrack('track-2');
+    rendered.rerender({ tracks: [trackOne, trackTwo] });
+
+    await act(async () => {
+      await stopPromise;
+    });
+
+    expect(setTracks).toHaveBeenCalledTimes(1);
+    const finalTracks = setTracks.mock.calls[0][0] as ClipTrack[];
+    // The concurrently-added track must survive...
+    expect(finalTracks.some((t) => t.id === 'track-2')).toBe(true);
+    // ...and the recorded clip lands on track-1
+    const t1 = finalTracks.find((t) => t.id === 'track-1')!;
+    expect(t1.clips).toHaveLength(1);
+  });
+});

--- a/packages/recording/src/__tests__/useMicrophoneLevel.test.tsx
+++ b/packages/recording/src/__tests__/useMicrophoneLevel.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+interface MockNode {
+  port: {
+    postMessage: ReturnType<typeof vi.fn>;
+    onmessage: ((event: MessageEvent) => void) | null;
+    close: ReturnType<typeof vi.fn>;
+  };
+  onprocessorerror: ((event: Event) => void) | null;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+let meterNode: MockNode;
+let mockContext: {
+  state: string;
+  resume: ReturnType<typeof vi.fn>;
+  createMediaStreamSource: ReturnType<typeof vi.fn>;
+  createAudioWorkletNode: ReturnType<typeof vi.fn>;
+  rawContext: { audioWorklet: { addModule: ReturnType<typeof vi.fn> } };
+};
+
+vi.mock('@waveform-playlist/playout', () => ({
+  getGlobalContext: () => mockContext,
+}));
+
+vi.mock('@waveform-playlist/worklets', () => ({
+  addMeterWorkletModule: vi.fn(() => Promise.resolve()),
+}));
+
+const { useMicrophoneLevel } = await import('../hooks/useMicrophoneLevel');
+const worklets = await import('@waveform-playlist/worklets');
+
+function createMockStream(id: string, channelCount = 1): MediaStream {
+  const track = {
+    stop: vi.fn(),
+    kind: 'audio',
+    getSettings: () => ({ channelCount }),
+  };
+  return { id, getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+}
+
+beforeEach(() => {
+  meterNode = {
+    port: { postMessage: vi.fn(), onmessage: null, close: vi.fn() },
+    onprocessorerror: null,
+    disconnect: vi.fn(),
+  };
+  mockContext = {
+    state: 'running',
+    resume: vi.fn(() => Promise.resolve()),
+    createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+    createAudioWorkletNode: vi.fn(() => meterNode),
+    rawContext: { audioWorklet: { addModule: vi.fn(() => Promise.resolve()) } },
+  };
+});
+
+afterEach(async () => {
+  await act(async () => {
+    cleanup();
+  });
+  vi.clearAllMocks();
+});
+
+describe('useMicrophoneLevel', () => {
+  it('surfaces a setup error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(worklets.addMeterWorkletModule).mockRejectedValueOnce(new Error('CSP blocked'));
+
+    // Stream must be stable across renders — a fresh object per render
+    // re-runs the setup effect, which would succeed on the second attempt.
+    const stream = createMockStream('s1');
+    const { result } = renderHook(() => useMicrophoneLevel(stream));
+    await act(async () => {});
+
+    expect(result.current.error).toBeTruthy();
+    warnSpy.mockRestore();
+  });
+
+  it('clears the error after a successful re-setup on a new stream', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(worklets.addMeterWorkletModule).mockRejectedValueOnce(new Error('CSP blocked'));
+
+    const { result, rerender } = renderHook(
+      ({ stream }: { stream: MediaStream }) => useMicrophoneLevel(stream),
+      { initialProps: { stream: createMockStream('s1') } }
+    );
+    await act(async () => {});
+    expect(result.current.error).toBeTruthy();
+
+    // New stream, setup succeeds — a stale error would leave the UI showing
+    // a permanent failure while metering actually works.
+    rerender({ stream: createMockStream('s2') });
+    await act(async () => {});
+
+    expect(result.current.error).toBeNull();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/recording/src/hooks/useIntegratedRecording.ts
+++ b/packages/recording/src/hooks/useIntegratedRecording.ts
@@ -62,11 +62,15 @@ export interface UseIntegratedRecordingReturn {
   duration: number;
   level: number;
   peakLevel: number;
-  /** Per-channel peak levels (0-1). Array length matches channelCount. */
+  /**
+   * Per-channel peak levels (0-1). Array length matches the metered channel
+   * count (auto-detected mic channels; mono mirrored up to channelCount —
+   * see UseMicrophoneLevelReturn.levels).
+   */
   levels: number[];
-  /** Per-channel held peak levels (0-1). Array length matches channelCount. */
+  /** Per-channel held peak levels (0-1). Same length contract as `levels`. */
   peakLevels: number[];
-  /** Per-channel RMS levels (0-1). Array length matches channelCount. */
+  /** Per-channel RMS levels (0-1). Same length contract as `levels`. */
   rmsLevels: number[];
   error: Error | null;
 
@@ -111,6 +115,11 @@ export function useIntegratedRecording(
   selectedTrackIdRef.current = selectedTrackId;
   const currentTimeRef = useRef(currentTime);
   currentTimeRef.current = currentTime;
+  // Latest tracks for reads that happen AFTER an await — the stop handshake
+  // can take >1s, and finalizing against a closure capture would discard any
+  // track edits that landed in that window.
+  const tracksRef = useRef(tracks);
+  tracksRef.current = tracks;
 
   // Microphone access
   const { stream, devices, hasPermission, requestAccess, error: micError } = useMicrophoneAccess();
@@ -182,10 +191,13 @@ export function useIntegratedRecording(
       return;
     }
 
-    // Add clip to track after recording completes
+    // Add clip to track after recording completes. Read tracks through the
+    // ref — the awaited stop handshake above can span >1s, and the closure's
+    // tracks capture would silently revert concurrent edits.
     const trackId = selectedTrackIdRef.current;
+    const currentTracks = tracksRef.current;
     if (buffer && trackId) {
-      const selectedTrackIndex = tracks.findIndex((t) => t.id === trackId);
+      const selectedTrackIndex = currentTracks.findIndex((t) => t.id === trackId);
       if (selectedTrackIndex === -1) {
         const err = new Error(
           `Recording completed but track "${trackId}" no longer exists. The recorded audio could not be saved.`
@@ -195,7 +207,7 @@ export function useIntegratedRecording(
         return;
       }
 
-      const selectedTrack = tracks[selectedTrackIndex];
+      const selectedTrack = currentTracks[selectedTrackIndex];
 
       // Use the captured start time (not live currentTime which advances during overdub)
       const recordStartTimeSamples = Math.floor(recordingStartTimeRef.current * buffer.sampleRate);
@@ -249,7 +261,7 @@ export function useIntegratedRecording(
       };
 
       // Add clip to track
-      const newTracks = tracks.map((track, index) => {
+      const newTracks = currentTracks.map((track, index) => {
         if (index === selectedTrackIndex) {
           return {
             ...track,
@@ -261,7 +273,7 @@ export function useIntegratedRecording(
 
       setTracks(newTracks);
     }
-  }, [tracks, setTracks, stopRec, latencyOffset]);
+  }, [setTracks, stopRec, latencyOffset]);
 
   // Auto-select first device when available, or fallback if selected device was unplugged
   useEffect(() => {
@@ -279,8 +291,20 @@ export function useIntegratedRecording(
     }
   }, [hasPermission, devices, selectedDevice, resetPeak, requestAccess, audioConstraints]);
 
+  // Mirror isRecording for the device-switch guards below — reading the
+  // state directly would churn the callbacks every recording toggle.
+  const isRecordingRef = useRef(isRecording);
+  isRecordingRef.current = isRecording;
+
   // Request microphone access
   const requestMicAccess = useCallback(async () => {
+    // requestAccess stops the current stream's tracks, and track.stop() fires
+    // no 'ended' event — the recording's source is never rewired, so the rest
+    // of the take silently records silence. Refuse while recording.
+    if (isRecordingRef.current) {
+      setHookError(new Error('Cannot request microphone access while recording. Stop first.'));
+      return;
+    }
     try {
       setHookError(null);
       await requestAccess(undefined, audioConstraints);
@@ -294,6 +318,11 @@ export function useIntegratedRecording(
   // Change device
   const changeDevice = useCallback(
     async (deviceId: string) => {
+      // Same silent-silence hazard as requestMicAccess above.
+      if (isRecordingRef.current) {
+        setHookError(new Error('Cannot switch microphone while recording. Stop first.'));
+        return;
+      }
       try {
         setHookError(null);
         setSelectedDevice(deviceId);

--- a/packages/recording/src/hooks/useMicrophoneLevel.ts
+++ b/packages/recording/src/hooks/useMicrophoneLevel.ts
@@ -48,18 +48,21 @@ export interface UseMicrophoneLevelReturn {
   resetPeak: () => void;
 
   /**
-   * Per-channel peak levels (0-1). Array length matches channelCount.
+   * Per-channel peak levels (0-1). Array length matches the metered channel
+   * count: the mic's auto-detected channels, with mono mirrored up to the
+   * requested `channelCount`. A mic with MORE channels than `channelCount`
+   * yields one entry per actual channel.
    * True peak: max absolute sample value per analysis frame.
    */
   levels: number[];
 
   /**
-   * Per-channel held peak levels (0-1). Array length matches channelCount.
+   * Per-channel held peak levels (0-1). Same length contract as `levels`.
    */
   peakLevels: number[];
 
   /**
-   * Per-channel RMS levels (0-1). Array length matches channelCount.
+   * Per-channel RMS levels (0-1). Same length contract as `levels`.
    * RMS: root mean square of samples per analysis frame.
    */
   rmsLevels: number[];
@@ -189,6 +192,10 @@ export function useMicrophoneLevel(
         setRmsLevels(mirroredRms);
         setPeakLevels((prev) => mirroredPeaks.map((val, i) => Math.max(prev[i] ?? 0, val)));
       };
+
+      // Setup succeeded — clear any error from a previous failed attempt so
+      // the UI doesn't show a permanent failure while metering works.
+      setMeterError(null);
     };
 
     setupMonitoring().catch((err) => {

--- a/packages/recording/src/types/index.ts
+++ b/packages/recording/src/types/index.ts
@@ -63,8 +63,17 @@ export interface UseRecordingReturn {
   duration: number;
   peaks: (Int8Array | Int16Array)[];
   audioBuffer: AudioBuffer | null;
-  level: number; // Current RMS level (0-1)
-  peakLevel: number; // Peak RMS level since recording started (0-1)
+  /**
+   * @deprecated Always 0 — VU levels come from `useMicrophoneLevel`
+   * (meter-processor worklet), not this hook. Will be removed in the next
+   * major version.
+   */
+  level: number;
+  /**
+   * @deprecated Always 0 — use `useMicrophoneLevel`'s `peakLevel` instead.
+   * Will be removed in the next major version.
+   */
+  peakLevel: number;
 
   // Controls
   startRecording: () => Promise<void>;


### PR DESCRIPTION
## Summary

Three recording-package findings from the 2026-07-04 review, all TDD'd (two new test files; every fix had a failing test first).

**#571 — device switch mid-recording records silence.** `requestAccess` stops the current stream's tracks, and `track.stop()` fires no `ended` event, so the recording's source node was never rewired — duration kept advancing while everything from the switch point on was silence. `changeDevice`/`requestMicAccess` now refuse while recording with a clear error; the mic selector in the website example already disables itself during recording, so this only hardens the programmatic path.

**#572 — concurrent track edits discarded on stop.** `stopRecording` finalized the clip against its closure's `tracks` capture, which could be >1s stale after the stop handshake + drain. It now reads through a per-render `tracksRef`, so clip drags/track adds landing during the handshake survive. (Also makes the callback stable — no more per-tracks-change recreation.)

**#580 — meter/level hygiene.**
- `useMicrophoneLevel` clears its error after a successful re-setup (previously one transient failure showed a permanent error while metering worked).
- The `levels`/`peakLevels`/`rmsLevels` length contract is now documented truthfully (auto-detected mic channels, mono mirrored up to `channelCount`) in both hooks — the auto-detect behavior is intentional per recording/CLAUDE.md, so the docs were wrong, not the code.
- `useRecording`'s dead `level`/`peakLevel` returns (always 0) are marked `@deprecated` pointing at `useMicrophoneLevel`, for removal in the next major.

## Test plan
- [x] New `useIntegratedRecording.test.tsx` (guard x2 + stale-tracks finalization) and `useMicrophoneLevel.test.tsx` (error clear + baseline) — RED verified before implementing
- [x] Full recording suite 48/48; typecheck clean; `pnpm lint` 0 errors; package builds

Fixes #571, fixes #572, fixes #580