### PR TITLE
docs: sync package READMEs with the recording overhaul

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -69,9 +69,12 @@ parseSpectrogramCanvasId(id);
 | `utils/meterDetection` | `MeterEntry`, `detectMeterChanges` |
 | `utils/peaksGenerator` | `generatePeaks`, `appendPeaks` |
 | `utils/audioBufferUtils` | `concatenateAudioData`, `createAudioBuffer`, `appendToAudioBuffer`, `calculateDuration` |
+| `utils/latency` | `resolveRecordingOffsetSamples` — override-vs-auto recording latency compensation (shared by React + dawcore) |
+| `utils/carveClipRange` | `carveClipRange` — punch-in replace: carve a sample range out of a clip list (trim/remove/split) |
 | `keyboard` | `KeyboardShortcut`, `handleKeyboardEvent`, `getShortcutLabel` |
 | `spectrogramCanvasId` | `buildSpectrogramCanvasId`, `parseSpectrogramCanvasId`, `SpectrogramCanvasIdParts` |
 | `probeRangeSupport` | `probeRangeSupport`, `RangeSupport` |
+| `enumerateMicrophones` | `enumerateMicrophones`, `watchMicrophoneDevices`, `MicrophoneEnumeration` — permission-free device listing with `supported`/`hasLabels` flags (labels are browser-redacted pre-permission) |
 | `constants` | `MAX_CANVAS_WIDTH` |
 
 ## Examples & Documentation

--- a/packages/dawcore/README.md
+++ b/packages/dawcore/README.md
@@ -11,7 +11,7 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 - **Keyboard shortcuts** — Play/pause, split, undo/redo via `<daw-keyboard-shortcuts>`
 - **Undo/redo** — Full transaction-based undo with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z
 - **File drop** — Drag audio files onto the editor to add tracks (enable with the `file-drop` attribute)
-- **Recording** — Live mic recording with waveform preview, pause/resume, cancelable clip creation
+- **Recording** — Live mic recording with waveform preview, pause/resume, cancelable clip creation; takes land at the playhead and replace overlapped clip content (punch-in)
 - **Pre-computed peaks** — Instant waveform rendering from `.dat` files before audio decodes
 - **MIDI tracks** — Declarative or programmatic MIDI clips render as piano-roll. Playback via the Tone.js adapter. See [MIDI Tracks](#midi-tracks).
 - **MIDI file loading** — `editor.loadMidi(urlOrFile)` parses a `.mid` file into piano-roll tracks via the optional `@dawcore/midi` peer

--- a/packages/recording/README.md
+++ b/packages/recording/README.md
@@ -9,7 +9,7 @@ Audio recording support for waveform-playlist using AudioWorklet — mic capture
 - **Sample-accurate VU metering** — a dedicated meter worklet measures peak/RMS on every sample, not just once per animation frame
 - **Multi-channel recording** — auto-detects the microphone's actual channel count from the `MediaStream`
 - **Overdub with latency compensation** — record against existing playback; the finalized clip's timeline position accounts for output latency and Tone.js scheduling lookahead, with an optional manual override
-- **Device selection & hot-plug** — enumerate microphones, switch devices mid-session, auto-fallback if the active device disconnects
+- **Device selection & hot-plug** — enumerate microphones, switch devices between takes (refused while actively recording — a mid-recording switch would silently record silence), auto-fallback if the active device disconnects
 - **Pause/resume** — pauses the worklet itself, not just the UI
 - **Hooks only** — no bundled UI components; wire the state into your own controls or `@waveform-playlist/ui-components`'s `SegmentedVUMeter`
 
@@ -132,7 +132,7 @@ function Recorder({
 }
 ```
 
-Stopping adds a new `AudioClip` to `selectedTrackId` at `max(currentTime at record-start, end of last clip on that track)` — safe for overdubbing onto a track that already has clips.
+Stopping adds a new `AudioClip` to `selectedTrackId` at the timeline position captured when recording STARTED (punch-in semantics): the take lands exactly at the playhead and REPLACES any existing clip content it overlaps — partial overlaps are trimmed, fully-covered clips removed, and a clip spanning the take is split in two.
 
 ## API Reference
 
@@ -168,7 +168,7 @@ The core AudioWorklet-based recording hook.
 - `isRecording: boolean`, `isPaused: boolean`, `duration: number` (seconds)
 - `peaks: (Int8Array | Int16Array)[]` — one entry per channel, growing live during recording
 - `audioBuffer: AudioBuffer | null` — set after `stopRecording()` resolves
-- `level: number`, `peakLevel: number` — reserved for backwards compatibility; prefer `useMicrophoneLevel` for metering
+- `level: number`, `peakLevel: number` — **deprecated** (always `0`); use `useMicrophoneLevel` for metering. Removed in the next major
 - `startRecording: () => Promise<void>`
 - `stopRecording: () => Promise<AudioBuffer | null>` — awaits the worklet's final flush before resolving, so the last samples are never dropped
 - `pauseRecording: () => void`, `resumeRecording: () => void` — pause/resume the worklet itself, not just the UI

--- a/packages/worklets/README.md
+++ b/packages/worklets/README.md
@@ -43,8 +43,15 @@ await addMeterWorkletModule((url) => ctx.audioWorklet.addModule(url));
 
 const meterNode = new AudioWorkletNode(ctx, 'meter-processor');
 meterNode.port.onmessage = (event: MessageEvent<MeterMessage>) => {
-  const { peak, rms } = event.data; // per-channel arrays
-  updateVuMeter(peak, rms);
+  // A single Float32Array of length 2*N (N = channel count):
+  // indices [0..N-1] are per-channel peak, [N..2N-1] are per-channel RMS.
+  // The worklet reuses one buffer (zero allocation on the audio thread);
+  // each message is a structured-clone copy.
+  const data = event.data;
+  const channels = data.length / 2;
+  for (let ch = 0; ch < channels; ch++) {
+    updateVuMeter(ch, data[ch], data[channels + ch]); // peak, rms
+  }
 };
 ```
 
@@ -53,7 +60,7 @@ meterNode.port.onmessage = (event: MessageEvent<MeterMessage>) => {
 - `addRecordingWorkletModule(addModule: (url: string) => Promise<void>): Promise<void>` — registers the `recording-processor` worklet module via your context's `addModule` callback
 - `addMeterWorkletModule(addModule: (url: string) => Promise<void>): Promise<void>` — registers the `meter-processor` worklet module via your context's `addModule` callback
 - `recordingProcessorUrl` / `meterProcessorUrl` — the underlying module URLs, for consumers who want to call `audioWorklet.addModule()` directly instead of using the loaders
-- `MeterMessage` — `{ peak: number[]; rms: number[] }`, the shape posted by the `meter-processor` on its port
+- `MeterMessage` — a `Float32Array` of length `2*N` (`N` = channel count) posted by the `meter-processor`: `[0..N-1]` per-channel peak, `[N..2N-1]` per-channel RMS. Derive the channel count as `data.length / 2`
 
 ## Examples & Documentation
 


### PR DESCRIPTION
## Summary

Pre-release README audit — these ship in the npm tarballs, and today's recording overhaul left drift in three of them:

- **worklets** (would have shipped with the MAJOR bump): the usage example and API row still showed the old `{ peak: number[], rms: number[] }` meter message; both now document the reused-Float32Array layout (`[0..N-1]` peak, `[N..2N-1]` RMS, channel count = `length / 2`).
- **recording**: clip placement text still described the removed clamp (`max(currentTime, lastClipEnd)`) — now documents punch-in replace; the device-selection bullet notes switching is refused while actively recording; `level`/`peakLevel` marked deprecated matching the JSDoc.
- **core**: API table gains `carveClipRange` and `enumerateMicrophones`/`watchMicrophoneDevices`, plus the previously-missing `utils/latency` row (pre-existing gap).
- **dawcore**: recording feature bullet mentions punch-in placement.

Browser/engine/playout READMEs checked — no recording-overhaul drift (none document the meter wire format or placement semantics).

Doc-only change; `pnpm lint` clean.