### PR TITLE
React multitrack starter example (Tone engine) with AudioContext-gesture explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,14 @@ pnpm example:dawcore-native  # Native Web Audio — localhost:5173
 pnpm example:dawcore-tone    # Tone.js backend — localhost:5174
 pnpm example:dawcore-wam     # WAM 2.0 plugins + Faust — localhost:5175
 pnpm example:media-element   # MediaElement-only React starter (no Tone) — localhost:5176
+pnpm example:react-starter   # Full multitrack React starter (Tone engine) — localhost:5177
 ```
+
+The **[react-starter](examples/react-starter/)** is the smallest correct setup for the full
+multitrack editor — `WaveformPlaylistProvider` on the default Tone.js engine with mixer
+controls, plus a README section explaining the "AudioContext was prevented from starting"
+browser warning and how the provider's gesture-safe startup avoids it (see its
+[README](examples/react-starter/README.md)).
 
 The **[media-element-player](examples/media-element-player/)** starter is a minimal React
 single-track player using only `@waveform-playlist/browser` + `@waveform-playlist/media-element-playout`

--- a/examples/react-starter/README.md
+++ b/examples/react-starter/README.md
@@ -1,0 +1,66 @@
+# React multitrack starter
+
+The smallest **correct** setup for the full multitrack editor:
+`WaveformPlaylistProvider` on the default Tone.js engine, three stem tracks with
+the built-in track controls (mute / solo / volume / pan), transport buttons,
+zoom, and master volume.
+
+```bash
+pnpm example:react-starter   # from the repo root → http://localhost:5177
+```
+
+## AudioContext and user gestures
+
+> _"An AudioContext was prevented from starting automatically. It must be
+> created or resumed after a user gesture on the page."_
+
+**Seeing this warning in the console is normal and harmless — including in
+this starter and in the online demos** (issue #620). Browsers log it whenever
+an `AudioContext` is *created* outside a user gesture, even though the context
+is only sitting there **suspended**. The provider deliberately creates its
+audio engine eagerly on mount (so the first play/record never races an async
+setup), which means the warning can appear at page load.
+
+What matters is what happens on the first **Play** click:
+
+- Decoding and waveform rendering happen up front (`useAudioTracks`) — that
+  never needs a gesture.
+- The first `play()` call *resumes* the suspended context (`Tone.start()`
+  internally) — inside the click handler, i.e. a real user gesture. From that
+  point audio runs normally.
+
+So: **warning + audio works after clicking Play = everything is correct.** If
+audio actually stays silent after a user clicks Play, that's a different
+problem — the usual causes are:
+
+1. **Creating your own AudioContext (or importing a library that does) at
+   module load and playing through it programmatically.** `import * as Tone
+   from 'tone'` eagerly creates a context — if you need Tone directly,
+   dynamically `import('tone')` after a gesture. This starter never imports
+   `tone` itself; the provider loads it lazily.
+2. **Auto-playing on mount** (`useEffect(() => play(), [])`). A mount effect
+   is not a gesture, so the resume is blocked. Let the user press Play.
+
+## Adapting this to a standalone app
+
+This example resolves the workspace packages from **source** via Vite aliases
+(see `vite.config.ts`) so it always runs against the current checkout. In your
+own app:
+
+- `npm install @waveform-playlist/browser @waveform-playlist/playout tone react react-dom styled-components @dnd-kit/abstract @dnd-kit/dom @dnd-kit/react`
+  and delete the `resolve.alias` / `resolve.dedupe` blocks — package resolution
+  is normal outside the monorepo. (`@dnd-kit/*` are required peers of
+  `@waveform-playlist/browser` even if you never enable clip dragging — they
+  tree-shake out of the bundle.)
+- Add `@vitejs/plugin-react` for Fast Refresh (this example skips it to avoid
+  the dependency; esbuild's automatic JSX runtime is enough for a demo).
+- Serve your own audio files and point `audioConfigs` at them (`publicDir`
+  here borrows the repo's shared website assets).
+
+## Where to go next
+
+- Clip editing (drag / trim / split): wrap the UI in `ClipInteractionProvider`
+  and pass `interactiveClips` — see the website's multi-clip example.
+- Track reordering: `<Waveform trackReordering />` inside
+  `ClipInteractionProvider` — see the stem-tracks example.
+- Single-track playback without Tone.js: see `examples/media-element-player`.

--- a/examples/react-starter/index.html
+++ b/examples/react-starter/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎚️</text></svg>"
+    />
+    <title>Waveform Playlist — React multitrack starter</title>
+  </head>
+  <body style="margin: 0; background: #16161e">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-starter/package.json
+++ b/examples/react-starter/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@waveform-playlist/example-react-starter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Full multitrack React starter — WaveformPlaylistProvider with the Tone.js engine, mixer controls, and gesture-safe audio startup.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@waveform-playlist/browser": "workspace:*",
+    "@waveform-playlist/core": "workspace:*",
+    "@waveform-playlist/playout": "workspace:*",
+    "@waveform-playlist/ui-components": "workspace:*",
+    "@dnd-kit/abstract": "^0.3.0",
+    "@dnd-kit/dom": "^0.3.0",
+    "@dnd-kit/react": "^0.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "styled-components": "^6.0.0",
+    "tone": "^15.1.22"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/react-starter/src/App.tsx
+++ b/examples/react-starter/src/App.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import {
+  WaveformPlaylistProvider,
+  Waveform,
+  PlayButton,
+  PauseButton,
+  StopButton,
+  AudioPosition,
+  ZoomInButton,
+  ZoomOutButton,
+  MasterVolumeControl,
+} from '@waveform-playlist/browser';
+import { useAudioTracks } from '@waveform-playlist/browser/tone';
+import type { ClipTrack } from '@waveform-playlist/core';
+import type { WaveformPlaylistTheme } from '@waveform-playlist/ui-components';
+
+// Audio stems served from website/static (Vite publicDir).
+const audioConfigs = [
+  { src: '/media/audio/AlbertKader_Whiptails/03_Kick.opus', name: 'Kick' },
+  { src: '/media/audio/AlbertKader_Whiptails/04_Snare.opus', name: 'Snare' },
+  { src: '/media/audio/AlbertKader_Whiptails/07_Bass1.opus', name: 'Bass' },
+];
+
+// Amber/gold gradient bars on a dark surface — matches the page chrome.
+// waveOutlineColor is the canvas background; waveFillColor draws the bars.
+const theme: Partial<WaveformPlaylistTheme> = {
+  waveOutlineColor: '#1d1d26',
+  waveFillColor: {
+    type: 'linear',
+    direction: 'vertical',
+    stops: [
+      { offset: 0, color: '#d4a574' },
+      { offset: 0.5, color: '#c49a6c' },
+      { offset: 1, color: '#d4a574' },
+    ],
+  },
+  waveProgressColor: 'rgba(232, 192, 144, 0.35)',
+  selectedWaveOutlineColor: '#241f2b',
+  selectedWaveFillColor: {
+    type: 'linear',
+    direction: 'vertical',
+    stops: [
+      { offset: 0, color: '#e8c090' },
+      { offset: 0.5, color: '#d4a87c' },
+      { offset: 1, color: '#e8c090' },
+    ],
+  },
+  playlistBackgroundColor: '#16161e',
+  timescaleBackgroundColor: '#1d1d26',
+  timeColor: '#9a9aa6',
+  playheadColor: '#d08070',
+  selectionColor: 'rgba(212, 165, 116, 0.18)',
+  // Track-controls surface (mute/solo/volume/pan panel)
+  backgroundColor: '#16161e',
+  surfaceColor: '#1d1d26',
+  selectedTrackControlsBackground: '#2a2433',
+  borderColor: '#2a2a35',
+  textColor: '#e6e6ea',
+  textColorMuted: '#9a9aa6',
+  buttonBackground: '#26262f',
+  buttonText: '#e6e6ea',
+  buttonBorder: '#3a3a46',
+  buttonHoverBackground: '#31313d',
+  sliderTrackColor: '#3a3a46',
+  sliderThumbColor: '#d4a574',
+};
+
+const Page = styled.div`
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  color: #e6e6ea;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+`;
+
+const Header = styled.header`
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0 0 0.4rem;
+    color: #d08070;
+    font-size: 1.5rem;
+    letter-spacing: 0.02em;
+  }
+  p {
+    margin: 0;
+    color: #9a9aa6;
+    font-size: 0.95rem;
+  }
+  code {
+    font-family: 'Courier New', monospace;
+    color: #c49a6c;
+  }
+`;
+
+const Controls = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid #2a2a35;
+  border-radius: 0.5rem;
+  background: #1d1d26;
+`;
+
+const Status = styled.div`
+  padding: 2rem;
+  text-align: center;
+  color: #9a9aa6;
+`;
+
+export function App() {
+  // Decoding happens up front; the AudioContext stays suspended until the
+  // first user gesture — see "AudioContext and user gestures" in README.md.
+  const { tracks: loadedTracks, loading, error, loadedCount, totalCount } =
+    useAudioTracks(audioConfigs);
+  const [tracks, setTracks] = useState<ClipTrack[]>([]);
+
+  // Sync local track state as peaks fill in; once loading finishes this stops
+  // firing, so later updates come from onTracksChange.
+  useEffect(() => {
+    if (loadedTracks.length > 0) {
+      setTracks(loadedTracks);
+    }
+  }, [loadedTracks]);
+
+  if (error) {
+    return (
+      <Page>
+        <Status>Error loading audio: {error}</Status>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <Header>
+        <h1>Waveform Playlist — React multitrack starter</h1>
+        <p>
+          <code>WaveformPlaylistProvider</code> with the default Tone.js engine: three stems,
+          mute/solo/volume/pan per track, zoom, and master volume. Audio starts on the first
+          Play click — never before a user gesture.
+        </p>
+      </Header>
+
+      <WaveformPlaylistProvider
+        tracks={tracks}
+        onTracksChange={setTracks}
+        deferEngineRebuild={loading}
+        sampleRate={48000}
+        samplesPerPixel={1024}
+        mono
+        waveHeight={90}
+        automaticScroll
+        controls={{ show: true, width: 200 }}
+        timescale
+        theme={theme}
+        barWidth={3}
+        barGap={1}
+        roundedBars
+      >
+        <Controls>
+          <PlayButton />
+          <PauseButton />
+          <StopButton />
+          <ZoomInButton />
+          <ZoomOutButton />
+          <AudioPosition />
+          <MasterVolumeControl />
+          {loading && (
+            <span style={{ fontSize: '0.875rem', color: '#9a9aa6' }}>
+              Loading {loadedCount}/{totalCount}…
+            </span>
+          )}
+        </Controls>
+
+        <Waveform />
+      </WaveformPlaylistProvider>
+    </Page>
+  );
+}

--- a/examples/react-starter/src/main.tsx
+++ b/examples/react-starter/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/examples/react-starter/tsconfig.json
+++ b/examples/react-starter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/react-starter/vite.config.ts
+++ b/examples/react-starter/vite.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+
+// Full multitrack starter: WaveformPlaylistProvider on the default Tone.js
+// engine. Unlike the media-element-player example, this path DOES resolve
+// `@waveform-playlist/playout` and `tone` — the provider dynamically imports
+// them when no `createAdapter` prop is given. Workspace packages resolve from
+// source so the dev page reflects edits without a rebuild. (In a standalone
+// app you would instead `npm install` the published packages — see README.md.)
+export default defineConfig({
+  root: import.meta.dirname,
+  // Audio stems are served from the shared website assets.
+  publicDir: path.resolve(repoRoot, 'website/static'),
+  // No @vitejs/plugin-react dependency needed — esbuild compiles TSX with the
+  // automatic JSX runtime (React 17+). A standalone copy would add the plugin
+  // for Fast Refresh (see README.md).
+  esbuild: { jsx: 'automatic' },
+  resolve: {
+    // Source-aliased workspace packages import bare `react`/`styled-components`;
+    // force a single copy so hooks/context work across the alias boundary
+    // (otherwise: "Invalid hook call" from duplicate React).
+    dedupe: ['react', 'react-dom', 'styled-components'],
+    alias: {
+      // Subpath alias must come before the bare one so `/tone` wins the match.
+      '@waveform-playlist/browser/tone': path.resolve(repoRoot, 'packages/browser/src/tone.ts'),
+      '@waveform-playlist/browser': path.resolve(repoRoot, 'packages/browser/src/index.tsx'),
+      '@waveform-playlist/playout': path.resolve(repoRoot, 'packages/playout/src/index.ts'),
+      '@waveform-playlist/core': path.resolve(repoRoot, 'packages/core/src/index.ts'),
+      '@waveform-playlist/engine': path.resolve(repoRoot, 'packages/engine/src/index.ts'),
+      '@waveform-playlist/ui-components': path.resolve(
+        repoRoot,
+        'packages/ui-components/src/index.tsx'
+      ),
+    },
+  },
+  // NOTE: `tone` must NOT be excluded from optimizeDeps — its CJS dependency
+  // `automation-events` needs pre-bundling or imports fail with "does not
+  // provide an export named".
+  server: {
+    port: 5177,
+    open: '/',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "example:dawcore-native": "vite --config examples/dawcore-native/vite.config.ts",
     "example:dawcore-tone": "vite --config examples/dawcore-tone/vite.config.ts",
     "example:dawcore-wam": "vite --config examples/dawcore-wam/vite.config.ts",
-    "example:media-element": "vite --config examples/media-element-player/vite.config.ts"
+    "example:media-element": "vite --config examples/media-element-player/vite.config.ts",
+    "example:react-starter": "vite --config examples/react-starter/vite.config.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,55 @@ importers:
         specifier: ^8.0.0
         version: 8.0.16(@types/node@20.19.42)
 
+  examples/react-starter:
+    dependencies:
+      '@dnd-kit/abstract':
+        specifier: ^0.3.0
+        version: 0.3.2
+      '@dnd-kit/dom':
+        specifier: ^0.3.0
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: ^0.3.0
+        version: 0.3.2(react-dom@18.3.1)(react@18.3.1)
+      '@waveform-playlist/browser':
+        specifier: workspace:*
+        version: link:../../packages/browser
+      '@waveform-playlist/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@waveform-playlist/playout':
+        specifier: workspace:*
+        version: link:../../packages/playout
+      '@waveform-playlist/ui-components':
+        specifier: workspace:*
+        version: link:../../packages/ui-components
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      styled-components:
+        specifier: ^6.0.0
+        version: 6.4.2(react-dom@18.3.1)(react@18.3.1)
+      tone:
+        specifier: ^15.1.22
+        version: 15.1.22
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.31)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.16(@types/node@20.19.42)
+
   packages/annotations:
     dependencies:
       '@dnd-kit/react':


### PR DESCRIPTION
Closes #620

Adds `examples/react-starter/` — the smallest **correct** setup for the full multitrack editor: `WaveformPlaylistProvider` on the default Tone.js engine, three stems with the built-in track controls (mute/solo/volume/pan), transport + zoom + master volume, and an amber-gradient rounded-bar dark theme. Run with `pnpm example:react-starter` → localhost:5177.

## The AudioContext warning (#620)

The *"AudioContext was prevented from starting"* console warning is **expected and harmless**: browsers log it whenever an AudioContext is created outside a user gesture, and the provider deliberately creates its engine eagerly on mount, in the suspended state. The first Play click resumes the context inside a real gesture, and audio runs normally from there. The example README's **"AudioContext and user gestures"** section documents this, plus the two setups that cause actually-broken audio: eagerly importing `tone` at module load, and auto-playing from a mount effect.

## Structure

Mirrors `examples/media-element-player/` (workspace member, source-aliased Vite config, shared `website/static` audio assets, no `@vitejs/plugin-react`), with the differences the Tone path needs: `@waveform-playlist/playout` + `tone` resolved (and `tone` deliberately NOT excluded from `optimizeDeps` — the `automation-events` CJS trap), plus a `@waveform-playlist/browser/tone` subpath alias for `useAudioTracks`.

## Test plan

- [x] Live-verified headless (real input): mounts to `data-playlist-state="ready"`, 3 track rows + canvases render, zero "Cannot create track" warnings, time advances after a real Play click, Stop works
- [x] Console clean apart from the documented (and now README-explained) suspended-AudioContext warning
- [x] `pnpm lint` 0 errors; lockfile committed (`--frozen-lockfile` CI)
- [x] Root README examples section updated (front-door rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

