### PR TITLE
fix: dawcore recording cleanup — button retargeting, capture rate, beats preview, disposal event (#573, #576-#578)

### DIFF
--- a/packages/dawcore/src/__tests__/daw-record-button.test.ts
+++ b/packages/dawcore/src/__tests__/daw-record-button.test.ts
@@ -117,6 +117,42 @@ describe('daw-record-button capability detection (#474 foundation)', () => {
     expect(startRecording).toHaveBeenCalled();
   });
 
+  it('reflects recording state from a late-appearing target (#573)', async () => {
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<daw-transport for="late-state-target"><daw-record-button></daw-record-button></daw-transport>'
+    );
+    const button = document.querySelector('daw-record-button')! as HTMLElement & {
+      updateComplete: Promise<boolean>;
+    };
+    // The connectedCallback rAF runs with no target resolvable
+    await nextFrame();
+    await button.updateComplete;
+
+    const startRecording = vi.fn();
+    const late = document.createElement('div');
+    late.id = 'late-state-target';
+    Object.assign(late, { startRecording, stopRecording: vi.fn() });
+    document.body.appendChild(late);
+
+    // Hover re-render — the state listeners must (re)attach here, not only
+    // in the one-shot connectedCallback rAF
+    button.dispatchEvent(new Event('pointerenter', { bubbles: true }));
+    await button.updateComplete;
+
+    const inner = button.shadowRoot!.querySelector('button')!;
+    inner.click();
+    expect(startRecording).toHaveBeenCalled();
+
+    late.dispatchEvent(new CustomEvent('daw-recording-start', { detail: {} }));
+    await button.updateComplete;
+    expect(inner.hasAttribute('data-recording')).toBe(true);
+
+    late.dispatchEvent(new CustomEvent('daw-recording-error', { detail: {} }));
+    await button.updateComplete;
+    expect(inner.hasAttribute('data-recording')).toBe(false);
+  });
+
   it('warns once on pointer interaction when the transport target is missing', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     document.body.insertAdjacentHTML(

--- a/packages/dawcore/src/__tests__/recording-clip.test.ts
+++ b/packages/dawcore/src/__tests__/recording-clip.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { addRecordedClip, type RecordingClipHost } from '../interactions/recording-clip';
+import type { PeakData } from '@waveform-playlist/core';
+
+function makeHost(overrides: Partial<RecordingClipHost> = {}): RecordingClipHost {
+  return {
+    samplesPerPixel: 1024,
+    mono: false,
+    isConnected: true,
+    effectiveSampleRate: 48000,
+    _tracks: new Map(),
+    _engineTracks: new Map(),
+    _peaksData: new Map(),
+    _clipBuffers: new Map(),
+    _peakPipeline: {
+      generatePeaks: vi.fn(async () => ({ data: [], length: 0, bits: 16 }) as unknown as PeakData),
+    } as unknown as RecordingClipHost['_peakPipeline'],
+    _engine: null,
+    _recomputeDuration: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+    ...overrides,
+  } as RecordingClipHost;
+}
+
+function makeBuffer(length: number): AudioBuffer {
+  return {
+    length,
+    numberOfChannels: 1,
+    sampleRate: 48000,
+    duration: length / 48000,
+    getChannelData: () => new Float32Array(length),
+  } as unknown as AudioBuffer;
+}
+
+describe('addRecordedClip', () => {
+  it('does not orphan a _peaksData entry when the track was removed during peak generation', async () => {
+    const host = makeHost(); // _engineTracks has no track — simulates removal mid-generation
+
+    addRecordedClip(host, 'gone-track', makeBuffer(1000), 0, 1000, 0);
+    await vi.waitFor(() => {
+      expect(host._peakPipeline.generatePeaks).toHaveBeenCalled();
+    });
+    // Let the .then() continuation settle
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Cleanup must cover every per-clip cache, not just _clipBuffers — the
+    // clip never enters the engine, so nothing else ever deletes this entry.
+    expect(host._clipBuffers.size).toBe(0);
+    expect(host._peaksData.size).toBe(0);
+  });
+});

--- a/packages/dawcore/src/__tests__/recording-controller.test.ts
+++ b/packages/dawcore/src/__tests__/recording-controller.test.ts
@@ -42,6 +42,7 @@ function createMockHost() {
       audioWorklet: { addModule: vi.fn(() => Promise.resolve()) },
     },
     samplesPerPixel: 1024,
+    renderSamplesPerPixel: 1024,
     effectiveSampleRate: 48000,
     resolveAudioContextSampleRate: vi.fn(),
     _addRecordedClip: vi.fn(),
@@ -959,6 +960,60 @@ describe('RecordingController', () => {
 
     expect(resumeSpy).toHaveBeenCalled();
     expect(controller.isRecording).toBe(true);
+  });
+
+  it('labels the recorded AudioBuffer with the capture-time context rate (#576)', async () => {
+    const { createAudioBuffer } = await import('@waveform-playlist/core');
+    vi.mocked(createAudioBuffer).mockClear();
+    // Capture context runs at 44100; the editor-space sticky rate lags at 48000
+    // (resolveAudioContextSampleRate only sets it when unset).
+    host.audioContext.sampleRate = 44100;
+    host.effectiveSampleRate = 48000;
+
+    const controller = new RecordingController(host);
+    await controller.startRecording(createMockStream(), { trackId: 'track-1' });
+    simulateWorkletData('track-1', 44100);
+
+    host.dispatchEvent = vi.fn(() => true);
+    await controller.stopRecording();
+
+    // Labeling with the stale editor rate plays the take ~8.9% off-speed.
+    expect(vi.mocked(createAudioBuffer).mock.calls[0][2]).toBe(44100);
+  });
+
+  it('appends live-preview peaks at renderSamplesPerPixel (beats-mode alignment, #577)', async () => {
+    const { appendPeaks } = await import('@waveform-playlist/core');
+    vi.mocked(appendPeaks).mockClear();
+    // In beats mode the render scale is derived from ticksPerPixel/bpm and
+    // differs from the raw samplesPerPixel property.
+    host.samplesPerPixel = 1024;
+    host.renderSamplesPerPixel = 512;
+
+    const controller = new RecordingController(host);
+    await controller.startRecording(createMockStream(), { trackId: 'track-1' });
+    simulateWorkletData('track-1', 512);
+
+    expect(vi.mocked(appendPeaks).mock.calls[0][2]).toBe(512);
+  });
+
+  it('dispatches daw-recording-error when the editor is disposed mid-recording (#578)', async () => {
+    const controller = new RecordingController(host);
+    await controller.startRecording(createMockStream(), { trackId: 'track-1' });
+    simulateWorkletData('track-1', 512);
+
+    const events: CustomEvent[] = [];
+    host.dispatchEvent = vi.fn((e: Event) => {
+      if (e instanceof CustomEvent) events.push(e);
+      return true;
+    });
+
+    controller.hostDisconnected();
+
+    // Without this, a record button in a still-connected <daw-transport>
+    // stays wedged red forever — its listeners are on the dead editor.
+    const errorEvent = events.find((e) => e.type === 'daw-recording-error');
+    expect(errorEvent).toBeTruthy();
+    expect(errorEvent!.detail.trackId).toBe('track-1');
   });
 
   it('latencyOffset option overrides the auto-computed offset', async () => {

--- a/packages/dawcore/src/controllers/recording-controller.ts
+++ b/packages/dawcore/src/controllers/recording-controller.ts
@@ -43,6 +43,11 @@ export interface RecordingSession {
   readonly peaks: (Int8Array | Int16Array)[];
   readonly startSample: number;
   readonly channelCount: number;
+  /** Sample rate of the AudioContext the worklet captured at. The finalized
+   * AudioBuffer must be labeled with THIS rate — the host's sticky
+   * effectiveSampleRate can lag after a context swap, mislabeling the take
+   * (~8.9% off-speed for 44.1k vs 48k). */
+  readonly captureSampleRate: number;
   readonly bits: Bits;
   isFirstMessage: boolean;
   /** Latency samples to skip in live preview (outputLatency only). */
@@ -75,6 +80,11 @@ export type ReadonlyRecordingSession = Readonly<
 export interface RecordingHost extends ReactiveControllerHost {
   readonly audioContext: AudioContext;
   readonly samplesPerPixel: number;
+  /** Render-space samples-per-pixel. In beats mode this is derived from
+   * ticksPerPixel/bpm and differs from samplesPerPixel — live-preview peaks
+   * must be generated at THIS scale or the drawn waveform disagrees with the
+   * preview container's width/position. */
+  readonly renderSamplesPerPixel: number;
   readonly effectiveSampleRate: number;
   readonly _selectedTrackId: string | null;
   /** Live playhead position in seconds. Must read from the engine during
@@ -133,7 +143,10 @@ export class RecordingController implements ReactiveController {
 
   hostDisconnected() {
     for (const trackId of [...this._sessions.keys()]) {
-      this._cleanupSession(trackId);
+      // notifyError: captured audio is silently discarded here — without an
+      // event, record buttons living in a still-connected <daw-transport>
+      // stay wedged in their recording state forever.
+      this._cleanupSession(trackId, true);
     }
     this._workletLoadedCtx = null;
   }
@@ -259,6 +272,7 @@ export class RecordingController implements ReactiveController {
         ),
         startSample,
         channelCount,
+        captureSampleRate: rawCtx.sampleRate,
         bits,
         isFirstMessage: true,
         latencySamples,
@@ -439,7 +453,7 @@ export class RecordingController implements ReactiveController {
     const audioBuffer = createAudioBuffer(
       stopCtx,
       channelData,
-      this._host.effectiveSampleRate,
+      session.captureSampleRate,
       session.channelCount
     );
 
@@ -572,7 +586,10 @@ export class RecordingController implements ReactiveController {
       (session.peaks as (Int8Array | Int16Array)[])[ch] = appendPeaks(
         session.peaks[ch],
         channels[ch],
-        this._host.samplesPerPixel,
+        // Render-space scale — in beats mode this differs from
+        // samplesPerPixel, and the preview container is laid out in
+        // render space (see RecordingHost.renderSamplesPerPixel).
+        this._host.renderSamplesPerPixel,
         samplesProcessedBefore,
         session.bits
       );
@@ -596,9 +613,9 @@ export class RecordingController implements ReactiveController {
     session.isFirstMessage = false;
 
     // Throttle requestUpdate — only when container width needs to grow
-    const newPixelWidth = Math.floor(session.totalSamples / this._host.samplesPerPixel);
+    const newPixelWidth = Math.floor(session.totalSamples / this._host.renderSamplesPerPixel);
     const oldPixelWidth = Math.floor(
-      (session.totalSamples - channels[0].length) / this._host.samplesPerPixel
+      (session.totalSamples - channels[0].length) / this._host.renderSamplesPerPixel
     );
     if (newPixelWidth > oldPixelWidth) {
       this._host.requestUpdate();
@@ -635,7 +652,10 @@ export class RecordingController implements ReactiveController {
     }
   }
 
-  private _cleanupSession(trackId: string) {
+  /** @param notifyError dispatch daw-recording-error after cleanup — used by
+   * disposal paths that would otherwise discard the session silently. The
+   * startRecording catch path passes false (it dispatches its own error). */
+  private _cleanupSession(trackId: string, notifyError = false) {
     const session = this._sessions.get(trackId);
     if (!session) return;
     try {
@@ -656,6 +676,18 @@ export class RecordingController implements ReactiveController {
       // A leftover pause flag would misreport isPaused for the next session
       // and send its stop down the no-ack fast path.
       this._isPaused = false;
+    }
+    if (notifyError) {
+      this._host.dispatchEvent(
+        new CustomEvent<DawRecordingErrorDetail>('daw-recording-error', {
+          bubbles: true,
+          composed: true,
+          detail: {
+            trackId,
+            error: new Error('Recording cancelled: editor was disconnected mid-recording'),
+          },
+        })
+      );
     }
   }
 }

--- a/packages/dawcore/src/elements/daw-record-button.ts
+++ b/packages/dawcore/src/elements/daw-record-button.ts
@@ -36,7 +36,10 @@ export class DawRecordButtonElement extends DawTransportButton {
   connectedCallback() {
     super.connectedCallback();
     // Defer so <daw-transport for="..."> and the target editor are resolved
-    requestAnimationFrame(() => this._listenToTarget());
+    requestAnimationFrame(() => {
+      if (!this.isConnected) return;
+      this._ensureTargetListeners();
+    });
   }
 
   disconnectedCallback() {
@@ -44,8 +47,18 @@ export class DawRecordButtonElement extends DawTransportButton {
     this._cleanupListeners();
   }
 
-  private _listenToTarget() {
+  protected override updated() {
+    // Re-resolve on every render (pointerenter triggers one via the base
+    // class) — a target that upgrades/appears after the one-shot
+    // connectedCallback rAF would otherwise never get the recording-state
+    // listeners: the button starts recordings it can't reflect (#573).
+    this._ensureTargetListeners();
+  }
+
+  private _ensureTargetListeners() {
     const target = this.target;
+    if (target === this._targetRef) return;
+    this._cleanupListeners();
     if (!target) return;
     this._targetRef = target;
     target.addEventListener('daw-recording-start', this._onStart);
@@ -84,6 +97,9 @@ export class DawRecordButtonElement extends DawTransportButton {
       warnNoTargetOnce(this);
       return;
     }
+    // Guarantee state listeners exist for any recording this button starts
+    // (covers programmatic clicks that never trigger a re-render).
+    this._ensureTargetListeners();
     target.startRecording(target.recordingStream);
   }
 }

--- a/packages/dawcore/src/interactions/recording-clip.ts
+++ b/packages/dawcore/src/interactions/recording-clip.ts
@@ -62,15 +62,17 @@ export function addRecordedClip(
   host._peakPipeline
     .generatePeaks(trimmedBuf, host.samplesPerPixel, host.mono)
     .then((pd) => {
-      host._peaksData = new Map(host._peaksData).set(clip.id, pd);
       const t = host._engineTracks.get(trackId);
       if (!t) {
-        // Track was removed during peak generation — clean up orphaned buffer
+        // Track was removed during peak generation — clean up the orphaned
+        // buffer and never insert the peaks entry (this clip never reaches
+        // the engine, so nothing else would ever delete it).
         const next = new Map(host._clipBuffers);
         next.delete(clip.id);
         host._clipBuffers = next;
         return;
       }
+      host._peaksData = new Map(host._peaksData).set(clip.id, pd);
       host._engineTracks = new Map(host._engineTracks).set(trackId, {
         ...t,
         clips: [...t.clips, clip],


### PR DESCRIPTION
## Summary

Four dawcore findings from the 2026-07-04 recording review, all TDD'd (5 new tests, RED verified first).

**#573 — record button never re-targets.** State listeners were attached in a one-shot `connectedCallback` rAF; a late-upgrading target (or a swapped `<daw-transport for>`) never got them, so the button started recordings it couldn't reflect (never turned red, repeated clicks re-invoked `startRecording`). Listeners now (re)attach whenever the resolved target changes: on every render via `updated()` (the base class re-renders on `pointerenter`), and unconditionally on the click path. The rAF also gained the base class's `isConnected` guard.

**#576 — mislabeled sample rate after context swap.** The finalized AudioBuffer was labeled with the host's sticky `effectiveSampleRate`; the session now records `captureSampleRate` from the context at record start and labels the buffer with that (a 44.1k capture labeled 48k plays ~8.9% slow/flat).

**#577 — beats-mode preview coordinate mismatch.** Live-preview peaks were appended at `samplesPerPixel` while the preview container is laid out at the render scale (`_renderSpp`, tick-derived in beats mode). The controller now uses a new `RecordingHost.renderSamplesPerPixel` (the editor already exposed this getter) for peak generation and the width-growth throttle. Identical values in temporal mode — no behavior change there. Note: changing zoom mid-recording still mixes peak scales in the preview (preview-only, finalized clip regenerates correctly) — documented, not addressed here.

**#578 — silent disposal.** `hostDisconnected` mid-recording now dispatches `daw-recording-error` per discarded session so record buttons in still-connected transports unwedge (direct listeners on the detached editor still fire). The `startRecording` catch path keeps its own dispatch (no double event). Also fixed the adjacent `addRecordedClip` leak: the `_peaksData` entry is now only inserted after the track-still-exists check.

## Test plan
- [x] 5 new tests (button late-target state reflection; capture-rate labeling; render-spp peaks; disposal error event; peaks-orphan cleanup) — all RED first
- [x] Full dawcore suite 721/721 (63 files); typecheck clean; `pnpm lint` 0 errors; package builds

Fixes #573, fixes #576, fixes #577, fixes #578