### PR TITLE
docs: record demo clip headers + stale punch-in features bullet

### DIFF
--- a/examples/dawcore-native/record.html
+++ b/examples/dawcore-native/record.html
@@ -78,6 +78,7 @@
     samples-per-pixel="1024"
     wave-height="100"
     timescale
+    clip-headers
     file-drop
     indefinite-playback
   >

--- a/website/src/pages/examples/recording.tsx
+++ b/website/src/pages/examples/recording.tsx
@@ -52,7 +52,7 @@ export default function RecordingExamplePage(): React.ReactElement {
             <li><strong>Drag-and-drop import</strong> — drop audio files (WAV, MP3, FLAC, etc.) onto the timeline to add backing tracks</li>
             <li><strong>VU meter</strong> — real-time input level monitoring with peak hold indicator</li>
             <li><strong>Device selection</strong> — choose between available microphones without restarting</li>
-            <li><strong>Smart recording position</strong> — recording starts from the cursor or the end of the last clip, whichever is later</li>
+            <li><strong>Punch-in recording</strong> — takes land exactly at the cursor and replace any clip content they overlap</li>
             <li><strong>Auto-scroll</strong> — the timeline scrolls to keep the recording head in view</li>
             <li><strong>WAV export</strong> — export your multitrack mix as a WAV file, entirely client-side</li>
           </ul>


### PR DESCRIPTION
Two small leftovers from the 2026-07-04 live browser verification session:

- **dawcore record demo** (`examples/dawcore-native/record.html`): enable the `clip-headers` attribute so recorded takes and punch-in carve boundaries are visually distinguishable (requested during testing — an unlabeled carved clip is invisible next to its neighbor).
- **Recording example page**: the Features list still said *"recording starts from the cursor or the end of the last clip, whichever is later"* — the clamp removed by #585. Now describes punch-in. (The How-It-Works paragraph was already fixed in #588; this bullet was missed.)

Text/attribute-only. `pnpm lint` 0 errors; the example page passes the website eslint.