### PR TITLE
Suppress immediate-mode pending-decode warnings in useAudioTracks

### DIFF
--- a/.changeset/immediate-pending-warnings.md
+++ b/.changeset/immediate-pending-warnings.md
@@ -1,0 +1,5 @@
+---
+'@waveform-playlist/browser': patch
+---
+
+`useAudioTracks` immediate mode no longer warns "Cannot create track" for configs still awaiting their audio decode — a missing duration there is an expected transient state, and each rebuild pass was re-warning for every pending track (quadratic console noise). Terminal misconfigurations (nothing left to load and no derivable duration) still warn.

--- a/packages/browser/src/hooks/__tests__/buildTrackFromConfig.test.ts
+++ b/packages/browser/src/hooks/__tests__/buildTrackFromConfig.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildTrackFromConfig } from '../buildTrackFromConfig';
+import type { AudioTrackConfig } from '../useAudioTracks';
+
+const stableIds = () => new Map<number, { trackId: string; clipId: string }>();
+
+describe('buildTrackFromConfig', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('builds a track when the config provides a duration', () => {
+    const config: AudioTrackConfig = { src: 'a.opus', name: 'A', duration: 10 };
+    const track = buildTrackFromConfig(config, 0, undefined, stableIds(), 48000);
+    expect(track).not.toBeNull();
+    expect(track?.clips[0].durationSamples).toBe(10 * 48000);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null and warns when duration is underivable (terminal case)', () => {
+    const config: AudioTrackConfig = { src: 'a.opus', name: 'A' };
+    const track = buildTrackFromConfig(config, 0, undefined, stableIds(), 48000);
+    expect(track).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('Cannot create track');
+  });
+
+  it('returns null SILENTLY when the missing duration is a pending decode (immediate mode)', () => {
+    const config: AudioTrackConfig = { src: 'a.opus', name: 'A' };
+    const track = buildTrackFromConfig(config, 0, undefined, stableIds(), 48000, {
+      suppressMissingDurationWarning: true,
+    });
+    expect(track).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves stable ids across rebuilds', () => {
+    const ids = stableIds();
+    const config: AudioTrackConfig = { src: 'a.opus', name: 'A', duration: 5 };
+    const first = buildTrackFromConfig(config, 0, undefined, ids, 48000);
+    const second = buildTrackFromConfig(config, 0, undefined, ids, 48000);
+    expect(second?.id).toBe(first?.id);
+    expect(second?.clips[0].id).toBe(first?.clips[0].id);
+  });
+});

--- a/packages/browser/src/hooks/buildTrackFromConfig.ts
+++ b/packages/browser/src/hooks/buildTrackFromConfig.ts
@@ -1,0 +1,94 @@
+import { ClipTrack, createTrack, createClipFromSeconds } from '@waveform-playlist/core';
+import type { AudioTrackConfig } from './useAudioTracks';
+
+export interface BuildTrackOptions {
+  /**
+   * Suppress the "Cannot create track" warning when the duration is
+   * underivable. Immediate mode passes true for configs still awaiting their
+   * decode — a missing duration there is an expected transient state (the
+   * track builds on the next pass once the buffer arrives), and warning on
+   * every rebuild pass floods the console (#620 follow-up). Terminal call
+   * sites (non-immediate mode, or configs with nothing left to load) keep
+   * the warning.
+   */
+  suppressMissingDurationWarning?: boolean;
+}
+
+/** Build a ClipTrack from config + optional audioBuffer, preserving stable IDs. */
+export function buildTrackFromConfig(
+  config: AudioTrackConfig,
+  index: number,
+  audioBuffer: AudioBuffer | undefined,
+  stableIds: Map<number, { trackId: string; clipId: string }>,
+  contextSampleRate: number = 48000,
+  options: BuildTrackOptions = {}
+): ClipTrack | null {
+  const buffer = audioBuffer ?? config.audioBuffer;
+
+  // Determine if we have enough info to create the track
+  // Prefer buffer/waveformData sample rate; fall back to the AudioContext's rate
+  const sampleRate = buffer?.sampleRate ?? config.waveformData?.sample_rate ?? contextSampleRate;
+  const sourceDuration =
+    buffer?.duration ??
+    config.waveformData?.duration ??
+    (config.duration != null ? config.duration + (config.offset ?? 0) : undefined);
+
+  if (sourceDuration === undefined) {
+    if (!options.suppressMissingDurationWarning) {
+      console.warn(
+        `[waveform-playlist] Track ${index + 1} ("${config.name ?? 'unnamed'}"): ` +
+          `Cannot create track — provide duration, audioBuffer, or waveformData with duration.`
+      );
+    }
+    return null;
+  }
+
+  const clip = createClipFromSeconds({
+    audioBuffer: buffer,
+    sampleRate,
+    sourceDuration,
+    startTime: config.startTime ?? 0,
+    duration: config.duration ?? sourceDuration,
+    offset: config.offset ?? 0,
+    name: config.name || `Track ${index + 1}`,
+    fadeIn: config.fadeIn,
+    fadeOut: config.fadeOut,
+    waveformData: config.waveformData,
+  });
+
+  // Validate clip values
+  if (isNaN(clip.startSample) || isNaN(clip.durationSamples) || isNaN(clip.offsetSamples)) {
+    console.error(
+      `[waveform-playlist] Invalid clip values for track ${index + 1} ("${config.name ?? 'unnamed'}"): ` +
+        `startSample=${clip.startSample}, durationSamples=${clip.durationSamples}, offsetSamples=${clip.offsetSamples}`
+    );
+    return null;
+  }
+
+  const track: ClipTrack = {
+    ...createTrack({
+      name: config.name || `Track ${index + 1}`,
+      clips: [clip],
+      muted: config.muted ?? false,
+      soloed: config.soloed ?? false,
+      volume: config.volume ?? 1.0,
+      pan: config.pan ?? 0,
+      color: config.color,
+    }),
+    effects: config.effects,
+    renderMode: config.renderMode,
+    spectrogramConfig: config.spectrogramConfig,
+    spectrogramColorMap: config.spectrogramColorMap,
+  };
+
+  // Preserve stable IDs across rebuilds so React doesn't unmount/remount tracks
+  const existingIds = stableIds.get(index);
+  if (existingIds) {
+    track.id = existingIds.trackId;
+    track.clips[0] = { ...track.clips[0], id: existingIds.clipId };
+  } else {
+    stableIds.set(index, { trackId: track.id, clipId: track.clips[0].id });
+  }
+
+  return track;
+}

--- a/packages/browser/src/hooks/useAudioTracks.ts
+++ b/packages/browser/src/hooks/useAudioTracks.ts
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import {
   ClipTrack,
-  createTrack,
-  createClipFromSeconds,
   type Fade,
   type TrackEffectsFunction,
   type WaveformDataObject,
@@ -11,6 +9,7 @@ import {
   type ColorMapValue,
 } from '@waveform-playlist/core';
 import * as Tone from 'tone';
+import { buildTrackFromConfig } from './buildTrackFromConfig';
 
 /**
  * Configuration for a single audio track to load
@@ -70,82 +69,6 @@ export interface UseAudioTracksOptions {
   immediate?: boolean;
   /** @deprecated Use `immediate` instead. */
   progressive?: boolean;
-}
-
-/** Build a ClipTrack from config + optional audioBuffer, preserving stable IDs. */
-function buildTrackFromConfig(
-  config: AudioTrackConfig,
-  index: number,
-  audioBuffer: AudioBuffer | undefined,
-  stableIds: Map<number, { trackId: string; clipId: string }>,
-  contextSampleRate: number = 48000
-): ClipTrack | null {
-  const buffer = audioBuffer ?? config.audioBuffer;
-
-  // Determine if we have enough info to create the track
-  // Prefer buffer/waveformData sample rate; fall back to the AudioContext's rate
-  const sampleRate = buffer?.sampleRate ?? config.waveformData?.sample_rate ?? contextSampleRate;
-  const sourceDuration =
-    buffer?.duration ??
-    config.waveformData?.duration ??
-    (config.duration != null ? config.duration + (config.offset ?? 0) : undefined);
-
-  if (sourceDuration === undefined) {
-    console.warn(
-      `[waveform-playlist] Track ${index + 1} ("${config.name ?? 'unnamed'}"): ` +
-        `Cannot create track — provide duration, audioBuffer, or waveformData with duration.`
-    );
-    return null;
-  }
-
-  const clip = createClipFromSeconds({
-    audioBuffer: buffer,
-    sampleRate,
-    sourceDuration,
-    startTime: config.startTime ?? 0,
-    duration: config.duration ?? sourceDuration,
-    offset: config.offset ?? 0,
-    name: config.name || `Track ${index + 1}`,
-    fadeIn: config.fadeIn,
-    fadeOut: config.fadeOut,
-    waveformData: config.waveformData,
-  });
-
-  // Validate clip values
-  if (isNaN(clip.startSample) || isNaN(clip.durationSamples) || isNaN(clip.offsetSamples)) {
-    console.error(
-      `[waveform-playlist] Invalid clip values for track ${index + 1} ("${config.name ?? 'unnamed'}"): ` +
-        `startSample=${clip.startSample}, durationSamples=${clip.durationSamples}, offsetSamples=${clip.offsetSamples}`
-    );
-    return null;
-  }
-
-  const track: ClipTrack = {
-    ...createTrack({
-      name: config.name || `Track ${index + 1}`,
-      clips: [clip],
-      muted: config.muted ?? false,
-      soloed: config.soloed ?? false,
-      volume: config.volume ?? 1.0,
-      pan: config.pan ?? 0,
-      color: config.color,
-    }),
-    effects: config.effects,
-    renderMode: config.renderMode,
-    spectrogramConfig: config.spectrogramConfig,
-    spectrogramColorMap: config.spectrogramColorMap,
-  };
-
-  // Preserve stable IDs across rebuilds so React doesn't unmount/remount tracks
-  const existingIds = stableIds.get(index);
-  if (existingIds) {
-    track.id = existingIds.trackId;
-    track.clips[0] = { ...track.clips[0], id: existingIds.clipId };
-  } else {
-    stableIds.set(index, { trackId: track.id, clipId: track.clips[0].id });
-  }
-
-  return track;
 }
 
 /**
@@ -219,12 +142,22 @@ export function useAudioTracks(configs: AudioTrackConfig[], options: UseAudioTra
 
     const result: ClipTrack[] = [];
     for (let i = 0; i < configs.length; i++) {
+      // A config whose decode hasn't arrived yet is an EXPECTED transient
+      // state in immediate mode — it builds on a later pass once the buffer
+      // lands. Suppress the missing-duration warning for those so each
+      // rebuild pass doesn't warn about every still-pending track (the
+      // count grows quadratically with track count otherwise). Configs with
+      // nothing left to load (no src, no buffer coming) keep the warning —
+      // for them, missing duration is a real misconfiguration.
+      const pendingDecode =
+        !loadedBuffers.has(i) && !configs[i].audioBuffer && configs[i].src != null;
       const track = buildTrackFromConfig(
         configs[i],
         i,
         loadedBuffers.get(i),
         stableIdsRef.current,
-        contextSampleRateRef.current
+        contextSampleRateRef.current,
+        { suppressMissingDurationWarning: pendingDecode }
       );
       if (track) result.push(track);
     }


### PR DESCRIPTION
In `useAudioTracks` immediate mode, every decode completion rebuilds all tracks from configs. A config whose buffer hasn't arrived yet (and that has no upfront `duration`/`waveformData`) can't be built on that pass, so it logged `Cannot create track — provide duration, audioBuffer, or waveformData with duration.` on **every** rebuild — an expected transient state reported as an error, with warning count growing quadratically with track count (the 12-track stem-tracks demo logged dozens on each load; found while building #621).

## Change

- `buildTrackFromConfig` is extracted from `useAudioTracks.ts` into its own module — it has no `tone` dependency, which also makes it unit-testable in plain vitest (the hook file imports `tone` at module scope).
- It gains a `suppressMissingDurationWarning` option; the immediate-mode derive pass sets it for configs whose decode is still pending (`!loadedBuffers.has(i) && !config.audioBuffer && config.src != null`).
- Terminal cases keep the warning: non-immediate mode is untouched, and immediate-mode configs with nothing left to load (no `src`, no buffer coming) still warn — for them a missing duration is a real misconfiguration.
- Decode failures are unaffected: they surface through the hook's `error` state as before, so suppression can't hide a genuinely broken track.

## Test plan

- [x] New unit tests for `buildTrackFromConfig`: builds with duration, warns on terminal missing duration, silent when suppressed (pending decode), stable-id preservation
- [x] Full browser suite: 311/311
- [x] Root `pnpm typecheck` clean, `pnpm lint` 0 errors
- [x] Live-verified on the website stem-tracks page (12 tracks, `immediate: true`): zero `Cannot create track` warnings, all 12 tracks render
- [x] Changeset: `@waveform-playlist/browser` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
