### PR TITLE
docs(website): sync recording docs with punch-in semantics and new core APIs

### DIFF
--- a/website/docs/llm-reference.md
+++ b/website/docs/llm-reference.md
@@ -802,6 +802,10 @@ function useIntegratedRecording(
 ): UseIntegratedRecordingReturn;
 
 interface IntegratedRecordingOptions {
+  /** Current playback/cursor position in seconds. Punch-in semantics: the
+   *  recorded clip lands exactly at this position and REPLACES any existing
+   *  clip content it overlaps (partial overlaps trimmed, covered clips
+   *  removed, spanning clips split). */
   currentTime?: number;
   audioConstraints?: MediaTrackConstraints;
   channelCount?: number;      // Default: 1 (auto-detected from stream; fallback)
@@ -820,6 +824,9 @@ interface UseIntegratedRecordingReturn {
   duration: number;
   level: number;
   peakLevel: number;
+  levels: number[];       // Per-channel peak levels (0-1); length = metered channel count
+  peakLevels: number[];   // Per-channel held peak levels (0-1)
+  rmsLevels: number[];    // Per-channel RMS levels (0-1)
   error: Error | null;
   stream: MediaStream | null;
   devices: MicrophoneDevice[];
@@ -829,8 +836,8 @@ interface UseIntegratedRecordingReturn {
   stopRecording: () => void;
   pauseRecording: () => void;
   resumeRecording: () => void;
-  requestMicAccess: () => Promise<void>;
-  changeDevice: (deviceId: string) => Promise<void>;
+  requestMicAccess: () => Promise<void>;   // Refused while recording (would record silence)
+  changeDevice: (deviceId: string) => Promise<void>; // Refused while recording
   recordingPeaks: (Int8Array | Int16Array)[];
 }
 ```
@@ -870,10 +877,35 @@ function useMicrophoneLevel(
 interface UseMicrophoneLevelReturn {
   level: number;          // 0-1 peak level (max across channels)
   peakLevel: number;      // 0-1 held peak with decay (max across channels)
-  levels: number[];       // Per-channel peak levels (0-1)
+  levels: number[];       // Per-channel peak levels (0-1); length = detected mic channels (mono mirrored up to channelCount)
   peakLevels: number[];   // Per-channel held peak levels with decay (0-1)
   rmsLevels: number[];    // Per-channel RMS levels (0-1)
   resetPeak: () => void;  // Reset held peaks
+  error: Error | null;    // Meter setup error; cleared on successful re-setup
+}
+```
+
+### enumerateMicrophones (`@waveform-playlist/core`)
+
+Framework-agnostic, permission-free microphone listing — usable without React (dawcore/vanilla consumers):
+
+```typescript
+function enumerateMicrophones(mediaDevices?: MediaDevices): Promise<MicrophoneEnumeration>;
+function watchMicrophoneDevices(
+  listener: (enumeration: MicrophoneEnumeration) => void,
+  mediaDevices?: MediaDevices
+): () => void; // returns unsubscribe; fires immediately + on every devicechange
+
+interface MicrophoneEnumeration {
+  supported: boolean;   // false on SSR/insecure contexts (no navigator.mediaDevices)
+  hasLabels: boolean;   // false pre-permission — browsers redact labels (and often deviceIds)
+  devices: MicrophoneDeviceInfo[]; // fallback labels generated when redacted
+}
+
+interface MicrophoneDeviceInfo {
+  deviceId: string;
+  label: string;
+  groupId: string;
 }
 ```
 

--- a/website/docs/react/guides/recording.md
+++ b/website/docs/react/guides/recording.md
@@ -396,7 +396,8 @@ function RecordToPlaylist() {
     }
 
     if (isRecording) {
-      // Stop recording - clip is automatically added to the selected track
+      // Stop recording — the clip lands at the record-start position and
+      // replaces any overlapped clip content on the track (punch-in)
       stopRecording();
     } else {
       startRecording();

--- a/website/src/pages/examples/recording.tsx
+++ b/website/src/pages/examples/recording.tsx
@@ -64,7 +64,8 @@ export default function RecordingExamplePage(): React.ReactElement {
             raw PCM samples and sends them to the main thread at ~60fps intervals. On the main
             thread, peaks are incrementally appended and rendered via HTML Canvas — the same rendering
             pipeline used for loaded audio files. When recording stops, the accumulated samples are
-            assembled into an <code>AudioBuffer</code> and added as a clip on the selected track.
+            assembled into an <code>AudioBuffer</code> and added as a clip at the record-start position on
+            the selected track, replacing any clip content it overlaps (punch-in).
           </p>
         </div>
       </main>

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -21,7 +21,7 @@ waveform-playlist builds browser-based audio editing applications. Use the React
 
 - `@waveform-playlist/browser` — Main package: React components, hooks, effects. Playout engines (`@waveform-playlist/playout` + `tone`, or `@waveform-playlist/media-element-playout`) are optional peer dependencies; provide `createAdapter`/`createPlayout` to inject a custom engine.
 - WAM 2.0 plugin hosting (from `@waveform-playlist/browser/tone`) — `addWamEffect`/`addWamEffectToTrack` host third-party [Web Audio Modules](https://www.webaudiomodules.com/) plugins alongside built-in Tone.js effects, requires native AudioContext mode (`configureGlobalContext({ nativeAudioContext: true })` from `@waveform-playlist/playout`; Firefox falls back automatically). `WamEffectGui` mounts plugin GUIs; `fetchWamLibrary`/`fetchWamDescriptor` from the optional `@dawcore/wam` peer discover community plugins. Same native-context call enables WAM hosting on `<daw-editor>`'s Tone.js backend (`createToneAdapter()`).
-- `@waveform-playlist/core` — Data model: ClipTrack, AudioClip, sample-based math
+- `@waveform-playlist/core` — Data model: ClipTrack, AudioClip, sample-based math, `carveClipRange` (punch-in), `enumerateMicrophones`/`watchMicrophoneDevices` (permission-free device listing)
 - `@waveform-playlist/engine` — Framework-agnostic timeline engine: PlaylistEngine class, pure clip/timeline operations, event emitter. Owns selection, loop, zoom, volume, selectedTrackId, and clip mutation state. Seek/play beyond audio duration is supported (silence where there's no audio).
 - `@waveform-playlist/playout` — Audio playback: Tone.js adapter (implements PlayoutAdapter from engine), global AudioContext. Incremental track updates via updateTrack/replaceClips — no full playout rebuild on clip operations. Optional adapter methods: addTrack, removeTrack, updateTrack.
 - `@waveform-playlist/ui-components` — Styled primitives, theming, virtual scrolling contexts, playhead components, PlaylistErrorBoundary, BeatsAndBarsProvider
@@ -155,8 +155,9 @@ Both providers use React Context with 4 split contexts for performance.
 
 ### Recording Hooks (from `@waveform-playlist/recording`)
 
-- `useIntegratedRecording(tracks, setTracks, selectedTrackId, options)` — Combined recording + track management: mic access, VU meter, start/stop/pause recording, auto-adds clips to selected track; recording latency compensation is configurable via `latencyOffset` (seconds) on both the React `IntegratedRecordingOptions` and the dawcore `RecordingOptions` passed to `editor.startRecording()`
+- `useIntegratedRecording(tracks, setTracks, selectedTrackId, options)` — Combined recording + track management: mic access, VU meter, start/stop/pause recording, adds the take at the record-start playhead position with punch-in replace semantics (overlapped clip content is trimmed/removed/split); recording latency compensation is configurable via `latencyOffset` (seconds) on both the React `IntegratedRecordingOptions` and the dawcore `RecordingOptions` passed to `editor.startRecording()`
 - `useRecording(stream, options)` — Low-level recording via AudioWorklet with live peaks
+- `enumerateMicrophones()` / `watchMicrophoneDevices(listener)` — framework-agnostic, permission-free mic listing from `@waveform-playlist/core` (`hasLabels` false pre-permission: browsers redact labels)
 - `useMicrophoneAccess()` — Request mic permission, enumerate devices, get MediaStream
 - `useMicrophoneLevel(stream, options?)` — Real-time VU meter levels from mic stream (supports multi-channel via `channelCount` option)
 - `useOutputMeter(options?)` — Real-time master output VU meter levels (from `@waveform-playlist/browser/tone`). Returns per-channel `levels`, `peakLevels`, and `resetPeak()`


### PR DESCRIPTION
## Summary

Website-docs half of the post-overhaul documentation sweep (package READMEs landed in #587).

- **llm-reference.md**: punch-in doc comment on `IntegratedRecordingOptions.currentTime`; restored fields that had drifted from source (`levels`/`peakLevels`/`rmsLevels` on `UseIntegratedRecordingReturn`, `error` on `UseMicrophoneLevelReturn` — pre-existing gaps); refused-while-recording notes on `requestMicAccess`/`changeDevice`; new **enumerateMicrophones / watchMicrophoneDevices** section with the `supported`/`hasLabels` contract.
- **llms.txt**: `useIntegratedRecording` description now states punch-in replace placement; core package line and the recording-hooks section mention `carveClipRange` and the permission-free device listing.
- **recording guide + example page**: "clip is added to the selected track" prose updated to the punch-in placement semantics.

No drift found for the meter wire format (the website never documented it) or elsewhere in the guides.

## Verification
- [x] `pnpm --filter website build` — clean (broken-link/anchor checks pass)
- [x] `cd website && npx eslint src/pages/examples/recording.tsx` — clean
- [x] Root `pnpm lint` — 0 errors