### PR TITLE
fix: playout correctness audit fixes (part 1)

### DIFF
--- a/.changeset/playout-audit-fixes-p1.md
+++ b/.changeset/playout-audit-fixes-p1.md
@@ -1,0 +1,5 @@
+---
+'@waveform-playlist/playout': patch
+---
+
+Correctness audit fixes (part 1): mixed audio+MIDI tracks' runtime controls (mute/volume/pan/solo) now reach the `:midi` companion playout track — previously muting a mixed track left its MIDI playing and soloing it silenced its own MIDI half; deleting a mixed track's last MIDI clip now removes the stale companion instead of leaving ghost MIDI playback; `TonePlayout.setMute` routes through solo-aware muting so unmuting a non-soloed track during an active solo no longer makes it audible; `closeGlobalAudioContext` resets the singleton even when the raw context was closed externally (previously stranded every future caller on a dead context); `SoundFontCache.load`/`loadFromBuffer` invalidate the per-sample AudioBuffer cache on hot-swap (stale entries paired the old font's buffers with the new font's pitch/envelope — mispitched audio); SoundFontToneTrack's Part callback contains `triggerNote` failures so one throwing note can't abort same-tick events across all tracks.

--- a/packages/playout/src/SoundFontCache.ts
+++ b/packages/playout/src/SoundFontCache.ts
@@ -243,6 +243,11 @@ export class SoundFontCache {
         `Failed to parse SoundFont ${url}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
+    // Cache keys are numeric sample indices — stale entries from a previous
+    // font would pair the OLD font's buffer with the NEW font's pitch/loop/
+    // envelope (mispitched audio). Clear only on successful parse: a failed
+    // reload keeps the old font, whose cache entries are still valid.
+    this.audioBufferCache.clear();
   }
 
   /**
@@ -256,6 +261,8 @@ export class SoundFontCache {
         `Failed to parse SoundFont from buffer: ${err instanceof Error ? err.message : String(err)}`
       );
     }
+    // Invalidate buffers from the previous font (see load() for rationale).
+    this.audioBufferCache.clear();
   }
 
   get isLoaded(): boolean {

--- a/packages/playout/src/SoundFontToneTrack.ts
+++ b/packages/playout/src/SoundFontToneTrack.ts
@@ -103,7 +103,18 @@ export class SoundFontToneTrack implements PlayableTrack {
 
       const part = new Part((time, event) => {
         if (event.duration > 0) {
-          this.triggerNote(event.midi, event.duration, time, event.velocity, event.channel);
+          // Contain failures: nothing in Tone.js catches a throw from a Part
+          // callback (ToneEvent._tick → Transport._processTick → Clock._loop
+          // are all unguarded) — an escape aborts every other same-tick event
+          // across ALL tracks. Same guard as startMidClipSources below.
+          try {
+            this.triggerNote(event.midi, event.duration, time, event.velocity, event.channel);
+          } catch (err) {
+            console.warn(
+              `[waveform-playlist] Failed to trigger SoundFont note on track "${this.id}": ` +
+                String(err)
+            );
+          }
         }
       }, partEvents);
 

--- a/packages/playout/src/TonePlayout.ts
+++ b/packages/playout/src/TonePlayout.ts
@@ -434,7 +434,10 @@ export class TonePlayout {
     const track = this.tracks.get(trackId);
     if (track) {
       this.manualMuteState.set(trackId, muted);
-      track.setMute(muted);
+      // Route through solo-aware muting: while any track is soloed, a
+      // non-soloed track must stay silent regardless of its manual mute —
+      // the manual state is remembered and applies when solo clears.
+      this.updateSoloMuting();
     }
   }
 

--- a/packages/playout/src/TonePlayoutAdapter.ts
+++ b/packages/playout/src/TonePlayoutAdapter.ts
@@ -344,13 +344,18 @@ export function createToneAdapter(options?: ToneAdapterOptions): ToneAdapter {
         // above, and TonePlayout.addTrack has no idempotency guard (a second
         // add leaks the old ToneTrack and duplicates its Transport events).
         const midiClips = track.clips.filter((c) => c.midiNotes && c.midiNotes.length > 0);
+        const midiTrackId = trackId + ':midi';
         if (midiClips.length > 0) {
-          const midiTrackId = trackId + ':midi';
           playout.removeTrack(midiTrackId);
           addMidiTrackToPlayout(playout, track);
           if (_isPlaying) {
             playout.resumeTrackMidPlayback(midiTrackId);
           }
+        } else {
+          // Last MIDI clip deleted — without this, the stale companion keeps
+          // its scheduled Part and the deleted MIDI plays as a ghost.
+          playout.removeTrack(midiTrackId);
+          _midiTrackBuild.delete(midiTrackId);
         }
 
         if (audioUpdated) {
@@ -441,28 +446,37 @@ export function createToneAdapter(options?: ToneAdapterOptions): ToneAdapter {
       playout?.setMasterGain(volume);
     },
 
+    // Runtime controls must reach BOTH playout halves of a mixed audio+MIDI
+    // track (trackId + trackId:midi) — otherwise muting a mixed track leaves
+    // its MIDI playing and soloing it silences its own MIDI half. The :midi
+    // calls no-op for audio-only and MIDI-only tracks (unknown playout id),
+    // same blind-forwarding pattern as removeTrack.
     setTrackVolume(trackId: string, volume: number): void {
       const existing = _currentTracks.get(trackId);
       if (existing) _currentTracks.set(trackId, { ...existing, volume });
       playout?.getTrack(trackId)?.setVolume(volume);
+      playout?.getTrack(trackId + ':midi')?.setVolume(volume);
     },
 
     setTrackMute(trackId: string, muted: boolean): void {
       const existing = _currentTracks.get(trackId);
       if (existing) _currentTracks.set(trackId, { ...existing, muted });
       playout?.setMute(trackId, muted);
+      playout?.setMute(trackId + ':midi', muted);
     },
 
     setTrackSolo(trackId: string, soloed: boolean): void {
       const existing = _currentTracks.get(trackId);
       if (existing) _currentTracks.set(trackId, { ...existing, soloed });
       playout?.setSolo(trackId, soloed);
+      playout?.setSolo(trackId + ':midi', soloed);
     },
 
     setTrackPan(trackId: string, pan: number): void {
       const existing = _currentTracks.get(trackId);
       if (existing) _currentTracks.set(trackId, { ...existing, pan });
       playout?.getTrack(trackId)?.setPan(pan);
+      playout?.getTrack(trackId + ':midi')?.setPan(pan);
     },
 
     setLoop(enabled: boolean, start: number, end: number): void {

--- a/packages/playout/src/__tests__/SoundFontCache.reload.test.ts
+++ b/packages/playout/src/__tests__/SoundFontCache.reload.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Parsing arbitrary bytes with the real soundfont2 parser throws, so mock it.
+// Kept out of SoundFontCache.test.ts, which imports the REAL GeneratorType
+// (same convention as SoundFontCache.fromUrl.test.ts).
+vi.mock('soundfont2', () => ({
+  SoundFont2: vi.fn().mockImplementation(() => ({})),
+}));
+
+import { SoundFontCache } from '../SoundFontCache';
+
+/** White-box handle on the private per-sample-index AudioBuffer cache. */
+function bufferCacheOf(cache: SoundFontCache): Map<number, AudioBuffer> {
+  return (cache as unknown as { audioBufferCache: Map<number, AudioBuffer> }).audioBufferCache;
+}
+
+describe('SoundFontCache reload invalidation', () => {
+  beforeEach(() => {
+    // Node has no OfflineAudioContext; the no-context constructor path needs it.
+    vi.stubGlobal(
+      'OfflineAudioContext',
+      vi.fn().mockImplementation(() => ({}))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // AudioBuffers are cached by numeric sample index. After a hot-swap the same
+  // index refers to a DIFFERENT sample in the new font — stale entries pair an
+  // old font's buffer with the new font's pitch/loop/envelope (mispitched audio).
+
+  it('loadFromBuffer clears AudioBuffers cached from the previous font', () => {
+    const cache = new SoundFontCache();
+    cache.loadFromBuffer(new ArrayBuffer(8));
+    bufferCacheOf(cache).set(0, {} as AudioBuffer); // sample cached under font 1
+
+    cache.loadFromBuffer(new ArrayBuffer(8)); // hot-swap to font 2
+
+    expect(bufferCacheOf(cache).size).toBe(0);
+  });
+
+  it('load clears AudioBuffers cached from the previous font', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      } as unknown as Response)
+    );
+    const cache = new SoundFontCache();
+    await cache.load('/font1.sf2');
+    bufferCacheOf(cache).set(0, {} as AudioBuffer);
+
+    await cache.load('/font2.sf2');
+
+    expect(bufferCacheOf(cache).size).toBe(0);
+  });
+
+  it('a failed reload keeps the previous font AND its cache intact', async () => {
+    const cache = new SoundFontCache();
+    cache.loadFromBuffer(new ArrayBuffer(8));
+    const buf = {} as AudioBuffer;
+    bufferCacheOf(cache).set(0, buf);
+
+    // Parser rejects the new bytes — the old font stays loaded, so its
+    // cache entries are still valid and must survive.
+    const { SoundFont2 } = await import('soundfont2');
+    (SoundFont2 as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('bad RIFF header');
+    });
+
+    expect(() => cache.loadFromBuffer(new ArrayBuffer(8))).toThrow('Failed to parse SoundFont');
+    expect(cache.isLoaded).toBe(true);
+    expect(bufferCacheOf(cache).get(0)).toBe(buf);
+  });
+});

--- a/packages/playout/src/__tests__/SoundFontToneTrack.test.ts
+++ b/packages/playout/src/__tests__/SoundFontToneTrack.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Track } from '@waveform-playlist/core';
+
+// Capture Part instances so tests can invoke the scheduled callback directly.
+const { mockPartInstances } = vi.hoisted(() => ({
+  mockPartInstances: [] as Array<{
+    callback: (time: number, event: unknown) => void;
+    events: unknown[];
+    start: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('tone', () => ({
+  Volume: vi.fn().mockImplementation(() => ({
+    chain: vi.fn(),
+    dispose: vi.fn(),
+    volume: { value: 0 },
+    input: { input: {} },
+  })),
+  Panner: vi.fn().mockImplementation(() => ({ dispose: vi.fn(), pan: { value: 0 } })),
+  Gain: vi.fn().mockImplementation(() => ({
+    connect: vi.fn(),
+    dispose: vi.fn(),
+    gain: { value: 1 },
+  })),
+  Part: vi
+    .fn()
+    .mockImplementation((callback: (time: number, event: unknown) => void, events: unknown[]) => {
+      const instance = { callback, events, start: vi.fn(), dispose: vi.fn() };
+      mockPartInstances.push(instance);
+      return instance;
+    }),
+  getDestination: vi.fn(() => ({})),
+  getContext: vi.fn(() => ({ rawContext: {} })),
+  ToneAudioNode: vi.fn(),
+}));
+
+import { SoundFontToneTrack } from '../SoundFontToneTrack';
+import type { SoundFontCache } from '../SoundFontCache';
+
+function makeTrack(id = 'sf1'): Track {
+  return {
+    id,
+    name: 'SoundFont Test',
+    gain: 1,
+    muted: false,
+    soloed: false,
+    stereoPan: 0,
+    startTime: 0,
+    endTime: 1,
+  };
+}
+
+describe('SoundFontToneTrack Part callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPartInstances.length = 0;
+  });
+
+  it('a throwing triggerNote does not escape into the Transport tick chain', () => {
+    // Nothing in Tone.js catches a throw from a Part callback
+    // (ToneEvent._tick → Transport._processTick → Clock._loop are all
+    // unguarded) — an escape aborts every other same-tick event across
+    // ALL tracks. The callback must contain its own failures.
+    const throwingCache = {
+      isLoaded: true,
+      getAudioBuffer: vi.fn(() => {
+        throw new Error('decode failed');
+      }),
+    } as unknown as SoundFontCache;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    new SoundFontToneTrack({
+      clips: [
+        {
+          notes: [{ midi: 60, name: 'C4', time: 0, duration: 0.5, velocity: 0.8 }],
+          startTime: 0,
+          duration: 1,
+          offset: 0,
+        },
+      ],
+      track: makeTrack(),
+      soundFontCache: throwingCache,
+    });
+
+    expect(mockPartInstances).toHaveLength(1);
+    const part = mockPartInstances[0];
+    expect(part.events).toHaveLength(1);
+
+    expect(() => part.callback(0.1, part.events[0])).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SoundFont note'));
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/playout/src/__tests__/TonePlayout.test.ts
+++ b/packages/playout/src/__tests__/TonePlayout.test.ts
@@ -378,4 +378,47 @@ describe('TonePlayout', () => {
       expect(playout.masterBusInputNode).toBe(mockVolume.input.input);
     });
   });
+
+  describe('setMute during active solo', () => {
+    it('keeps a non-soloed track silent when its manual mute is toggled off during solo', () => {
+      const playout = new TonePlayout();
+      playout.addTrack({ clips: [], track: makeTrack('a') });
+      const trackB = playout.addTrack({ clips: [], track: makeTrack('b') });
+
+      playout.setSolo('a', true); // B muted by updateSoloMuting
+      (trackB.setMute as ReturnType<typeof vi.fn>).mockClear();
+
+      // User toggles B's mute button off while A is still soloed.
+      // Solo takes precedence: B must remain effectively muted.
+      playout.setMute('b', false);
+
+      expect(trackB.setMute).toHaveBeenCalledWith(true);
+      expect(trackB.setMute).not.toHaveBeenCalledWith(false);
+    });
+
+    it('remembers the manual mute for when solo clears', () => {
+      const playout = new TonePlayout();
+      playout.addTrack({ clips: [], track: makeTrack('a') });
+      const trackB = playout.addTrack({ clips: [], track: makeTrack('b') });
+
+      playout.setSolo('a', true);
+      playout.setMute('b', false); // stored, not audible yet
+      (trackB.setMute as ReturnType<typeof vi.fn>).mockClear();
+
+      playout.setSolo('a', false); // solo cleared — manual state applies
+
+      expect(trackB.setMute).toHaveBeenCalledWith(false);
+    });
+
+    it('applies manual mute directly when no track is soloed', () => {
+      const playout = new TonePlayout();
+      const trackA = playout.addTrack({ clips: [], track: makeTrack('a') });
+
+      playout.setMute('a', true);
+      expect(trackA.setMute).toHaveBeenCalledWith(true);
+
+      playout.setMute('a', false);
+      expect(trackA.setMute).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/packages/playout/src/__tests__/TonePlayoutAdapter.test.ts
+++ b/packages/playout/src/__tests__/TonePlayoutAdapter.test.ts
@@ -432,6 +432,59 @@ describe('createToneAdapter', () => {
       const mockTrack = mockInstance.getTrack.mock.results[0].value;
       expect(mockTrack.setPan).toHaveBeenCalledWith(-0.5);
     });
+
+    // A mixed audio+MIDI track becomes TWO playout tracks (t1 + t1:midi).
+    // Every runtime control must reach both halves — otherwise muting a mixed
+    // track leaves its MIDI playing, and soloing it silences its own MIDI half
+    // (the companion isn't in soloedTracks, so updateSoloMuting mutes it).
+    describe('mixed-track :midi companion', () => {
+      function mixedTrack(): ClipTrack {
+        return makeTrack('t1', [
+          makeClip({ id: 'a1', startSample: 0, durationSamples: 44100 }),
+          makeMidiClip({ id: 'm1', startSample: 0, durationSamples: 44100 }),
+        ]);
+      }
+
+      it('setTrackMute also mutes the :midi companion', () => {
+        const adapter = createToneAdapter();
+        adapter.setTracks([mixedTrack()]);
+        adapter.setTrackMute('t1', true);
+
+        const instance = (TonePlayout as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+        expect(instance.setMute).toHaveBeenCalledWith('t1', true);
+        expect(instance.setMute).toHaveBeenCalledWith('t1:midi', true);
+      });
+
+      it('setTrackSolo also soloes the :midi companion', () => {
+        const adapter = createToneAdapter();
+        adapter.setTracks([mixedTrack()]);
+        adapter.setTrackSolo('t1', true);
+
+        const instance = (TonePlayout as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+        expect(instance.setSolo).toHaveBeenCalledWith('t1', true);
+        expect(instance.setSolo).toHaveBeenCalledWith('t1:midi', true);
+      });
+
+      it('setTrackVolume also reaches the :midi companion', () => {
+        const adapter = createToneAdapter();
+        adapter.setTracks([mixedTrack()]);
+        adapter.setTrackVolume('t1', 0.5);
+
+        const instance = (TonePlayout as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+        expect(instance.getTrack).toHaveBeenCalledWith('t1');
+        expect(instance.getTrack).toHaveBeenCalledWith('t1:midi');
+      });
+
+      it('setTrackPan also reaches the :midi companion', () => {
+        const adapter = createToneAdapter();
+        adapter.setTracks([mixedTrack()]);
+        adapter.setTrackPan('t1', 0.25);
+
+        const instance = (TonePlayout as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+        expect(instance.getTrack).toHaveBeenCalledWith('t1');
+        expect(instance.getTrack).toHaveBeenCalledWith('t1:midi');
+      });
+    });
   });
 
   describe('setLoop', () => {
@@ -619,6 +672,31 @@ describe('createToneAdapter', () => {
       // MIDI half removed and re-added
       expect(instance.removeTrack).toHaveBeenCalledWith('t1:midi');
       expect(instance.addMidiTrack).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes the stale :midi companion when the last MIDI clip is deleted', () => {
+      const adapter = createToneAdapter();
+      const mixedTrack = makeTrack('t1', [
+        makeClip({ id: 'a1', startSample: 0, durationSamples: 44100 }),
+        makeMidiClip({ id: 'm1', startSample: 0, durationSamples: 44100 }),
+      ]);
+      adapter.setTracks([mixedTrack]);
+
+      const instance = (TonePlayout as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+      expect(instance.addMidiTrack).toHaveBeenCalledTimes(1);
+      instance.replaceTrackClips.mockReturnValue(true);
+
+      // User deletes the MIDI clip — audio-only update. Without companion
+      // cleanup, the t1:midi MidiToneTrack keeps its Part scheduled and the
+      // deleted MIDI keeps playing (ghost playback).
+      const audioOnly = makeTrack('t1', [
+        makeClip({ id: 'a1', startSample: 0, durationSamples: 44100 }),
+      ]);
+      adapter.updateTrack!('t1', audioOnly);
+
+      expect(instance.removeTrack).toHaveBeenCalledWith('t1:midi');
+      // No MIDI clips remain — nothing re-added
+      expect(instance.addMidiTrack).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/playout/src/__tests__/audioContext.test.ts
+++ b/packages/playout/src/__tests__/audioContext.test.ts
@@ -178,5 +178,21 @@ describe('audioContext singleton', () => {
       expect(contextCreateCount).toBe(2);
       expect(Context).toHaveBeenCalledTimes(2);
     });
+
+    it('resets the singleton even when the raw context is already closed', async () => {
+      getGlobalContext();
+      expect(contextCreateCount).toBe(1);
+
+      // getGlobalAudioContext() hands out the live raw AudioContext, so a
+      // consumer can close it directly. The singleton must still reset —
+      // otherwise every future getGlobalContext() returns a dead context
+      // forever and resumeGlobalAudioContext() rejects with InvalidStateError.
+      mockRawContext.state = 'closed';
+      await closeGlobalAudioContext();
+
+      expect(mockClose).not.toHaveBeenCalled(); // nothing left to close
+      getGlobalContext();
+      expect(contextCreateCount).toBe(2);
+    });
   });
 });

--- a/packages/playout/src/audioContext.ts
+++ b/packages/playout/src/audioContext.ts
@@ -188,9 +188,13 @@ export function getGlobalAudioContextState(): AudioContextState {
  * Should only be called when the application is shutting down
  */
 export async function closeGlobalAudioContext(): Promise<void> {
-  if (globalToneContext && globalToneContext.rawContext.state !== 'closed') {
+  if (!globalToneContext) return;
+  // Skip close() when the raw context is already closed (a consumer can close
+  // it directly via getGlobalAudioContext()), but ALWAYS reset the singleton —
+  // otherwise every future getGlobalContext() returns the dead context forever.
+  if (globalToneContext.rawContext.state !== 'closed') {
     await globalToneContext.close();
-    globalToneContext = null;
-    _nativeMode = false;
   }
+  globalToneContext = null;
+  _nativeMode = false;
 }


### PR DESCRIPTION
## Summary

Part 1 of the `packages/playout` correctness audit: the three high-severity findings plus the three behavioral mediums. All fixes were TDD'd — 11 new tests, each watched failing for its exact bug reason before implementation.

### Mixed audio+MIDI tracks (adapter)

A track with both audio and MIDI clips becomes TWO playout tracks (`id` + `id:midi`). Two gaps in that pairing:

1. **Runtime controls only reached the audio half** — `setTrackMute`/`setTrackVolume`/`setTrackPan`/`setTrackSolo` now blind-forward to the `:midi` companion (same pattern `removeTrack` already used; no-ops for non-mixed tracks). Worst prior symptom: soloing a mixed track **silenced its own MIDI half** (the companion wasn't in `soloedTracks`, so solo-muting muted it); muting a mixed track left its MIDI playing.
2. **Deleting the last MIDI clip left a stale companion** — `updateTrack`'s in-place audio path now removes the `:midi` playout track (and its build record) when the updated track has no MIDI clips, instead of leaving its scheduled `Part` playing ghost MIDI.

### Solo/mute semantics (TonePlayout)

`setMute` applied the manual mute directly to the track, bypassing `updateSoloMuting` — unmuting a non-soloed track while another was soloed made it audible. It now stores the manual state and routes through solo-aware muting: solo takes precedence, and the manual state applies when solo clears. (Standard DAW semantics, and the package's own documented invariant.)

### Global context lifecycle (audioContext)

`closeGlobalAudioContext` only reset the singleton when the raw context wasn't already closed. Since `getGlobalAudioContext()` hands out the live native context, a consumer closing it directly permanently stranded every future `getGlobalContext()` on a dead context (and `resumeGlobalAudioContext()` rejected with `InvalidStateError` — verified Tone 15.1.22's `Context.resume()` has no closed-state guard). The singleton now always resets; `close()` is still skipped when already closed. Notably, the existing test file's `beforeEach` contained a comment working around exactly this bug.

### SoundFont hot-swap (SoundFontCache)

`load()`/`loadFromBuffer()` replaced the parsed font but never cleared the per-sample-index `AudioBuffer` cache (`dispose()` did — the invalidation was simply missing from the reload paths). Hot-swapping fonts on one instance returned **the old font's buffers paired with the new font's pitch/loop/ADSR** — audibly mispitched output. Cache now clears only on successful parse, so a failed reload keeps the old font and its still-valid cache.

### Part callback containment (SoundFontToneTrack)

The `Part` note callback called `triggerNote` unguarded — verified against Tone.js source that nothing in `ToneEvent._tick → Transport._processTick → Clock._loop` catches, so one throwing note aborted every other same-tick event across ALL tracks. Now wrapped in try/catch (matching the class's own `startMidClipSources` and `ToneTrack.startClipSource` conventions). This also adds the package's first `SoundFontToneTrack` test file.

## Not in this PR (part 2 candidates)

Remaining audit findings: `mediaStreamSourceManager` dead code with nonexistent-event cleanup, `latencyHint` dropped in the default context path, per-synth try/catch in `MidiToneTrack.stopAllSources`, plus the low-severity items (unsorted-array `duration` getters, fades on mid-playback clip adds, cross-package re-exports in `fades.ts`, `fade-maker.d.ts` leftover, console object-arg warns).

## Test plan

- [x] TDD: 10 bug tests watched RED for exact bug reasons (+1 behavior-preservation test green before and after)
- [x] `packages/playout`: 268/268 tests pass (was 255), `tsc --noEmit` clean
- [x] `packages/browser` (downstream, dist-resolved): 279/279 pass after playout rebuild
- [x] Root `pnpm lint`: 0 errors
- [x] `@waveform-playlist/playout` patch changeset included
