### PR TITLE
docs: README release sync — end-of-timeline semantics + recording session features

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ const { masterEffects, toggleBypass, updateParameter } = useDynamicEffects();
 const { exportWav, isExporting, progress } = useExportWav();
 
 // Recording
-const { startRecording, stopRecording, isRecording } = useIntegratedRecording();
+const { startRecording, stopRecording, isRecording } = useIntegratedRecording(
+  tracks, setTracks, selectedTrackId
+);
 ```
 
 ## Web Components (Experimental)
@@ -199,11 +201,11 @@ npm install @waveform-playlist/playout tone  # Tone.js (effects, MIDI synths)
 - Keyboard shortcuts (Space=play/pause, S=split, Cmd/Ctrl+Z=undo)
 - File drop for adding tracks
 - Frozen-panes layout — height-constrained editors scroll vertically with a pinned ruler and row-locked track controls; controls adapt to short rows
-- Recording with overdub and latency compensation
+- Recording with overdub, punch-in replace (takes land at the playhead and replace overlapped content), automatic armed-track mute (the recorded-over material is silenced during the take), named takes with live clip headers, and latency compensation
 - Metronome with mixed meters and tempo changes
 - Tempo automation — linear ramps and Möbius-Ease curves with exact integration
 - Pre-computed peaks for fast initial render
-- `indefinite-playback` attribute fills the viewport when no audio is loaded — ruler renders before any track
+- Player-style end-of-timeline auto-stop by default; `indefinite-playback` rolls DAW-style until an explicit stop, `fill-viewport` fills the empty viewport so the ruler renders before any track (recording sessions suppress the auto-stop automatically)
 
 **Packages:**
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -9,7 +9,7 @@ React components, hooks, and context providers for building a multitrack Web Aud
 - **Split context providers** — `WaveformPlaylistProvider` (multitrack, Tone.js-backed) and `MediaElementPlaylistProvider` (single-track, `<audio>`-backed with pitch-preserving playback rate)
 - **Four focused context hooks** — `usePlaybackAnimation`, `usePlaylistState`, `usePlaylistControls`, `usePlaylistData` isolate 60fps playhead updates from low-frequency state so unrelated components don't re-render on every animation frame
 - **Audio effects** — 20 Tone.js effects (reverb, delay, modulation, filter, distortion, dynamics, spatial) with runtime parameter control, master and per-track chains, plus WAM 2.0 plugin hosting
-- **Recording** — pairs with `@waveform-playlist/recording` for mic input, overdubbing, and live waveform preview
+- **Recording** — pairs with `@waveform-playlist/recording` for mic input, overdubbing, and live waveform preview; punch-in takes replace overlapped content, and `setRecordingActive(active, armedTrackId)` suppresses the end-of-timeline auto-stop and transiently mutes the recorded-over track for the session
 - **Annotations & spectrogram** — optional integration contexts for `@waveform-playlist/annotations` and `@waveform-playlist/spectrogram`
 - **WAV export** — render the full mix (including effects) offline to a downloadable WAV file
 - **MediaElement player mode** — a lightweight single-track player with pitch-preserving speed control, for podcast/audiobook-style use cases that don't need multitrack mixing
@@ -88,7 +88,7 @@ Prefer a lightweight single-track player instead? Use `MediaElementPlaylistProvi
 |------|---------|
 | `usePlaybackAnimation` | `isPlaying`, `currentTime`, animation refs, `getPlaybackTime()`, `registerFrameCallback()` for 60fps-driven UI (playhead, progress bars) |
 | `usePlaylistState` | Low-frequency state — selection, loop region, annotations, `selectedTrackId`, `canUndo`/`canRedo` |
-| `usePlaylistControls` | Actions — `play`, `pause`, `stop`, `seekTo`, track mute/solo/volume/pan, zoom, undo/redo |
+| `usePlaylistControls` | Actions — `play`, `pause`, `stop`, `seekTo`, track mute/solo/volume/pan, zoom, undo/redo, `setRecordingActive` (recording-session suppression + armed-track mute) |
 | `usePlaylistData` | Derived/config data — `tracks`, `duration`, `sampleRate`, `peaksDataArray`, `trackStates`, `isReady` |
 
 `usePlaylistDataOptional` is the same as `usePlaylistData` but returns `null` outside a provider (for components that render both inside and outside one). `MediaElementPlaylistProvider` has the equivalent `useMediaElementAnimation`, `useMediaElementState`, `useMediaElementControls`, `useMediaElementData`.

--- a/packages/dawcore/README.md
+++ b/packages/dawcore/README.md
@@ -11,7 +11,7 @@ Framework-agnostic Web Components for multi-track audio editing. Drop `<daw-edit
 - **Keyboard shortcuts** — Play/pause, split, undo/redo via `<daw-keyboard-shortcuts>`
 - **Undo/redo** — Full transaction-based undo with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z
 - **File drop** — Drag audio files onto the editor to add tracks (enable with the `file-drop` attribute)
-- **Recording** — Live mic recording with waveform preview, pause/resume, cancelable clip creation; takes land at the playhead and replace overlapped clip content (punch-in)
+- **Recording** — Live mic recording with waveform preview (full clip chrome incl. header while capturing), pause/resume, cancelable clip creation; takes land at the playhead and replace overlapped clip content (punch-in), the recorded-over track is transiently muted during the take, and the end-of-timeline auto-stop is suppressed so takes run past existing audio
 - **Pre-computed peaks** — Instant waveform rendering from `.dat` files before audio decodes
 - **MIDI tracks** — Declarative or programmatic MIDI clips render as piano-roll. Playback via the Tone.js adapter. See [MIDI Tracks](#midi-tracks).
 - **MIDI file loading** — `editor.loadMidi(urlOrFile)` parses a `.mid` file into piano-roll tracks via the optional `@dawcore/midi` peer
@@ -353,6 +353,8 @@ const result = await editor.loadFiles(fileList);
 </script>
 ```
 
+During a take the editor shows the live preview with full clip chrome (header label from `RecordingOptions.clipName`, default "Recording…"), transiently mutes the recorded track (punch-in replaces whatever the take overlaps, so the doomed material never plays under the overdub — the track's Mute control is untouched and the previous state is restored when the session ends), and suppresses the end-of-timeline auto-stop so the take can run past existing audio.
+
 ## Single-Track Player
 
 `<daw-player>` is a standalone element for single-track playback (podcasts, audiobooks, previewing one file) — it wraps `@waveform-playlist/media-element-playout` and needs no `adapter`, `AudioContext`, or `PlaylistEngine`. `@waveform-playlist/media-element-playout` ships as a direct dependency of `@dawcore/components`, so there's nothing extra to install:
@@ -442,7 +444,8 @@ Core orchestrator. Attributes:
 | `mono` | boolean | `false` | Merge stereo to mono display |
 | `bar-width` / `bar-gap` | number | `1` / `0` | Waveform bar rendering style |
 | `rounded-bars` | boolean | `false` | Pill-shaped bar caps (radius `bar-width / 2`) |
-| `indefinite-playback` | boolean | `false` | Keep ruler/timeline filling the viewport with no clips |
+| `indefinite-playback` | boolean | `false` | Disable the end-of-timeline auto-stop — roll until explicit stop (DAW style). Implies `fill-viewport` |
+| `fill-viewport` | boolean | `false` | Keep ruler/timeline filling the viewport even when audio is shorter (layout only) |
 | `scale-mode` | string | `'temporal'` | `'temporal'` (seconds) or `'beats'` (tick-linear grid) |
 | `ticks-per-pixel` | number | `24` | Zoom level in beats mode |
 | `snap-to` | string | `'off'` | Grid snapping in beats mode (`'bar'`, `'beat'`, `'1/2'`…`'1/16'`, `'off'`) |
@@ -458,7 +461,7 @@ Methods:
 - Display: `setTimeFormat(format)` — sugar over the `timeFormat` property, fires `daw-time-format-change`
 - Tracks & clips: `addTrack(config)`, `removeTrack(id)`, `updateTrack(id, partial)`, `addClip(trackId, config)`, `removeClip(trackId, clipId)`, `updateClip(trackId, clipId, partial)`
 - Editing: `splitAtPlayhead()`, `undo()`, `redo()`, `setSelection(start, end)`
-- Recording: `startRecording(stream?, options?)`, `stopRecording()`, `pauseRecording()`, `resumeRecording()`, `togglePauseRecording()`
+- Recording: `startRecording(stream?, options?)`, `stopRecording()`, `pauseRecording()`, `resumeRecording()`, `togglePauseRecording()`. Options include `overdub` (start playback with the take), `latencyOffset` (seconds), and `clipName` (live-preview header + finalized clip name, default `"Recording"`)
 - Effects & export: the master-chain effects API (see [Effects](#effects)), `getEffectsState()` / `setEffectsState(entries)`, `openEffectGui()` / `closeEffectGui()`, `exportAudio(options?)`
 
 ### `<daw-track>`

--- a/packages/recording/README.md
+++ b/packages/recording/README.md
@@ -169,7 +169,7 @@ The core AudioWorklet-based recording hook.
 - `peaks: (Int8Array | Int16Array)[]` — one entry per channel, growing live during recording
 - `audioBuffer: AudioBuffer | null` — set after `stopRecording()` resolves
 - `level: number`, `peakLevel: number` — **deprecated** (always `0`); use `useMicrophoneLevel` for metering. Removed in the next major
-- `startRecording: () => Promise<void>`
+- `startRecording: () => Promise<boolean>` — resolves `true` when the capture pipeline actually started (`false`: no stream, already recording, worklet failure); check it before starting synchronized playback
 - `stopRecording: () => Promise<AudioBuffer | null>` — awaits the worklet's final flush before resolving, so the last samples are never dropped
 - `pauseRecording: () => void`, `resumeRecording: () => void` — pause/resume the worklet itself, not just the UI
 - `error: Error | null`
@@ -203,7 +203,9 @@ Batteries-included hook: wires `useMicrophoneAccess` + `useMicrophoneLevel` + `u
   - `samplesPerPixel?: number` (default: `1024`)
   - `latencyOffset?: number` — seconds; overrides the auto-computed `outputLatency + lookAhead` compensation applied to the clip's start. `0` disables compensation; omit to auto-compute
 
-**Returns (`UseIntegratedRecordingReturn`):** recording state (`isRecording`, `isPaused`, `duration`, `level`, `peakLevel`, `levels`, `peakLevels`, `rmsLevels`), microphone state (`stream`, `devices`, `hasPermission`, `selectedDevice`), controls (`startRecording`, `stopRecording`, `pauseRecording`, `resumeRecording`, `requestMicAccess`, `changeDevice`), `recordingPeaks` (live per-channel peaks for preview), and a combined `error`.
+**Returns (`UseIntegratedRecordingReturn`):** recording state (`isRecording`, `isPaused`, `duration`, `level`, `peakLevel`, `levels`, `peakLevels`, `rmsLevels`), microphone state (`stream`, `devices`, `hasPermission`, `selectedDevice`), controls (`startRecording` — resolves `true` when capture actually started, `stopRecording`, `pauseRecording`, `resumeRecording`, `requestMicAccess`, `changeDevice`), `recordingPeaks` (live per-channel peaks for preview), and a combined `error`.
+
+**Overdub with `@waveform-playlist/browser`:** call `usePlaylistControls().setRecordingActive(true, trackId)` *before* `play()` — while the session is active the end-of-timeline auto-stop is suppressed (the take can run past existing audio) and the recorded-over track's existing content is transiently muted (punch-in replaces it). Both reset automatically when the recording ends; check `startRecording()`'s boolean and release the session on `false`.
 
 ### Types
 


### PR DESCRIPTION
## Summary

Release-readiness sweep of the READMEs for the changes #592 introduced (all other packages were already synced by #587 and are untouched by the release):

- **root `README.md`** — the dawcore feature bullet described `indefinite-playback` as layout-only (its pre-#592 behavior); now documents the matched semantics (player-style auto-stop by default, `indefinite-playback` = DAW roll, `fill-viewport` = layout). Recording bullet gains punch-in replace / armed-track mute / named takes. Also fixes the `useIntegratedRecording()` snippet that called the hook with no arguments (it requires `tracks, setTracks, selectedTrackId`).
- **`packages/dawcore/README.md`** — attribute table: `indefinite-playback` gets its real (new) meaning and `fill-viewport` is added; `startRecording` options documented (`overdub`, `latencyOffset`, `clipName`); a recording-behavior paragraph covers the live-preview clip chrome, the armed-track transient mute, and the auto-stop suppression.
- **`packages/recording/README.md`** — `startRecording` return type `Promise<void>` → `Promise<boolean>` in both hook sections, plus the overdub pairing note (`setRecordingActive(true, trackId)` before `play()`).
- **`packages/browser/README.md`** — `setRecordingActive` added to the features bullet and the `usePlaylistControls` hook table row.

Verified no stale claims remain: repo-wide grep of all READMEs for `auto-stop` / `indefinite` / `startRecording.*Promise<void>` hits only the updated text.

## Test plan

- [x] Docs-only; grep sweep for stale claims across all `packages/*/README.md` + root